### PR TITLE
gh-702 RoaringBitmap aggregation function

### DIFF
--- a/library/bitmap-library/pom.xml
+++ b/library/bitmap-library/pom.xml
@@ -16,10 +16,43 @@
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
+            <groupId>uk.gov.gchq.gaffer</groupId>
+            <artifactId>function</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>
             <version>0.5.11</version>
         </dependency>
     </dependencies>
-
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${shade.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>deploy</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true
+                            </shadedArtifactAttached>
+                            <shadedClassifierName>deploy
+                            </shadedClassifierName>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.roaringbitmap:RoaringBitmap
+                                    </include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/library/bitmap-library/src/main/java/uk/gov/gchq/gaffer/bitmap/function/aggregate/RoaringBitmapAggregator.java
+++ b/library/bitmap-library/src/main/java/uk/gov/gchq/gaffer/bitmap/function/aggregate/RoaringBitmapAggregator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.gov.gchq.gaffer.bitmap.function.aggregate;
+
+import org.roaringbitmap.RoaringBitmap;
+import uk.gov.gchq.gaffer.function.AggregateFunction;
+import uk.gov.gchq.gaffer.function.SimpleAggregateFunction;
+
+public class RoaringBitmapAggregator extends SimpleAggregateFunction<RoaringBitmap> {
+    private RoaringBitmap result = null;
+
+    @Override
+    protected void _aggregate(final RoaringBitmap input) {
+        if (null == input) {
+            return;
+        }
+        if (null == result) {
+            result = input;
+            return;
+        }
+        result.or(input);
+    }
+
+    @Override
+    protected RoaringBitmap _state() {
+        return result;
+    }
+
+    @Override
+    public void init() {
+
+    }
+
+    @Override
+    public AggregateFunction statelessClone() {
+        return new RoaringBitmapAggregator();
+    }
+}

--- a/library/bitmap-library/src/main/java/uk/gov/gchq/gaffer/bitmap/function/aggregate/RoaringBitmapAggregator.java
+++ b/library/bitmap-library/src/main/java/uk/gov/gchq/gaffer/bitmap/function/aggregate/RoaringBitmapAggregator.java
@@ -28,7 +28,7 @@ public class RoaringBitmapAggregator extends SimpleAggregateFunction<RoaringBitm
             return;
         }
         if (null == result) {
-            result = input;
+            result = input.clone();
             return;
         }
         result.or(input);

--- a/library/bitmap-library/src/main/java/uk/gov/gchq/gaffer/bitmap/serialisation/RoaringBitmapSerialiser.java
+++ b/library/bitmap-library/src/main/java/uk/gov/gchq/gaffer/bitmap/serialisation/RoaringBitmapSerialiser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Crown Copyright
+ * Copyright 2017 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package gaffer.bitmap.serialisation;
+package uk.gov.gchq.gaffer.bitmap.serialisation;
 
-import gaffer.bitmap.serialisation.utils.RoaringBitmapUtils;
+
 import org.roaringbitmap.RoaringBitmap;
+
+import uk.gov.gchq.gaffer.bitmap.serialisation.utils.RoaringBitmapUtils;
 import uk.gov.gchq.gaffer.exception.SerialisationException;
 import uk.gov.gchq.gaffer.serialisation.Serialisation;
 

--- a/library/bitmap-library/src/main/java/uk/gov/gchq/gaffer/bitmap/serialisation/json/RoaringBitmapConstants.java
+++ b/library/bitmap-library/src/main/java/uk/gov/gchq/gaffer/bitmap/serialisation/json/RoaringBitmapConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Crown Copyright
+ * Copyright 2017 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package gaffer.bitmap.serialisation.json;
+package uk.gov.gchq.gaffer.bitmap.serialisation.json;
 
 public final class RoaringBitmapConstants {
 

--- a/library/bitmap-library/src/main/java/uk/gov/gchq/gaffer/bitmap/serialisation/json/RoaringBitmapJsonDeserialiser.java
+++ b/library/bitmap-library/src/main/java/uk/gov/gchq/gaffer/bitmap/serialisation/json/RoaringBitmapJsonDeserialiser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Crown Copyright
+ * Copyright 2017 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package gaffer.bitmap.serialisation.json;
+package uk.gov.gchq.gaffer.bitmap.serialisation.json;
 
 
 import com.fasterxml.jackson.core.JsonParser;
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.node.TextNode;
-import gaffer.bitmap.serialisation.RoaringBitmapSerialiser;
 import org.roaringbitmap.RoaringBitmap;
+import uk.gov.gchq.gaffer.bitmap.serialisation.RoaringBitmapSerialiser;
 
 import java.io.IOException;
 

--- a/library/bitmap-library/src/main/java/uk/gov/gchq/gaffer/bitmap/serialisation/json/RoaringBitmapJsonSerialiser.java
+++ b/library/bitmap-library/src/main/java/uk/gov/gchq/gaffer/bitmap/serialisation/json/RoaringBitmapJsonSerialiser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Crown Copyright
+ * Copyright 2017 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package gaffer.bitmap.serialisation.json;
+package uk.gov.gchq.gaffer.bitmap.serialisation.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;

--- a/library/bitmap-library/src/main/java/uk/gov/gchq/gaffer/bitmap/serialisation/utils/RoaringBitmapUtils.java
+++ b/library/bitmap-library/src/main/java/uk/gov/gchq/gaffer/bitmap/serialisation/utils/RoaringBitmapUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Crown Copyright
+ * Copyright 2017 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package gaffer.bitmap.serialisation.utils;
+package uk.gov.gchq.gaffer.bitmap.serialisation.utils;
 
 import uk.gov.gchq.gaffer.exception.SerialisationException;
 

--- a/library/bitmap-library/src/test/java/uk/gov/gchq/gaffer/bitmap/function/aggregate/RoaringBitmapAggregatorTest.java
+++ b/library/bitmap-library/src/test/java/uk/gov/gchq/gaffer/bitmap/function/aggregate/RoaringBitmapAggregatorTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.gov.gchq.gaffer.bitmap.function.aggregate;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.roaringbitmap.RoaringBitmap;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class RoaringBitmapAggregatorTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void aggregatorDealsWithNullInput() {
+        RoaringBitmapAggregator roaringBitmapAggregator = new RoaringBitmapAggregator();
+        roaringBitmapAggregator.init();
+        roaringBitmapAggregator._aggregate(null);
+        assertNull(roaringBitmapAggregator.state()[0]);
+    }
+
+    @Test
+    public void emptyInputBitmapGeneratesEmptyOutputBitmap() {
+        RoaringBitmap bitmap = new RoaringBitmap();
+        RoaringBitmapAggregator roaringBitmapAggregator = new RoaringBitmapAggregator();
+        roaringBitmapAggregator.init();
+        roaringBitmapAggregator._aggregate(bitmap);
+
+        assertEquals(0, ((RoaringBitmap) roaringBitmapAggregator.state()[0]).getCardinality());
+    }
+
+    @Test
+    public void singleInputBitmapGeneratesIdenticalOutputBitmap() {
+        RoaringBitmap inputBitmap = new RoaringBitmap();
+        int input1 = 123298333;
+        int input2 = 342903339;
+        inputBitmap.add(input1);
+        inputBitmap.add(input2);
+
+        RoaringBitmapAggregator roaringBitmapAggregator = new RoaringBitmapAggregator();
+        roaringBitmapAggregator.init();
+        roaringBitmapAggregator._aggregate(inputBitmap);
+
+        assertEquals(2, ((RoaringBitmap) roaringBitmapAggregator.state()[0]).getCardinality());
+        assertEquals(inputBitmap, roaringBitmapAggregator.state()[0]);
+    }
+
+    @Test
+    public void threeOverlappingInputBitmapsProducesSingleSortedBitmap() {
+        int[] inputs = new int[6];
+        RoaringBitmap inputBitmap1 = new RoaringBitmap();
+        int input1 = 23615000;
+        int input2 = 23616440;
+        inputBitmap1.add(input1);
+        inputBitmap1.add(input2);
+        inputs[0] = input1;
+        inputs[1] = input2;
+
+        RoaringBitmapAggregator roaringBitmapAggregator = new RoaringBitmapAggregator();
+        roaringBitmapAggregator._aggregate(inputBitmap1);
+        assertEquals(inputBitmap1, roaringBitmapAggregator.state()[0]);
+
+        RoaringBitmap inputBitmap2 = new RoaringBitmap();
+        int input3 = 23615003;
+        int input4 = 23615018;
+        inputBitmap2.add(input3);
+        inputBitmap2.add(input4);
+        inputs[2] = input3;
+        inputs[3] = input4;
+        roaringBitmapAggregator._aggregate(inputBitmap2);
+
+        RoaringBitmap inputBitmap3 = new RoaringBitmap();
+        int input5 = 23615002;
+        int input6 = 23615036;
+        inputBitmap3.add(input5);
+        inputBitmap3.add(input6);
+        inputs[4] = input5;
+        inputs[5] = input6;
+        roaringBitmapAggregator._aggregate(inputBitmap3);
+
+        Arrays.sort(inputs);
+        RoaringBitmap result = (RoaringBitmap) roaringBitmapAggregator.state()[0];
+        int outPutBitmapSize = result.getCardinality();
+        assertEquals(6, outPutBitmapSize);
+        int i = 0;
+        for(Integer value : result) {
+            assertEquals((Integer) inputs[i], value);
+            i++;
+        }
+    }
+}

--- a/library/bitmap-library/src/test/java/uk/gov/gchq/gaffer/bitmap/function/aggregate/RoaringBitmapAggregatorTest.java
+++ b/library/bitmap-library/src/test/java/uk/gov/gchq/gaffer/bitmap/function/aggregate/RoaringBitmapAggregatorTest.java
@@ -19,11 +19,14 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.roaringbitmap.RoaringBitmap;
-
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 public class RoaringBitmapAggregatorTest {
 
@@ -102,9 +105,27 @@ public class RoaringBitmapAggregatorTest {
         int outPutBitmapSize = result.getCardinality();
         assertEquals(6, outPutBitmapSize);
         int i = 0;
-        for(Integer value : result) {
+        for (Integer value : result) {
             assertEquals((Integer) inputs[i], value);
             i++;
         }
+    }
+
+    @Test
+    public void shouldCloneInputBitmapWhenAggregating() {
+        // Given
+        final RoaringBitmapAggregator roaringBitmapAggregator = new RoaringBitmapAggregator();
+        roaringBitmapAggregator.init();
+
+        final RoaringBitmap bitmap = mock(RoaringBitmap.class);
+        final RoaringBitmap clonedBitmap = mock(RoaringBitmap.class);
+        given(bitmap.clone()).willReturn(clonedBitmap);
+
+        // When
+        roaringBitmapAggregator._aggregate(bitmap);
+
+        // Then
+        assertSame(clonedBitmap, roaringBitmapAggregator.state()[0]);
+        assertNotSame(bitmap, roaringBitmapAggregator.state()[0]);
     }
 }

--- a/library/bitmap-library/src/test/java/uk/gov/gchq/gaffer/bitmap/serialisation/RoaringBitmapSerialiserTest.java
+++ b/library/bitmap-library/src/test/java/uk/gov/gchq/gaffer/bitmap/serialisation/RoaringBitmapSerialiserTest.java
@@ -1,4 +1,19 @@
-package gaffer.bitmap.serialisation;
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.gov.gchq.gaffer.bitmap.serialisation;
 
 import org.junit.Test;
 import org.roaringbitmap.RoaringBitmap;

--- a/library/bitmap-library/src/test/java/uk/gov/gchq/gaffer/bitmap/serialisation/json/RoaringBitmapJsonSerialisationTest.java
+++ b/library/bitmap-library/src/test/java/uk/gov/gchq/gaffer/bitmap/serialisation/json/RoaringBitmapJsonSerialisationTest.java
@@ -1,5 +1,19 @@
-package gaffer.bitmap.serialisation.json;
-
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.gov.gchq.gaffer.bitmap.serialisation.json;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;

--- a/library/sketches-library/pom.xml
+++ b/library/sketches-library/pom.xml
@@ -57,4 +57,33 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${shade.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>deploy</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true
+                            </shadedArtifactAttached>
+                            <shadedClassifierName>deploy
+                            </shadedClassifierName>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.clearspring.analytics:stream
+                                    </include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Change package to have uk.gov.gchq prefix and add a RoaringBitmap aggregation function.

Adding shaded "deploy" jars build instructions to the pom of the bitmap and sketches library, so these can be used alongside core gaffer without other dependencies.