### PR TITLE
gh-444 - Added CommonTimeUtil class

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -95,6 +95,11 @@ Jersey Server (com.sun.jersey:jersey-server:1.9)
 - GNU General Public License 2.0
 
 
+Joda Time (joda-time:joda-time:2.9.5)
+
+- Apache License, Version 2.0
+
+
 Junit (junit:junit:4.12):
 
 - Eclipse Public License 1.0

--- a/core/common-util/pom.xml
+++ b/core/common-util/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>reflections</artifactId>
         </dependency>
         <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.9.5</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>${jackson.version}</version>

--- a/core/common-util/src/main/java/gaffer/commonutil/CommonTimeUtil.java
+++ b/core/common-util/src/main/java/gaffer/commonutil/CommonTimeUtil.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gaffer.commonutil;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTime.Property;
+
+import static org.joda.time.DateTimeZone.UTC;
+
+/**
+ * Utility methods for dates and times.
+ */
+public class CommonTimeUtil {
+
+    private CommonTimeUtil() {
+        // this class should not be instantiated - it contains only util methods and constants.
+    }
+
+    /**
+     * Place a time value (a Java {@link Long} representing the number of
+     * milliseconds since the start of the Unix epoch) in a {@link TimeBucket}.
+     *
+     * @param time   the time, in milliseconds since the start of the Unix epoch
+     * @param bucket the time bucket to place the time value into
+     * @return the value of the time bucket
+     */
+    public static long timeToBucket(final long time, final TimeBucket bucket) {
+        final DateTime dateTime = new DateTime(time, UTC);
+
+        final long timeBucket;
+
+        switch (bucket) {
+            case HOUR:
+                timeBucket = roundDown(dateTime.hourOfDay());
+                break;
+            case DAY:
+                timeBucket = roundDown(dateTime.dayOfYear());
+                break;
+            case WEEK:
+                timeBucket = roundDown(dateTime.weekOfWeekyear());
+                break;
+            case MONTH:
+                timeBucket = roundDown(dateTime.monthOfYear());
+                break;
+            default:
+                timeBucket = time;
+        }
+
+        return timeBucket;
+    }
+
+    private static long roundDown(final Property property) {
+        return property.roundFloorCopy().getMillis();
+    }
+
+    private static long roundUp(final Property property) {
+        return property.roundCeilingCopy().getMillis();
+    }
+
+    /**
+     * Type representing a "bucket" of time.
+     */
+    public enum TimeBucket {
+        HOUR, DAY, WEEK, MONTH, YEAR;
+    }
+}

--- a/core/common-util/src/main/java/gaffer/commonutil/CommonTimeUtil.java
+++ b/core/common-util/src/main/java/gaffer/commonutil/CommonTimeUtil.java
@@ -67,10 +67,6 @@ public final class CommonTimeUtil {
         return property.roundFloorCopy().getMillis();
     }
 
-    private static long roundUp(final Property property) {
-        return property.roundCeilingCopy().getMillis();
-    }
-
     /**
      * Type representing a "bucket" of time.
      */

--- a/core/common-util/src/main/java/gaffer/commonutil/CommonTimeUtil.java
+++ b/core/common-util/src/main/java/gaffer/commonutil/CommonTimeUtil.java
@@ -24,7 +24,7 @@ import static org.joda.time.DateTimeZone.UTC;
 /**
  * Utility methods for dates and times.
  */
-public class CommonTimeUtil {
+public final class CommonTimeUtil {
 
     private CommonTimeUtil() {
         // this class should not be instantiated - it contains only util methods and constants.

--- a/core/common-util/src/test/java/gaffer/commonutil/CommonTimeUtilTest.java
+++ b/core/common-util/src/test/java/gaffer/commonutil/CommonTimeUtilTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gaffer.commonutil;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import static gaffer.commonutil.CommonTimeUtil.TimeBucket.DAY;
+import static gaffer.commonutil.CommonTimeUtil.TimeBucket.HOUR;
+import static gaffer.commonutil.CommonTimeUtil.TimeBucket.MONTH;
+import static gaffer.commonutil.CommonTimeUtil.TimeBucket.WEEK;
+import static gaffer.commonutil.CommonTimeUtil.timeToBucket;
+import static org.joda.time.DateTime.parse;
+import static org.junit.Assert.assertEquals;
+
+public class CommonTimeUtilTest {
+
+    @Test
+    public void shouldCorrectlyPlaceTimestampsIntoBuckets() {
+        final long time = parse("2000-01-01T12:34:56.789").getMillis();
+        final DateTime dateTime = new DateTime(time, DateTimeZone.UTC);
+
+        assertEquals(timeToBucket(time, HOUR), parse("2000-01-01T12:00:00.000").getMillis());
+        assertEquals(timeToBucket(time, DAY), parse("2000-01-01T00:00:00.000").getMillis());
+        assertEquals(timeToBucket(time, WEEK), parse("1999-12-27T00:00:00.000").getMillis());
+        assertEquals(timeToBucket(time, MONTH), parse("2000-01-01T00:00:00.000")
+                .getMillis());
+    }
+
+}

--- a/core/common-util/src/test/java/gaffer/commonutil/CommonTimeUtilTest.java
+++ b/core/common-util/src/test/java/gaffer/commonutil/CommonTimeUtilTest.java
@@ -35,11 +35,10 @@ public class CommonTimeUtilTest {
         final long time = parse("2000-01-01T12:34:56.789").getMillis();
         final DateTime dateTime = new DateTime(time, DateTimeZone.UTC);
 
-        assertEquals(timeToBucket(time, HOUR), parse("2000-01-01T12:00:00.000").getMillis());
-        assertEquals(timeToBucket(time, DAY), parse("2000-01-01T00:00:00.000").getMillis());
-        assertEquals(timeToBucket(time, WEEK), parse("1999-12-27T00:00:00.000").getMillis());
-        assertEquals(timeToBucket(time, MONTH), parse("2000-01-01T00:00:00.000")
-                .getMillis());
+        assertEquals(parse("2000-01-01T12:00:00.000").getMillis(), timeToBucket(time, HOUR));
+        assertEquals(parse("2000-01-01T00:00:00.000").getMillis(),timeToBucket(time, DAY));
+        assertEquals(parse("1999-12-27T00:00:00.000").getMillis(),timeToBucket(time, WEEK));
+        assertEquals(parse("2000-01-01T00:00:00.000").getMillis(),timeToBucket(time, MONTH));
     }
 
 }


### PR DESCRIPTION
Started the CommonTimeUtils class with a rough method for creating buckets of time from long timestamps.

The joda-time library has been added and replaces the functionality that was in the Gaffer1 TimeUtils class.