### PR TITLE
gh-659 - updated tests to use the edge builder

### DIFF
--- a/core/data/src/test/java/uk/gov/gchq/gaffer/data/IsEdgeValidatorTest.java
+++ b/core/data/src/test/java/uk/gov/gchq/gaffer/data/IsEdgeValidatorTest.java
@@ -30,7 +30,9 @@ public class IsEdgeValidatorTest {
     @Test
     public void shouldValidateWhenEdge() {
         // Given
-        final Element element = new Edge(TestGroups.EDGE);
+        final Element element = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .build();
 
         // When
         final boolean valid = new IsEdgeValidator().validate(element);
@@ -42,7 +44,9 @@ public class IsEdgeValidatorTest {
     @Test
     public void shouldNotValidateWhenEntity() {
         // Given
-        final Element element = new Entity(TestGroups.ENTITY);
+        final Element element = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .build();
 
         // When
         final boolean valid = new IsEdgeValidator().validate(element);

--- a/core/data/src/test/java/uk/gov/gchq/gaffer/data/IsElementValidatorTest.java
+++ b/core/data/src/test/java/uk/gov/gchq/gaffer/data/IsElementValidatorTest.java
@@ -30,7 +30,9 @@ public class IsElementValidatorTest {
     @Test
     public void shouldValidateWhenEntity() {
         // Given
-        final Element element = new Entity(TestGroups.ENTITY);
+        final Element element = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .build();
 
         // When
         final boolean valid = new IsElementValidator().validate(element);
@@ -42,7 +44,9 @@ public class IsElementValidatorTest {
     @Test
     public void shouldValidateWhenEdge() {
         // Given
-        final Element element = new Edge(TestGroups.EDGE);
+        final Element element = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .build();
 
         // When
         final boolean valid = new IsElementValidator().validate(element);

--- a/core/data/src/test/java/uk/gov/gchq/gaffer/data/IsEntityValidatorTest.java
+++ b/core/data/src/test/java/uk/gov/gchq/gaffer/data/IsEntityValidatorTest.java
@@ -30,7 +30,9 @@ public class IsEntityValidatorTest {
     @Test
     public void shouldValidateWhenEntity() {
         // Given
-        final Element element = new Entity(TestGroups.ENTITY);
+        final Element element = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .build();
 
         // When
         final boolean valid = new IsEntityValidator().validate(element);
@@ -42,7 +44,9 @@ public class IsEntityValidatorTest {
     @Test
     public void shouldNotValidateWhenEdge() {
         // Given
-        final Element element = new Edge(TestGroups.EDGE);
+        final Element element = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .build();
 
         // When
         final boolean valid = new IsEntityValidator().validate(element);

--- a/core/data/src/test/java/uk/gov/gchq/gaffer/data/element/EdgeTest.java
+++ b/core/data/src/test/java/uk/gov/gchq/gaffer/data/element/EdgeTest.java
@@ -39,17 +39,17 @@ public class EdgeTest extends ElementTest {
     @Test
     public void shouldSetAndGetFields() {
         // Given
-        final Edge edge = new Edge("group");
+        final Edge edge = new Edge.Builder()
+                .group("group")
+                .source("source vertex")
+                .dest("destination vertex")
+                .directed(true)
+                .build();
 
-        // When
-        edge.setSource("source vertex");
-        edge.setDestination("dest vertex");
-        edge.setDirected(true);
-
-        // Then
+        // When/Then
         assertEquals("group", edge.getGroup());
         assertEquals("source vertex", edge.getSource());
-        assertEquals("dest vertex", edge.getDestination());
+        assertEquals("destination vertex", edge.getDestination());
         assertTrue(edge.isDirected());
     }
 
@@ -87,7 +87,13 @@ public class EdgeTest extends ElementTest {
         final String propValue = "propValue";
 
         // When
-        final Edge edge = new Edge(TestGroups.EDGE, source, destination, directed);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source(source)
+                .dest(destination)
+                .directed(directed)
+                .build();
+
         edge.putProperty(TestPropertyNames.STRING, propValue);
 
         // Then
@@ -104,10 +110,15 @@ public class EdgeTest extends ElementTest {
         final String source = "source vertex";
         final String destination = "dest vertex";
         final boolean directed = true;
-        final String propValue = "propValue";
 
         // When
-        final Edge edge = new Edge(TestGroups.EDGE, source, destination, directed);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source(source)
+                .dest(destination)
+                .directed(directed)
+                .build();
+
         final Edge clone = edge.emptyClone();
 
         // Then
@@ -118,10 +129,12 @@ public class EdgeTest extends ElementTest {
     @Test
     public void shouldReturnTrueForEqualsWithTheSameInstance() {
         // Given
-        final Edge edge = new Edge("group");
-        edge.setSource("source vertex");
-        edge.setDestination("dest vertex");
-        edge.setDirected(true);
+        final Edge edge = new Edge.Builder()
+                .group("group")
+                .source("source vertex")
+                .dest("dest vertex")
+                .directed(true)
+                .build();
 
         // When
         boolean isEqual = edge.equals(edge);
@@ -134,11 +147,13 @@ public class EdgeTest extends ElementTest {
     @Test
     public void shouldReturnTrueForShallowEqualsWhenAllCoreFieldsAreEqual() {
         // Given
-        final Edge edge1 = new Edge("group");
-        edge1.setSource("source vertex");
-        edge1.setDestination("dest vertex");
-        edge1.setDirected(true);
-        edge1.putProperty("some property", "some value");
+        final Edge edge1 = new Edge.Builder()
+                .group("group")
+                .source("source vertex")
+                .dest("dest vertex")
+                .directed(true)
+                .property("some property", "some value")
+                .build();
 
         final Edge edge2 = cloneCoreFields(edge1);
         edge2.putProperty("some different property", "some other value");
@@ -153,12 +168,13 @@ public class EdgeTest extends ElementTest {
     @Override
     @Test
     public void shouldReturnTrueForEqualsWhenAllCoreFieldsAreEqual() {
-        // Given
-        final Edge edge1 = new Edge("group");
-        edge1.setSource("source vertex");
-        edge1.setDestination("dest vertex");
-        edge1.setDirected(true);
-        edge1.putProperty("some property", "some value");
+        final Edge edge1 = new Edge.Builder()
+                .group("group")
+                .source("source vertex")
+                .dest("dest vertex")
+                .directed(true)
+                .property("some property", "some value")
+                .build();
 
         final Edge edge2 = cloneCoreFields(edge1);
         edge2.putProperty("some property", "some value");
@@ -174,11 +190,13 @@ public class EdgeTest extends ElementTest {
     @Test
     public void shouldReturnFalseForEqualsWhenPropertyIsDifferent() {
         // Given
-        final Edge edge1 = new Edge("group");
-        edge1.setSource("source vertex");
-        edge1.setDestination("dest vertex");
-        edge1.setDirected(true);
-        edge1.putProperty("some property", "some value");
+        final Edge edge1 = new Edge.Builder()
+                .group("group")
+                .source("source vertex")
+                .dest("dest vertex")
+                .directed(true)
+                .property("some property", "some value")
+                .build();
 
         final Edge edge2 = cloneCoreFields(edge1);
         edge2.putProperty("some property", "some other value");
@@ -195,15 +213,19 @@ public class EdgeTest extends ElementTest {
     @Test
     public void shouldReturnFalseForEqualsWhenGroupIsDifferent() {
         // Given
-        final Edge edge1 = new Edge("group");
-        edge1.setSource("source vertex");
-        edge1.setDestination("dest vertex");
-        edge1.setDirected(true);
+        final Edge edge1 = new Edge.Builder()
+                .group("group")
+                .source("source vertex")
+                .dest("dest vertex")
+                .directed(true)
+                .build();
 
-        final Edge edge2 = new Edge("a different group");
-        edge2.setSource(edge1.getSource());
-        edge2.setDestination(edge1.getDestination());
-        edge2.setDirected(edge1.isDirected());
+        final Edge edge2 = new Edge.Builder()
+                .group("a different group")
+                .source(edge1.getSource())
+                .dest(edge1.getDestination())
+                .directed(edge1.isDirected())
+                .build();
 
         // When
         boolean isEqual = edge1.equals((Object) edge2);
@@ -216,10 +238,12 @@ public class EdgeTest extends ElementTest {
     @Test
     public void shouldReturnFalseForEqualsWhenDirectedIsDifferent() {
         // Given
-        final Edge edge1 = new Edge("group");
-        edge1.setSource("source vertex");
-        edge1.setDestination("dest vertex");
-        edge1.setDirected(true);
+        final Edge edge1 = new Edge.Builder()
+                .group("group")
+                .source("source vertex")
+                .dest("dest vertex")
+                .directed(true)
+                .build();
 
         final Edge edge2 = cloneCoreFields(edge1);
         edge2.setDirected(!edge1.isDirected());
@@ -235,10 +259,12 @@ public class EdgeTest extends ElementTest {
     @Test
     public void shouldReturnFalseForEqualsWhenSourceIsDifferent() {
         // Given
-        final Edge edge1 = new Edge("group");
-        edge1.setSource("source vertex");
-        edge1.setDestination("dest vertex");
-        edge1.setDirected(true);
+        final Edge edge1 = new Edge.Builder()
+                .group("group")
+                .source("source vertex")
+                .dest("dest vertex")
+                .directed(true)
+                .build();
 
         final Edge edge2 = cloneCoreFields(edge1);
         edge2.setSource("different source");
@@ -254,10 +280,11 @@ public class EdgeTest extends ElementTest {
     @Test
     public void shouldReturnFalseForEqualsWhenDestinationIsDifferent() {
         // Given
-        final Edge edge1 = new Edge("group");
-        edge1.setSource("source vertex");
-        edge1.setDestination("dest vertex");
-        edge1.setDirected(true);
+        final Edge edge1 = new Edge.Builder().group("group")
+                .source("source vertex")
+                .dest("dest vertex")
+                .directed(true)
+                .build();
 
         final Edge edge2 = cloneCoreFields(edge1);
         edge2.setDestination("different dest vertex");
@@ -273,16 +300,20 @@ public class EdgeTest extends ElementTest {
     @Test
     public void shouldReturnTrueForEqualsWhenUndirectedIdentifiersFlipped() {
         // Given
-        final Edge edge1 = new Edge("group");
-        edge1.setSource("source vertex");
-        edge1.setDestination("dest vertex");
-        edge1.setDirected(false);
+        final Edge edge1 = new Edge.Builder()
+                .group("group")
+                .source("source vertex")
+                .dest("dest vertex")
+                .directed(false)
+                .build();
 
         // Given
-        final Edge edge2 = new Edge("group");
-        edge2.setSource("dest vertex");
-        edge2.setDestination("source vertex");
-        edge2.setDirected(false);
+        final Edge edge2 = new Edge.Builder()
+                .group("group")
+                .source("dest vertex")
+                .dest("source vertex")
+                .directed(false)
+                .build();
 
         // When
         boolean isEqual = edge1.equals((Object) edge2);
@@ -295,16 +326,20 @@ public class EdgeTest extends ElementTest {
     @Test
     public void shouldReturnFalseForEqualsWhenDirectedIdentifiersFlipped() {
         // Given
-        final Edge edge1 = new Edge("group");
-        edge1.setSource("source vertex");
-        edge1.setDestination("dest vertex");
-        edge1.setDirected(true);
+        final Edge edge1 = new Edge.Builder()
+                .group("group")
+                .source("source vertex")
+                .dest("dest vertex")
+                .directed(true)
+                .build();
 
         // Given
-        final Edge edge2 = new Edge("group");
-        edge2.setSource("dest vertex");
-        edge2.setDestination("source vertex");
-        edge2.setDirected(true);
+        final Edge edge2 = new Edge.Builder()
+                .group("group")
+                .source("dest vertex")
+                .dest("source vertex")
+                .directed(true)
+                .build();
 
         // When
         boolean isEqual = edge1.equals((Object) edge2);
@@ -338,21 +373,21 @@ public class EdgeTest extends ElementTest {
 
     @Override
     protected Edge newElement(final String group) {
-        return new Edge(group);
+        return new Edge.Builder().group(group).build();
     }
 
     @Override
     protected Edge newElement() {
-        return new Edge();
+        return new Edge.Builder().build();
     }
 
     private Edge cloneCoreFields(final Edge edge) {
-        final Edge newEdge = new Edge(edge.getGroup());
-        newEdge.setSource(edge.getSource());
-        newEdge.setDestination(edge.getDestination());
-        newEdge.setDirected(edge.isDirected());
-
-        return newEdge;
+        return new Edge.Builder()
+                .group(edge.getGroup())
+                .source(edge.getSource())
+                .dest(edge.getDestination())
+                .directed(edge.isDirected())
+                .build();
     }
 
     private Edge cloneAllFields(final Edge edge) {

--- a/core/data/src/test/java/uk/gov/gchq/gaffer/data/element/EntityTest.java
+++ b/core/data/src/test/java/uk/gov/gchq/gaffer/data/element/EntityTest.java
@@ -37,10 +37,10 @@ public class EntityTest extends ElementTest {
     @Test
     public void shouldSetAndGetFields() {
         // Given
-        final Entity entity = new Entity("group");
-
-        // When
-        entity.setVertex("identifier");
+        final Entity entity = new Entity.Builder()
+                .group("group")
+                .vertex("identifier")
+                .build();
 
         // Then
         assertEquals("group", entity.getGroup());

--- a/core/data/src/test/java/uk/gov/gchq/gaffer/data/element/LazyEdgeTest.java
+++ b/core/data/src/test/java/uk/gov/gchq/gaffer/data/element/LazyEdgeTest.java
@@ -33,7 +33,7 @@ public class LazyEdgeTest {
     @Test
     public void shouldLoadPropertyFromLazyProperties() {
         // Given
-        final Edge edge = new Edge();
+        final Edge edge = new Edge.Builder().build();
         final ElementValueLoader edgeLoader = mock(ElementValueLoader.class);
         final LazyEdge lazyEdge = new LazyEdge(edge, edgeLoader);
         final String propertyName = "property name";
@@ -51,7 +51,7 @@ public class LazyEdgeTest {
     @Test
     public void shouldLoadIdentifierWhenNotLoaded() {
         // Given
-        final Edge edge = new Edge();
+        final Edge edge = new Edge.Builder().build();
         final ElementValueLoader edgeLoader = mock(ElementValueLoader.class);
         final LazyEdge lazyEdge = new LazyEdge(edge, edgeLoader);
         final IdentifierType identifierType = IdentifierType.DESTINATION;
@@ -70,7 +70,7 @@ public class LazyEdgeTest {
     @Test
     public void shouldNotLoadIdentifierWhenLoaded() {
         // Given
-        final Edge edge = new Edge();
+        final Edge edge = new Edge.Builder().build();
         final ElementValueLoader edgeLoader = mock(ElementValueLoader.class);
         final LazyEdge lazyEdge = new LazyEdge(edge, edgeLoader);
         final IdentifierType identifierType = IdentifierType.SOURCE;
@@ -91,7 +91,7 @@ public class LazyEdgeTest {
     @Test
     public void shouldNotLoadIsDirectedWhenLoaded() {
         // Given
-        final Edge edge = new Edge();
+        final Edge edge = new Edge.Builder().build();
         final ElementValueLoader edgeLoader = mock(ElementValueLoader.class);
         final LazyEdge lazyEdge = new LazyEdge(edge, edgeLoader);
         lazyEdge.setDirected(true); // call it to load the value.
@@ -109,7 +109,7 @@ public class LazyEdgeTest {
     @Test
     public void shouldDelegatePutPropertyToLazyProperties() {
         // Given
-        final Edge edge = new Edge();
+        final Edge edge = new Edge.Builder().build();
         final ElementValueLoader edgeLoader = mock(ElementValueLoader.class);
         final LazyEdge lazyEdge = new LazyEdge(edge, edgeLoader);
         final String propertyName = "property name";
@@ -126,7 +126,7 @@ public class LazyEdgeTest {
     @Test
     public void shouldDelegateSetDestinationToEdge() {
         // Given
-        final Edge edge = new Edge();
+        final Edge edge = new Edge.Builder().build();
         final ElementValueLoader edgeLoader = mock(ElementValueLoader.class);
         final LazyEdge lazyEdge = new LazyEdge(edge, edgeLoader);
         final IdentifierType identifierType = IdentifierType.DESTINATION;
@@ -143,7 +143,7 @@ public class LazyEdgeTest {
     @Test
     public void shouldDelegateSetSourceToEdge() {
         // Given
-        final Edge edge = new Edge();
+        final Edge edge = new Edge.Builder().build();
         final ElementValueLoader edgeLoader = mock(ElementValueLoader.class);
         final LazyEdge lazyEdge = new LazyEdge(edge, edgeLoader);
         final IdentifierType identifierType = IdentifierType.SOURCE;
@@ -160,7 +160,7 @@ public class LazyEdgeTest {
     @Test
     public void shouldDelegateSetDirectedToEdge() {
         // Given
-        final Edge edge = new Edge();
+        final Edge edge = new Edge.Builder().build();
         final ElementValueLoader edgeLoader = mock(ElementValueLoader.class);
         final LazyEdge lazyEdge = new LazyEdge(edge, edgeLoader);
         final IdentifierType identifierType = IdentifierType.DIRECTED;
@@ -179,7 +179,7 @@ public class LazyEdgeTest {
         // Given
         final ElementValueLoader edgeLoader = mock(ElementValueLoader.class);
         final String group = "group";
-        final Edge edge = new Edge(group);
+        final Edge edge = new Edge.Builder().group(group).build();
         final LazyEdge lazyEdge = new LazyEdge(edge, edgeLoader);
 
         // When
@@ -192,7 +192,7 @@ public class LazyEdgeTest {
     @Test
     public void shouldGetLazyProperties() {
         // Given
-        final Edge edge = new Edge();
+        final Edge edge = new Edge.Builder().build();
         final ElementValueLoader edgeLoader = mock(ElementValueLoader.class);
         final LazyEdge lazyEdge = new LazyEdge(edge, edgeLoader);
 
@@ -207,7 +207,7 @@ public class LazyEdgeTest {
     @Test
     public void shouldUnwrapEdge() {
         // Given
-        final Edge edge = new Edge();
+        final Edge edge = new Edge.Builder().build();
         final ElementValueLoader edgeLoader = mock(ElementValueLoader.class);
         final LazyEdge lazyEdge = new LazyEdge(edge, edgeLoader);
 

--- a/core/data/src/test/java/uk/gov/gchq/gaffer/data/element/function/ElementAggregatorTest.java
+++ b/core/data/src/test/java/uk/gov/gchq/gaffer/data/element/function/ElementAggregatorTest.java
@@ -221,8 +221,8 @@ public class ElementAggregatorTest {
     public void shouldAggregateWithNoPropertiesOrFunctions() {
         // Given
         final ElementAggregator aggregator = new ElementAggregator();
-        final Edge edge1 = new Edge("group");
-        final Edge edge2 = new Edge("group");
+        final Edge edge1 = new Edge.Builder().group("group").build();
+        final Edge edge2 = new Edge.Builder().group("group").build();
 
         // When - aggregate and set state
         final Element result = aggregator.apply(edge1, edge2);

--- a/core/data/src/test/java/uk/gov/gchq/gaffer/data/element/function/ElementTransformerTest.java
+++ b/core/data/src/test/java/uk/gov/gchq/gaffer/data/element/function/ElementTransformerTest.java
@@ -67,9 +67,11 @@ public class ElementTransformerTest {
                 .project("prop3")
                 .build();
 
-        final Entity element = new Entity("test");
-        element.putProperty("prop1", "value");
-        element.putProperty("prop2", 1);
+        final Entity element = new Entity.Builder()
+                .group("test")
+                .property("prop1", "value")
+                .property("prop2", 1)
+                .build();
 
         // When
         final Element result = transformer.apply(element);
@@ -88,9 +90,11 @@ public class ElementTransformerTest {
                 .project("prop3")
                 .build();
 
-        final Entity element = new Entity("test");
-        element.putProperty("prop1", "value");
-        element.putProperty("prop2", 1);
+        final Entity element = new Entity.Builder()
+                .group("test")
+                .property("prop1", "value")
+                .property("prop2", 1)
+                .build();
 
         // When
         final Element result = transformer.apply(element);

--- a/core/operation/src/test/java/uk/gov/gchq/gaffer/data/generator/EdgeIdExtractorTest.java
+++ b/core/operation/src/test/java/uk/gov/gchq/gaffer/data/generator/EdgeIdExtractorTest.java
@@ -33,7 +33,12 @@ public class EdgeIdExtractorTest {
     public void shouldGetIdentifierFromEdge() {
         // Given
         final EdgeIdExtractor extractor = new EdgeIdExtractor();
-        final Edge edge = new Edge(TestGroups.EDGE, "source", "destination", true);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("source")
+                .dest("destination")
+                .directed(true)
+                .build();
 
         // When
         final EdgeId seed = extractor._apply(edge);

--- a/core/operation/src/test/java/uk/gov/gchq/gaffer/data/generator/EntityIdExtractorTest.java
+++ b/core/operation/src/test/java/uk/gov/gchq/gaffer/data/generator/EntityIdExtractorTest.java
@@ -34,7 +34,10 @@ public class EntityIdExtractorTest {
     public void shouldGetIdentifierFromEntity() {
         // Given
         final EntityIdExtractor extractor = new EntityIdExtractor();
-        final Entity entity = new Entity(TestGroups.ENTITY, "identifier");
+        final Entity entity = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex("identifier")
+                .build();
 
         // When
         final EntityId seed = extractor._apply(entity);
@@ -47,7 +50,12 @@ public class EntityIdExtractorTest {
     public void shouldGetSourceFromEdge() {
         // Given
         final EntityIdExtractor extractor = new EntityIdExtractor(IdentifierType.SOURCE);
-        final Edge edge = new Edge(TestGroups.EDGE, "source", "destination", false);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("source")
+                .dest("destination")
+                .directed(false)
+                .build();
 
         // When
         final EntityId seed = extractor._apply(edge);
@@ -60,7 +68,12 @@ public class EntityIdExtractorTest {
     public void shouldGetDestinationFromEdge() {
         // Given
         final EntityIdExtractor extractor = new EntityIdExtractor(IdentifierType.DESTINATION);
-        final Edge edge = new Edge(TestGroups.EDGE, "source", "destination", false);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("source")
+                .dest("destination")
+                .directed(false)
+                .build();
 
         // When
         final EntityId seed = extractor._apply(edge);
@@ -73,7 +86,12 @@ public class EntityIdExtractorTest {
     public void shouldThrowIllegalArgumentExceptionFromEdgeWhenIdTypeIsDirected() {
         // Given
         final EntityIdExtractor extractor = new EntityIdExtractor(IdentifierType.DIRECTED);
-        final Edge edge = new Edge(TestGroups.EDGE, "source", "destination", false);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("source")
+                .dest("destination")
+                .directed(false)
+                .build();
 
         // When / Then
         try {

--- a/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/ValidateTest.java
+++ b/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/ValidateTest.java
@@ -24,7 +24,7 @@ import uk.gov.gchq.gaffer.exception.SerialisationException;
 import uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.OperationTest;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -45,18 +45,19 @@ public class ValidateTest extends OperationTest {
     @Override
     public void shouldSerialiseAndDeserialiseOperation() throws SerialisationException {
         // Given
-        final List<Element> elements = new ArrayList<>();
-        {
-            final Entity elm1 = new Entity("entity type 1", "vertex 1");
-            elm1.putProperty("property 1", "property 1 value");
-            elements.add(elm1);
-
-        }
-        {
-            final Edge elm2 = new Edge("edge type 2", "source vertex 1", "dest vertex 1", true);
-            elm2.putProperty("property 2", "property 2 value");
-            elements.add(elm2);
-        }
+        final List<Element> elements = Arrays.asList(
+                new Entity.Builder()
+                        .group("entity type 1")
+                        .vertex("vertex 1")
+                        .property("property 1", "property 1 value")
+                        .build(),
+                new Edge.Builder().group("edge type 2")
+                        .source("source vertex 1")
+                        .dest("dest vertex 1")
+                        .directed(true)
+                        .property("property 2", "property 2 value")
+                        .build()
+        );
 
         final Validate op = new Validate.Builder()
                 .validate(true)
@@ -91,7 +92,9 @@ public class ValidateTest extends OperationTest {
     @Test
     @Override
     public void builderShouldCreatePopulatedOperation() {
-        Element edge = new Edge("testGroup");
+        Element edge = new Edge.Builder()
+                .group("testGroup")
+                .build();
         Validate validate = new Validate.Builder()
                 .input(edge)
                 .skipInvalidElements(true)

--- a/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/add/AddElementsTest.java
+++ b/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/add/AddElementsTest.java
@@ -26,7 +26,7 @@ import uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.OperationTest;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -84,18 +84,19 @@ public class AddElementsTest extends OperationTest {
     @Test
     public void shouldSerialisePopulatedAddElementsOperation() throws IOException {
         // Given
-        final List<Element> elements = new ArrayList<>();
-        {
-            final Entity elm1 = new Entity("entity type 1", "vertex 1");
-            elm1.putProperty("property 1", "property 1 value");
-            elements.add(elm1);
-
-        }
-        {
-            final Edge elm2 = new Edge("edge type 2", "source vertex 1", "dest vertex 1", true);
-            elm2.putProperty("property 2", "property 2 value");
-            elements.add(elm2);
-        }
+        final List<Element> elements = Arrays.asList(
+                new Entity.Builder()
+                        .group("entity type 1")
+                        .vertex("vertex 1")
+                        .property("property 1", "property 1 value")
+                        .build(),
+                new Edge.Builder().group("edge type 2")
+                        .source("source vertex 1")
+                        .dest("dest vertex 1")
+                        .directed(true)
+                        .property("property 2", "property 2 value")
+                        .build()
+        );
 
         final AddElements addElements = new AddElements.Builder()
                 .input(elements)
@@ -136,7 +137,7 @@ public class AddElementsTest extends OperationTest {
     @Test
     @Override
     public void builderShouldCreatePopulatedOperation() {
-        Element element = new Edge("testEdgeGroup");
+        Element element = new Edge.Builder().group("testEdgeGroup").build();
         AddElements addElements = new AddElements.Builder()
                 .input(element)
                 .skipInvalidElements(true)

--- a/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/generate/GenerateObjectsTest.java
+++ b/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/generate/GenerateObjectsTest.java
@@ -26,7 +26,7 @@ import uk.gov.gchq.gaffer.exception.SerialisationException;
 import uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.OperationTest;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -53,18 +53,21 @@ public class GenerateObjectsTest extends OperationTest {
     @Override
     public void shouldSerialiseAndDeserialiseOperation() throws SerialisationException {
         // Given
-        final List<Element> elements = new ArrayList<>();
-        {
-            final Entity elm1 = new Entity("entity type 1", "vertex 1");
-            elm1.putProperty("property 1", "property 1 value");
-            elements.add(elm1);
+        final List<Element> elements = Arrays.asList(
+                new Entity.Builder()
+                        .group("entity type 1")
+                        .vertex("vertex 1")
+                        .property("property 1", "property 1 value")
+                        .build(),
 
-        }
-        {
-            final Edge elm2 = new Edge("edge type 2", "source vertex 1", "dest vertex 1", true);
-            elm2.putProperty("property 2", "property 2 value");
-            elements.add(elm2);
-        }
+                new Edge.Builder()
+                        .group("edge type 2")
+                        .source("source vertex 1")
+                        .dest("dest vertex 1")
+                        .directed(true)
+                        .property("property 2", "property 2 value")
+                        .build()
+        );
 
         final GenerateObjects<String> op = new GenerateObjects.Builder<String>()
                 .input(elements)

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/output/ToArrayHandlerTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/output/ToArrayHandlerTest.java
@@ -60,7 +60,14 @@ public class ToArrayHandlerTest {
     @Test
     public void shouldConvertIterableOfElementsToArray() throws OperationException {
         // Given
-        final Element[] originalArray = new Element[]{new Entity("entity"), new Edge("edge")};
+        final Element[] originalArray = new Element[]{
+                new Entity.Builder()
+                        .group("entity")
+                        .build(),
+                new Edge.Builder()
+                        .group("edge")
+                        .build()
+        };
 
         final Iterable<Element> originalResults = new WrappedCloseableIterable<>(Arrays.asList(originalArray));
         final ToArrayHandler<Element> handler = new ToArrayHandler<>();
@@ -97,8 +104,12 @@ public class ToArrayHandlerTest {
     public void shouldConvertIterableOfElementsAndElementIdsToArray() throws OperationException {
         // Given
         final ElementId[] originalArray = new ElementId[]{
-                new Entity("entity"),
-                new Edge("edge"),
+                new Entity.Builder()
+                        .group("entity")
+                        .build(),
+                new Edge.Builder()
+                        .group("edge")
+                        .build(),
                 new EntitySeed("vertex"),
                 new EdgeSeed("src", "dest", true)
         };
@@ -121,7 +132,7 @@ public class ToArrayHandlerTest {
         // Given
         final Object[] originalArray = new Object[]{
                 new Entity("entity"),
-                new Edge("edge"),
+                new Edge.Builder().group("edge"),
                 new EntitySeed("vertex"),
                 new EdgeSeed("src", "dest", true),
                 1,

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/serialiser/lengthvalue/EdgeSerialiserTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/serialiser/lengthvalue/EdgeSerialiserTest.java
@@ -65,7 +65,11 @@ public class EdgeSerialiserTest {
     @Test
     public void testCanSerialiseEdge() throws SerialisationException {
         // Given
-        final Edge edge = new Edge(TestGroups.EDGE, "source", "destination", true);
+        final Edge edge = new Edge.Builder().group(TestGroups.EDGE)
+                .source("source")
+                .dest("destination")
+                .directed(true)
+                .build();
 
         // When
         final byte[] serialisedEdge = serialiser.serialise(edge);

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/serialiser/lengthvalue/ElementSerialiserTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/serialiser/lengthvalue/ElementSerialiserTest.java
@@ -56,7 +56,12 @@ public class ElementSerialiserTest {
     @Test
     public void testCanSerialiseEdgeElement() throws SerialisationException {
         // Given
-        final Edge edge = new Edge(TestGroups.EDGE, "source", "destination", true);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("source")
+                .dest("destination")
+                .directed(true)
+                .build();
 
         // When
         final byte[] serialisedEdge = elementSerialiser.serialise(edge);
@@ -82,7 +87,11 @@ public class ElementSerialiserTest {
     @Test
     public void testGetGroup() throws SerialisationException {
         // Given
-        final Edge edge = new Edge(TestGroups.ENTITY, "source", "destination", true);
+        final Edge edge = new Edge.Builder().group(TestGroups.ENTITY)
+                .source("source")
+                .dest("destination")
+                .directed(true)
+                .build();
 
         // When
         final byte[] serialisedEdge = elementSerialiser.serialise(edge);

--- a/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/AbstractStoreIT.java
+++ b/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/AbstractStoreIT.java
@@ -280,23 +280,43 @@ public abstract class AbstractStoreIT {
         final Map<EdgeId, Edge> edges = new HashMap<>();
         for (int i = 0; i <= 10; i++) {
             for (int j = 0; j < VERTEX_PREFIXES.length; j++) {
-                final Edge edge = new Edge(TestGroups.EDGE, VERTEX_PREFIXES[0] + i, VERTEX_PREFIXES[j] + i, false);
-                edge.putProperty(TestPropertyNames.INT, 1);
-                edge.putProperty(TestPropertyNames.COUNT, 1L);
+                final Edge edge = new Edge.Builder()
+                        .group(TestGroups.EDGE)
+                        .source(VERTEX_PREFIXES[0] + i)
+                        .dest(VERTEX_PREFIXES[j] + i)
+                        .directed(false)
+                        .property(TestPropertyNames.INT, 1)
+                        .property(TestPropertyNames.COUNT, 1L)
+                        .build();
                 addToMap(edge, edges);
 
-                final Edge edgeDir = new Edge(TestGroups.EDGE, VERTEX_PREFIXES[0] + i, VERTEX_PREFIXES[j] + i, true);
-                edgeDir.putProperty(TestPropertyNames.INT, 1);
-                edgeDir.putProperty(TestPropertyNames.COUNT, 1L);
+                final Edge edgeDir = new Edge.Builder()
+                        .group(TestGroups.EDGE)
+                        .source(VERTEX_PREFIXES[0] + i)
+                        .dest(VERTEX_PREFIXES[j] + i)
+                        .directed(true)
+                        .property(TestPropertyNames.INT, 1)
+                        .property(TestPropertyNames.COUNT, 1L)
+                        .build();
                 addToMap(edgeDir, edges);
             }
 
-            final Edge edge = new Edge(TestGroups.EDGE, SOURCE + i, DEST + i, false);
-            edge.putProperty(TestPropertyNames.INT, 1);
-            edge.putProperty(TestPropertyNames.COUNT, 1L);
+            final Edge edge = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source(SOURCE + i)
+                    .dest(DEST + i)
+                    .directed(false)
+                    .property(TestPropertyNames.INT, 1)
+                    .property(TestPropertyNames.COUNT, 1L)
+                    .build();
             addToMap(edge, edges);
 
-            final Edge edgeDir = new Edge(TestGroups.EDGE, SOURCE_DIR + i, DEST_DIR + i, true);
+            final Edge edgeDir = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source(SOURCE_DIR + i)
+                    .dest(DEST_DIR + i)
+                    .directed(true)
+                    .build();
             edgeDir.putProperty(TestPropertyNames.INT, 1);
             edgeDir.putProperty(TestPropertyNames.COUNT, 1L);
             addToMap(edgeDir, edges);

--- a/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/generators/BasicEdgeGenerator.java
+++ b/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/generators/BasicEdgeGenerator.java
@@ -33,9 +33,13 @@ import uk.gov.gchq.gaffer.integration.domain.EdgeDomainObject;
 public class BasicEdgeGenerator implements OneToOneElementGenerator<EdgeDomainObject> {
     @Override
     public Element _apply(final EdgeDomainObject domainObject) {
-        final Edge edge = new Edge(TestGroups.EDGE, domainObject.getSource(), domainObject.getDestination(), domainObject.getDirected());
-        edge.putProperty(TestPropertyNames.INT, domainObject.getIntProperty());
-        edge.putProperty(TestPropertyNames.COUNT, 1L);
-        return edge;
+        return new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source(domainObject.getSource())
+                .dest(domainObject.getDestination())
+                .directed(domainObject.getDirected())
+                .property(TestPropertyNames.INT, domainObject.getIntProperty())
+                .property(TestPropertyNames.COUNT, 1L)
+                .build();
     }
 }

--- a/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/AggregationIT.java
+++ b/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/AggregationIT.java
@@ -71,7 +71,11 @@ public class AggregationIT extends AbstractStoreIT {
 
         // Edge with existing ids but directed
         graph.execute(new AddElements.Builder()
-                .input(new Edge(TestGroups.EDGE, NON_AGGREGATED_SOURCE, NON_AGGREGATED_DEST, true))
+                .input(new Edge.Builder().group(TestGroups.EDGE)
+                        .source(NON_AGGREGATED_SOURCE)
+                        .dest(NON_AGGREGATED_DEST)
+                        .directed(true)
+                        .build())
                 .build(), getUser());
     }
 
@@ -93,7 +97,12 @@ public class AggregationIT extends AbstractStoreIT {
         final Entity expectedEntity = new Entity(TestGroups.ENTITY, AGGREGATED_SOURCE);
         expectedEntity.putProperty(TestPropertyNames.STRING, "3,3,3");
 
-        final Edge expectedEdge = new Edge(TestGroups.EDGE, AGGREGATED_SOURCE, AGGREGATED_DEST, false);
+        final Edge expectedEdge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source(AGGREGATED_SOURCE)
+                .dest(AGGREGATED_DEST)
+                .directed(false)
+                .build();
         expectedEdge.putProperty(TestPropertyNames.INT, 1);
         expectedEdge.putProperty(TestPropertyNames.COUNT, 2L);
 
@@ -130,7 +139,11 @@ public class AggregationIT extends AbstractStoreIT {
         assertEquals(2, results.size());
         assertThat(results, IsCollectionContaining.hasItems(
                 getEdge(NON_AGGREGATED_SOURCE, NON_AGGREGATED_DEST, false),
-                new Edge(TestGroups.EDGE, NON_AGGREGATED_SOURCE, NON_AGGREGATED_DEST, true)
+                new Edge.Builder().group(TestGroups.EDGE)
+                        .source(NON_AGGREGATED_SOURCE)
+                        .dest(NON_AGGREGATED_DEST)
+                        .directed(true)
+                        .build()
         ));
     }
 

--- a/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/ExportIT.java
+++ b/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/ExportIT.java
@@ -58,7 +58,12 @@ public class ExportIT extends AbstractStoreIT {
     protected Map<EdgeId, Edge> createEdges() {
         final Map<EdgeId, Edge> edges = super.createEdges();
         for (int i = 0; i <= 10; i++) {
-            final Edge thirdEdge = new Edge(TestGroups.EDGE, DEST_DIR + i, SOURCE_DIR + (i + 1), true);
+            final Edge thirdEdge = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source(DEST_DIR + i)
+                    .dest(SOURCE_DIR + (i + 1))
+                    .directed(true)
+                    .build();
             thirdEdge.putProperty(TestPropertyNames.INT, 1);
             thirdEdge.putProperty(TestPropertyNames.COUNT, 1L);
             addToMap(thirdEdge, edges);

--- a/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/GeneratorsIT.java
+++ b/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/GeneratorsIT.java
@@ -102,7 +102,12 @@ public class GeneratorsIT extends AbstractStoreIT {
                 .input(new EntitySeed(NEW_VERTEX), new EdgeSeed(NEW_SOURCE, NEW_DEST, false))
                 .build(), getUser()));
 
-        final Edge expectedEdge = new Edge(TestGroups.EDGE, NEW_SOURCE, NEW_DEST, false);
+        final Edge expectedEdge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source(NEW_SOURCE)
+                .dest(NEW_DEST)
+                .directed(false)
+                .build();
         expectedEdge.putProperty(TestPropertyNames.INT, 1);
         expectedEdge.putProperty(TestPropertyNames.COUNT, 1L);
 

--- a/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/GetAllElementsIT.java
+++ b/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/GetAllElementsIT.java
@@ -235,7 +235,12 @@ public class GetAllElementsIT extends AbstractStoreIT {
                 if (edge.isDirected()) {
                     assertTrue("Edge was not expected: " + edge, expectedElements.contains(edge));
                 } else {
-                    final Edge edgeReversed = new Edge(TestGroups.EDGE, edge.getDestination(), edge.getSource(), edge.isDirected());
+                    final Edge edgeReversed = new Edge.Builder()
+                            .group(TestGroups.EDGE)
+                            .source(edge.getDestination())
+                            .dest(edge.getSource())
+                            .directed(edge.isDirected())
+                            .build();
                     expectedElementsCopy.remove(edgeReversed);
                     assertTrue("Edge was not expected: " + seed, expectedElements.contains(result) || expectedElements.contains(edgeReversed));
                 }

--- a/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/GetElementsIT.java
+++ b/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/GetElementsIT.java
@@ -289,7 +289,12 @@ public class GetElementsIT extends AbstractStoreIT {
                                     + ". \n\nSeeds: \n  " + StringUtils.join(seeds, "\n  "),
                             expectedElements.contains(edge));
                 } else {
-                    final Edge edgeReversed = new Edge(TestGroups.EDGE, edge.getDestination(), edge.getSource(), edge.isDirected());
+                    final Edge edgeReversed = new Edge.Builder()
+                            .group(TestGroups.EDGE)
+                            .source(edge.getDestination())
+                            .dest(edge.getSource())
+                            .directed(edge.isDirected())
+                            .build();
 
                     Properties properties = edge.getProperties();
                     edgeReversed.copyProperties(properties);
@@ -322,21 +327,36 @@ public class GetElementsIT extends AbstractStoreIT {
             } else {
                 if (DirectedType.isEither(((EdgeId) seed).getDirectedType())) {
                     if (BooleanUtils.isNotTrue(direction)) {
-                        final Edge edge = new Edge(TestGroups.EDGE, ((EdgeId) seed).getSource(), ((EdgeId) seed).getDestination(), false);
-                        edge.putProperty("intProperty", 1);
-                        edge.putProperty("count", 1L);
+                        final Edge edge = new Edge.Builder()
+                                .group(TestGroups.EDGE)
+                                .source(((EdgeId) seed).getSource())
+                                .dest(((EdgeId) seed).getDestination())
+                                .directed(false)
+                                .property("intProperty", 1)
+                                .property("count", 1L)
+                                .build();
                         elements.add(edge);
                     }
                     if (BooleanUtils.isNotFalse(direction)) {
-                        final Edge edgeDir = new Edge(TestGroups.EDGE, ((EdgeId) seed).getSource(), ((EdgeId) seed).getDestination(), true);
-                        edgeDir.putProperty("intProperty", 1);
-                        edgeDir.putProperty("count", 1L);
+                        final Edge edgeDir = new Edge.Builder()
+                                .group(TestGroups.EDGE)
+                                .source(((EdgeId) seed).getSource())
+                                .dest(((EdgeId) seed).getDestination())
+                                .directed(true)
+                                .property("intProperty", 1)
+                                .property("count", 1L)
+                                .build();
                         elements.add(edgeDir);
                     }
                 } else {
-                    final Edge edge = new Edge(TestGroups.EDGE, ((EdgeId) seed).getSource(), ((EdgeId) seed).getDestination(), ((EdgeId) seed).isDirected());
-                    edge.putProperty("intProperty", 1);
-                    edge.putProperty("count", 1L);
+                    final Edge edge = new Edge.Builder()
+                            .group(TestGroups.EDGE)
+                            .source(((EdgeId) seed).getSource())
+                            .dest(((EdgeId) seed).getDestination())
+                            .directed(((EdgeId) seed).isDirected())
+                            .property("intProperty", 1)
+                            .property("count", 1L)
+                            .build();
                     elements.add(edge);
                 }
             }

--- a/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/TransformationIT.java
+++ b/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/TransformationIT.java
@@ -36,7 +36,7 @@ import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
 import uk.gov.gchq.gaffer.operation.impl.get.GetElements;
 import uk.gov.gchq.gaffer.store.StoreTrait;
 import uk.gov.gchq.koryphe.impl.function.Concat;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -53,15 +53,22 @@ public class TransformationIT extends AbstractStoreIT {
         super.setup();
         addDefaultElements();
 
-        final Collection<Element> elements = new ArrayList<>(2);
-        final Edge sampleEdgeWithTransientProperty = new Edge(TestGroups.EDGE, VERTEX + SOURCE, VERTEX + DEST, true);
-        sampleEdgeWithTransientProperty.putProperty(TestPropertyNames.COUNT, 1L);
-        sampleEdgeWithTransientProperty.putProperty(TestPropertyNames.TRANSIENT_1, "test");
-        elements.add(sampleEdgeWithTransientProperty);
+        final Collection<Element> elements = Arrays.asList(
+                new Edge.Builder()
+                        .group(TestGroups.EDGE)
+                        .source(VERTEX + SOURCE)
+                        .dest(VERTEX + DEST)
+                        .directed(true)
+                        .property(TestPropertyNames.COUNT, 1L)
+                        .property(TestPropertyNames.TRANSIENT_1, "test")
+                        .build(),
 
-        final Entity sampleEntityWithTransientProperty = new Entity(TestGroups.ENTITY, VERTEX);
-        sampleEntityWithTransientProperty.putProperty(TestPropertyNames.TRANSIENT_1, "test");
-        elements.add(sampleEntityWithTransientProperty);
+                new Entity.Builder()
+                        .group(TestGroups.ENTITY)
+                        .vertex(VERTEX)
+                        .property(TestPropertyNames.TRANSIENT_1, "test")
+                        .build()
+        );
 
         graph.execute(new AddElements.Builder()
                 .input(elements)

--- a/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/dataframe/AccumuloStoreRelationTest.java
+++ b/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/dataframe/AccumuloStoreRelationTest.java
@@ -262,42 +262,50 @@ public class AccumuloStoreRelationTest {
     private static List<Element> getElements() {
         final List<Element> elements = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            final Entity entity = new Entity(GetDataFrameOfElementsHandlerTest.ENTITY_GROUP);
-            entity.setVertex("" + i);
-            entity.putProperty("columnQualifier", 1);
-            entity.putProperty("property1", i);
-            entity.putProperty("property2", 3.0F);
-            entity.putProperty("property3", 4.0D);
-            entity.putProperty("property4", i * 2L);
-            entity.putProperty("count", 6L);
+            final Entity entity = new Entity.Builder()
+                    .group(GetDataFrameOfElementsHandlerTest.ENTITY_GROUP)
+                    .vertex("" + i)
+                    .property("columnQualifier", 1)
+                    .property("property1", i)
+                    .property("property2", 3.0F)
+                    .property("property3", 4.0D)
+                    .property("property4", i * 2L)
+                    .property("count", 6L)
+                    .build();
 
-            final Edge edge1 = new Edge(GetDataFrameOfElementsHandlerTest.EDGE_GROUP);
-            edge1.setSource("" + i);
-            edge1.setDestination("B");
-            edge1.setDirected(true);
-            edge1.putProperty("columnQualifier", 1);
-            edge1.putProperty("property1", 2);
-            edge1.putProperty("property2", 3.0F);
-            edge1.putProperty("property3", 4.0D);
-            edge1.putProperty("property4", 5L);
-            edge1.putProperty("count", 100L);
+            final Edge edge1 = new Edge.Builder()
+                    .group(GetDataFrameOfElementsHandlerTest.EDGE_GROUP)
+                    .source("" + i)
+                    .dest("B")
+                    .directed(true)
+                    .property("columnQualifier", 1)
+                    .property("property1", 2)
+                    .property("property2", 3.0F)
+                    .property("property3", 4.0D)
+                    .property("property4", 5L)
+                    .property("count", 100L)
+                    .build();
 
-            final Edge edge2 = new Edge(GetDataFrameOfElementsHandlerTest.EDGE_GROUP);
-            edge2.setSource("" + i);
-            edge2.setDestination("C");
-            edge2.setDirected(true);
-            edge2.putProperty("columnQualifier", 6);
-            edge2.putProperty("property1", 7);
-            edge2.putProperty("property2", 8.0F);
-            edge2.putProperty("property3", 9.0D);
-            edge2.putProperty("property4", 10L);
-            edge2.putProperty("count", i * 200L);
+            final Edge edge2 = new Edge.Builder()
+                    .group(GetDataFrameOfElementsHandlerTest.EDGE_GROUP)
+                    .source("" + i)
+                    .dest("C")
+                    .directed(true)
+                    .property("columnQualifier", 6)
+                    .property("property1", 7)
+                    .property("property2", 8.0F)
+                    .property("property3", 9.0D)
+                    .property("property4", 10L)
+                    .property("count", i * 200L)
+                    .build();
 
-            final Edge edge3 = new Edge(GetDataFrameOfElementsHandlerTest.EDGE_GROUP2);
-            edge3.setSource("" + i);
-            edge3.setDestination("D");
-            edge3.setDirected(true);
-            edge3.putProperty("property1", 1000);
+            final Edge edge3 = new Edge.Builder()
+                    .group(GetDataFrameOfElementsHandlerTest.EDGE_GROUP2)
+                    .source("" + i)
+                    .dest("D")
+                    .directed(true)
+                    .property("property1", 1000)
+                    .build();
 
             elements.add(edge1);
             elements.add(edge2);

--- a/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/dataframe/GetDataFrameOfElementsHandlerTest.java
+++ b/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/dataframe/GetDataFrameOfElementsHandlerTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import scala.collection.mutable.Map;
 import scala.collection.mutable.Map$;
 import scala.collection.mutable.MutableList;
+import uk.gov.gchq.gaffer.commonutil.TestGroups;
 import uk.gov.gchq.gaffer.data.element.Edge;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.Entity;
@@ -530,36 +531,39 @@ public class GetDataFrameOfElementsHandlerTest {
     static List<Element> getElements() {
         final List<Element> elements = new ArrayList<>();
         for (int i = 0; i < NUM_ELEMENTS; i++) {
-            final Entity entity = new Entity(ENTITY_GROUP);
-            entity.setVertex("" + i);
-            entity.putProperty("columnQualifier", 1);
-            entity.putProperty("property1", i);
-            entity.putProperty("property2", 3.0F);
-            entity.putProperty("property3", 4.0D);
-            entity.putProperty("property4", 5L);
-            entity.putProperty("count", 6L);
+            final Entity entity = new Entity.Builder().group(TestGroups.ENTITY)
+                    .vertex("" + i)
+                    .property("columnQualifier", 1)
+                    .property("property1", i)
+                    .property("property2", 3.0F)
+                    .property("property3", 4.0D)
+                    .property("property4", 5L)
+                    .property("count", 6L)
+                    .build();
 
-            final Edge edge1 = new Edge(EDGE_GROUP);
-            edge1.setSource("" + i);
-            edge1.setDestination("B");
-            edge1.setDirected(true);
-            edge1.putProperty("columnQualifier", 1);
-            edge1.putProperty("property1", 2);
-            edge1.putProperty("property2", 3.0F);
-            edge1.putProperty("property3", 4.0D);
-            edge1.putProperty("property4", 5L);
-            edge1.putProperty("count", 100L);
+            final Edge edge1 = new Edge.Builder().group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("B")
+                    .directed(true)
+                    .property("columnQualifier", 1)
+                    .property("property1", 2)
+                    .property("property2", 3.0F)
+                    .property("property3", 4.0D)
+                    .property("property4", 5L)
+                    .property("count", 100L)
+                    .build();
 
-            final Edge edge2 = new Edge(EDGE_GROUP);
-            edge2.setSource("" + i);
-            edge2.setDestination("C");
-            edge2.setDirected(true);
-            edge2.putProperty("columnQualifier", 6);
-            edge2.putProperty("property1", 7);
-            edge2.putProperty("property2", 8.0F);
-            edge2.putProperty("property3", 9.0D);
-            edge2.putProperty("property4", 10L);
-            edge2.putProperty("count", i * 200L);
+            final Edge edge2 = new Edge.Builder().group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("C")
+                    .directed(true)
+                    .property("columnQualifier", 6)
+                    .property("property1", 7)
+                    .property("property2", 8.0F)
+                    .property("property3", 9.0D)
+                    .property("property4", 10L)
+                    .property("count", i * 200L)
+                    .build();
 
             elements.add(edge1);
             elements.add(edge2);
@@ -570,20 +574,28 @@ public class GetDataFrameOfElementsHandlerTest {
 
     private static List<Element> getElementsWithNonStandardProperties() {
         final List<Element> elements = new ArrayList<>();
-        final Entity entity = new Entity(ENTITY_GROUP);
-        entity.setVertex("A");
+
         final FreqMap freqMap = new FreqMap();
         freqMap.put("W", 10L);
         freqMap.put("X", 100L);
-        entity.putProperty("freqMap", freqMap);
+
         final HyperLogLogPlus hllpp = new HyperLogLogPlus(5, 5);
         hllpp.offer("AAA");
-        entity.putProperty("hllpp", hllpp);
+
+        final Entity entity = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex("A")
+                .property("freqMap", freqMap)
+                .property("hllpp", hllpp)
+                .build();
         elements.add(entity);
-        final Edge edge = new Edge(EDGE_GROUP);
-        edge.setSource("B");
-        edge.setDestination("C");
-        edge.setDirected(true);
+
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("B")
+                .dest("C")
+                .directed(true)
+                .build();
         final FreqMap freqMap2 = new FreqMap();
         freqMap2.put("Y", 1000L);
         freqMap2.put("Z", 10000L);
@@ -598,25 +610,35 @@ public class GetDataFrameOfElementsHandlerTest {
 
     private static List<Element> getElementsForUserDefinedConversion() {
         final List<Element> elements = new ArrayList<>();
-        final Entity entity = new Entity(ENTITY_GROUP);
-        entity.setVertex("A");
+
         final FreqMap freqMap = new FreqMap();
         freqMap.put("W", 10L);
         freqMap.put("X", 100L);
-        entity.putProperty("freqMap", freqMap);
+
         final HyperLogLogPlus hllpp = new HyperLogLogPlus(5, 5);
         hllpp.offer("AAA");
-        entity.putProperty("hllpp", hllpp);
-        entity.putProperty("myProperty", new MyProperty(10));
+
+        final Entity entity = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex("A")
+                .property("freqMap", freqMap)
+                .property("hllpp", hllpp)
+                .property("myProperty", new MyProperty(10))
+                .build();
         elements.add(entity);
-        final Edge edge = new Edge(EDGE_GROUP);
-        edge.setSource("B");
-        edge.setDestination("C");
-        edge.setDirected(true);
+
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("B")
+                .dest("C")
+                .directed(true)
+                .build();
+
         final FreqMap freqMap2 = new FreqMap();
         freqMap2.put("Y", 1000L);
         freqMap2.put("Z", 10000L);
         edge.putProperty("freqMap", freqMap2);
+
         final HyperLogLogPlus hllpp2 = new HyperLogLogPlus(5, 5);
         hllpp2.offer("AAA");
         hllpp2.offer("BBB");

--- a/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/javardd/GetJavaRDDOfAllElementsHandlerTest.java
+++ b/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/javardd/GetJavaRDDOfAllElementsHandlerTest.java
@@ -59,20 +59,26 @@ public class GetJavaRDDOfAllElementsHandlerTest {
         final List<Element> elements = new ArrayList<>();
         final Set<Element> expectedElements = new HashSet<>();
         for (int i = 0; i < 10; i++) {
-            final Entity entity = new Entity(TestGroups.ENTITY);
-            entity.setVertex("" + i);
+            final Entity entity = new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("" + i)
+                    .build();
 
-            final Edge edge1 = new Edge(TestGroups.EDGE);
-            edge1.setSource("" + i);
-            edge1.setDestination("B");
-            edge1.setDirected(false);
-            edge1.putProperty(TestPropertyNames.COUNT, 2);
+            final Edge edge1 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("B")
+                    .directed(false)
+                    .property(TestPropertyNames.COUNT, 2)
+                    .build();
 
-            final Edge edge2 = new Edge(TestGroups.EDGE);
-            edge2.setSource("" + i);
-            edge2.setDestination("C");
-            edge2.setDirected(false);
-            edge2.putProperty(TestPropertyNames.COUNT, 4);
+            final Edge edge2 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("C")
+                    .directed(false)
+                    .property(TestPropertyNames.COUNT, 4)
+                    .build();
 
             elements.add(edge1);
             elements.add(edge2);
@@ -127,23 +133,28 @@ public class GetJavaRDDOfAllElementsHandlerTest {
 
         final List<Element> elements = new ArrayList<>();
         for (int i = 0; i < 1; i++) {
-            final Entity entity = new Entity(TestGroups.ENTITY);
-            entity.setVertex("" + i);
-            entity.putProperty("visibility", "public");
+            final Entity entity = new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("" + i)
+                    .property("visibility", "public")
+                    .build();
 
-            final Edge edge1 = new Edge(TestGroups.EDGE);
-            edge1.setSource("" + i);
-            edge1.setDestination("B");
-            edge1.setDirected(false);
-            edge1.putProperty(TestPropertyNames.COUNT, 2);
-            edge1.putProperty("visibility", "private");
+            final Edge edge1 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("B")
+                    .directed(false)
+                    .property(TestPropertyNames.COUNT, 2)
+                    .property("visibility", "private")
+                    .build();
 
-            final Edge edge2 = new Edge(TestGroups.EDGE);
-            edge2.setSource("" + i);
-            edge2.setDestination("C");
-            edge2.setDirected(false);
-            edge2.putProperty(TestPropertyNames.COUNT, 4);
-            edge2.putProperty("visibility", "public");
+            final Edge edge2 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("C")
+                    .directed(false)
+                    .property(TestPropertyNames.COUNT, 4)
+                    .property("visibility", "public").build();
 
             elements.add(edge1);
             elements.add(edge2);

--- a/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/javardd/GetJavaRDDOfElementsHandlerTest.java
+++ b/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/javardd/GetJavaRDDOfElementsHandlerTest.java
@@ -22,6 +22,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.junit.Test;
 import uk.gov.gchq.gaffer.commonutil.CommonConstants;
+import uk.gov.gchq.gaffer.commonutil.TestGroups;
 import uk.gov.gchq.gaffer.data.element.Edge;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.Entity;
@@ -63,20 +64,26 @@ public class GetJavaRDDOfElementsHandlerTest {
 
         final List<Element> elements = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            final Entity entity = new Entity(ENTITY_GROUP);
-            entity.setVertex("" + i);
+            final Entity entity = new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("" + i)
+                    .build();
 
-            final Edge edge1 = new Edge(EDGE_GROUP);
-            edge1.setSource("" + i);
-            edge1.setDestination("B");
-            edge1.setDirected(false);
-            edge1.putProperty("count", 2);
+            final Edge edge1 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("B")
+                    .directed(false)
+                    .property("count", 2)
+                    .build();
 
-            final Edge edge2 = new Edge(EDGE_GROUP);
-            edge2.setSource("" + i);
-            edge2.setDestination("C");
-            edge2.setDirected(false);
-            edge2.putProperty("count", 4);
+            final Edge edge2 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("C")
+                    .directed(false)
+                    .property("count", 4)
+                    .build();
 
             elements.add(edge1);
             elements.add(edge2);
@@ -111,18 +118,22 @@ public class GetJavaRDDOfElementsHandlerTest {
         }
         final Set<Element> results = new HashSet<>(rdd.collect());
         final Set<Element> expectedElements = new HashSet<>();
-        final Entity entity1 = new Entity(ENTITY_GROUP);
-        entity1.setVertex("1");
-        final Edge edge1B = new Edge(EDGE_GROUP);
-        edge1B.setSource("1");
-        edge1B.setDestination("B");
-        edge1B.setDirected(false);
-        edge1B.putProperty("count", 2);
-        final Edge edge1C = new Edge(EDGE_GROUP);
-        edge1C.setSource("1");
-        edge1C.setDestination("C");
-        edge1C.setDirected(false);
-        edge1C.putProperty("count", 4);
+        final Entity entity1 = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex("1")
+                .build();
+        final Edge edge1B = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("1")
+                .dest("B")
+                .directed(false)
+                .property("count", 2).build();
+        final Edge edge1C = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("1")
+                .dest("C")
+                .directed(false)
+                .property("count", 4).build();
         expectedElements.add(entity1);
         expectedElements.add(edge1B);
         expectedElements.add(edge1C);
@@ -179,18 +190,21 @@ public class GetJavaRDDOfElementsHandlerTest {
         }
         results.clear();
         results.addAll(rdd.collect());
-        final Entity entity5 = new Entity(ENTITY_GROUP);
-        entity5.setVertex("5");
-        final Edge edge5B = new Edge(EDGE_GROUP);
-        edge5B.setSource("5");
-        edge5B.setDestination("B");
-        edge5B.setDirected(false);
-        edge5B.putProperty("count", 2);
-        final Edge edge5C = new Edge(EDGE_GROUP);
-        edge5C.setSource("5");
-        edge5C.setDestination("C");
-        edge5C.setDirected(false);
-        edge5C.putProperty("count", 4);
+        final Entity entity5 = new Entity.Builder()
+                .group(TestGroups.ENTITY).
+                        vertex("5").build();
+        final Edge edge5B = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("5")
+                .dest("B")
+                .directed(false)
+                .property("count", 2).build();
+        final Edge edge5C = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("5")
+                .dest("C")
+                .directed(false)
+                .property("count", 4).build();
         expectedElements.clear();
         expectedElements.add(entity1);
         expectedElements.add(edge1B);
@@ -215,20 +229,26 @@ public class GetJavaRDDOfElementsHandlerTest {
 
         final List<Element> elements = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            final Entity entity = new Entity(ENTITY_GROUP);
-            entity.setVertex("" + i);
+            final Entity entity = new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("" + i)
+                    .build();
 
-            final Edge edge1 = new Edge(EDGE_GROUP);
-            edge1.setSource("" + i);
-            edge1.setDestination("B");
-            edge1.setDirected(false);
-            edge1.putProperty("count", 2);
+            final Edge edge1 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("B")
+                    .directed(false)
+                    .property("count", 2)
+                    .build();
 
-            final Edge edge2 = new Edge(EDGE_GROUP);
-            edge2.setSource("" + i);
-            edge2.setDestination("C");
-            edge2.setDirected(false);
-            edge2.putProperty("count", 4);
+            final Edge edge2 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("C")
+                    .directed(false)
+                    .property("count", 4)
+                    .build();
 
             elements.add(edge1);
             elements.add(edge2);
@@ -267,11 +287,13 @@ public class GetJavaRDDOfElementsHandlerTest {
         final Set<Element> results = new HashSet<>();
         results.addAll(rdd.collect());
         final Set<Element> expectedElements = new HashSet<>();
-        final Edge edge1B = new Edge(EDGE_GROUP);
-        edge1B.setSource("1");
-        edge1B.setDestination("B");
-        edge1B.setDirected(false);
-        edge1B.putProperty("count", 2);
+        final Edge edge1B = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("1")
+                .dest("B")
+                .directed(false)
+                .property("count", 2)
+                .build();
         expectedElements.add(edge1B);
         assertEquals(expectedElements, results);
 
@@ -291,8 +313,9 @@ public class GetJavaRDDOfElementsHandlerTest {
         results.clear();
         results.addAll(rdd.collect());
         expectedElements.clear();
-        final Entity entity1 = new Entity(ENTITY_GROUP);
-        entity1.setVertex("1");
+        final Entity entity1 = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex("1").build();
         expectedElements.add(entity1);
         assertEquals(expectedElements, results);
 
@@ -331,11 +354,13 @@ public class GetJavaRDDOfElementsHandlerTest {
         }
         results.clear();
         results.addAll(rdd.collect());
-        final Edge edge5C = new Edge(EDGE_GROUP);
-        edge5C.setSource("5");
-        edge5C.setDestination("C");
-        edge5C.setDirected(false);
-        edge5C.putProperty("count", 4);
+        final Edge edge5C = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("5")
+                .dest("C")
+                .directed(false)
+                .property("count", 4)
+                .build();
         expectedElements.clear();
         expectedElements.add(edge1B);
         expectedElements.add(edge5C);

--- a/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/javardd/ImportJavaRDDOfElementsHandlerTest.java
+++ b/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/javardd/ImportJavaRDDOfElementsHandlerTest.java
@@ -59,20 +59,26 @@ public class ImportJavaRDDOfElementsHandlerTest {
 
         final List<Element> elements = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            final Entity entity = new Entity(TestGroups.ENTITY);
-            entity.setVertex("" + i);
+            final Entity entity = new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("" + i)
+                    .build();
 
-            final Edge edge1 = new Edge(TestGroups.EDGE);
-            edge1.setSource("" + i);
-            edge1.setDestination("B");
-            edge1.setDirected(false);
-            edge1.putProperty(TestPropertyNames.COUNT, 2);
+            final Edge edge1 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("B")
+                    .directed(false)
+                    .property(TestPropertyNames.COUNT, 2)
+                    .build();
 
-            final Edge edge2 = new Edge(TestGroups.EDGE);
-            edge2.setSource("" + i);
-            edge2.setDestination("C");
-            edge2.setDirected(false);
-            edge2.putProperty(TestPropertyNames.COUNT, 4);
+            final Edge edge2 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("C")
+                    .directed(false)
+                    .property(TestPropertyNames.COUNT, 4)
+                    .build();
 
             elements.add(edge1);
             elements.add(edge2);

--- a/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/javardd/ImportKeyValueJavaPairRDDToAccumuloHandlerTest.java
+++ b/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/javardd/ImportKeyValueJavaPairRDDToAccumuloHandlerTest.java
@@ -65,20 +65,26 @@ public class ImportKeyValueJavaPairRDDToAccumuloHandlerTest {
 
         final List<Element> elements = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            final Entity entity = new Entity(TestGroups.ENTITY);
-            entity.setVertex("" + i);
+            final Entity entity = new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("" + i)
+                    .build();
 
-            final Edge edge1 = new Edge(TestGroups.EDGE);
-            edge1.setSource("" + i);
-            edge1.setDestination("B");
-            edge1.setDirected(false);
-            edge1.putProperty(TestPropertyNames.COUNT, 2);
+            final Edge edge1 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("B")
+                    .directed(false)
+                    .property(TestPropertyNames.COUNT, 2)
+                    .build();
 
-            final Edge edge2 = new Edge(TestGroups.EDGE);
-            edge2.setSource("" + i);
-            edge2.setDestination("C");
-            edge2.setDirected(false);
-            edge2.putProperty(TestPropertyNames.COUNT, 4);
+            final Edge edge2 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("C")
+                    .directed(false)
+                    .property(TestPropertyNames.COUNT, 4)
+                    .build();
 
             elements.add(edge1);
             elements.add(edge2);

--- a/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/scalardd/GetRDDOfElementsHandlerTest.java
+++ b/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/scalardd/GetRDDOfElementsHandlerTest.java
@@ -22,6 +22,7 @@ import org.apache.spark.SparkContext;
 import org.apache.spark.rdd.RDD;
 import org.junit.Test;
 import uk.gov.gchq.gaffer.commonutil.CommonConstants;
+import uk.gov.gchq.gaffer.commonutil.TestGroups;
 import uk.gov.gchq.gaffer.data.element.Edge;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.Entity;
@@ -37,6 +38,7 @@ import uk.gov.gchq.gaffer.user.User;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -62,20 +64,26 @@ public class GetRDDOfElementsHandlerTest {
 
         final List<Element> elements = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            final Entity entity = new Entity(ENTITY_GROUP);
-            entity.setVertex("" + i);
+            final Entity entity = new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("" + i)
+                    .build();
 
-            final Edge edge1 = new Edge(EDGE_GROUP);
-            edge1.setSource("" + i);
-            edge1.setDestination("B");
-            edge1.setDirected(false);
-            edge1.putProperty("count", 2);
+            final Edge edge1 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("B")
+                    .directed(false)
+                    .property("count", 2)
+                    .build();
 
-            final Edge edge2 = new Edge(EDGE_GROUP);
-            edge2.setSource("" + i);
-            edge2.setDestination("C");
-            edge2.setDirected(false);
-            edge2.putProperty("count", 4);
+            final Edge edge2 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("C")
+                    .directed(false)
+                    .property("count", 4)
+                    .build();
 
             elements.add(edge1);
             elements.add(edge2);
@@ -116,18 +124,24 @@ public class GetRDDOfElementsHandlerTest {
         }
 
         final Set<Element> expectedElements = new HashSet<>();
-        final Entity entity1 = new Entity(ENTITY_GROUP);
-        entity1.setVertex("1");
-        final Edge edge1B = new Edge(EDGE_GROUP);
-        edge1B.setSource("1");
-        edge1B.setDestination("B");
-        edge1B.setDirected(false);
-        edge1B.putProperty("count", 2);
-        final Edge edge1C = new Edge(EDGE_GROUP);
-        edge1C.setSource("1");
-        edge1C.setDestination("C");
-        edge1C.setDirected(false);
-        edge1C.putProperty("count", 4);
+        final Entity entity1 = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex("1")
+                .build();
+        final Edge edge1B = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("1")
+                .dest("B")
+                .directed(false)
+                .property("count", 2)
+                .build();
+        final Edge edge1C = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("1")
+                .dest("C")
+                .directed(false)
+                .property("count", 4)
+                .build();
         expectedElements.add(entity1);
         expectedElements.add(edge1B);
         expectedElements.add(edge1C);
@@ -196,21 +210,25 @@ public class GetRDDOfElementsHandlerTest {
 
         results.clear();
         returnedElements = (Element[]) rdd.collect();
-        for (int i = 0; i < returnedElements.length; i++) {
-            results.add(returnedElements[i]);
-        }
-        final Entity entity5 = new Entity(ENTITY_GROUP);
-        entity5.setVertex("5");
-        final Edge edge5B = new Edge(EDGE_GROUP);
-        edge5B.setSource("5");
-        edge5B.setDestination("B");
-        edge5B.setDirected(false);
-        edge5B.putProperty("count", 2);
-        final Edge edge5C = new Edge(EDGE_GROUP);
-        edge5C.setSource("5");
-        edge5C.setDestination("C");
-        edge5C.setDirected(false);
-        edge5C.putProperty("count", 4);
+        results.addAll(Arrays.asList(returnedElements));
+        final Entity entity5 = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex("5")
+                .build();
+        final Edge edge5B = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("5")
+                .dest("B")
+                .directed(false)
+                .property("count", 2)
+                .build();
+        final Edge edge5C = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("5")
+                .dest("C")
+                .directed(false)
+                .property("count", 4)
+                .build();
         expectedElements.clear();
         expectedElements.add(entity1);
         expectedElements.add(edge1B);
@@ -235,20 +253,26 @@ public class GetRDDOfElementsHandlerTest {
 
         final List<Element> elements = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            final Entity entity = new Entity(ENTITY_GROUP);
-            entity.setVertex("" + i);
+            final Entity entity = new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("" + i)
+                    .build();
 
-            final Edge edge1 = new Edge(EDGE_GROUP);
-            edge1.setSource("" + i);
-            edge1.setDestination("B");
-            edge1.setDirected(false);
-            edge1.putProperty("count", 2);
+            final Edge edge1 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("B")
+                    .directed(false)
+                    .property("count", 2)
+                    .build();
 
-            final Edge edge2 = new Edge(EDGE_GROUP);
-            edge2.setSource("" + i);
-            edge2.setDestination("C");
-            edge2.setDirected(false);
-            edge2.putProperty("count", 4);
+            final Edge edge2 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("C")
+                    .directed(false)
+                    .property("count", 4)
+                    .build();
 
             elements.add(edge1);
             elements.add(edge2);
@@ -292,11 +316,13 @@ public class GetRDDOfElementsHandlerTest {
         }
 
         final Set<Element> expectedElements = new HashSet<>();
-        final Edge edge1B = new Edge(EDGE_GROUP);
-        edge1B.setSource("1");
-        edge1B.setDestination("B");
-        edge1B.setDirected(false);
-        edge1B.putProperty("count", 2);
+        final Edge edge1B = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("1")
+                .dest("B")
+                .directed(false)
+                .property("count", 2)
+                .build();
         expectedElements.add(edge1B);
         assertEquals(expectedElements, results);
 
@@ -320,8 +346,10 @@ public class GetRDDOfElementsHandlerTest {
             results.add(returnedElements[i]);
         }
         expectedElements.clear();
-        final Entity entity1 = new Entity(ENTITY_GROUP);
-        entity1.setVertex("1");
+        final Entity entity1 = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex("1")
+                .build();
         expectedElements.add(entity1);
         assertEquals(expectedElements, results);
 
@@ -364,14 +392,14 @@ public class GetRDDOfElementsHandlerTest {
 
         results.clear();
         returnedElements = (Element[]) rdd.collect();
-        for (int i = 0; i < returnedElements.length; i++) {
-            results.add(returnedElements[i]);
-        }
-        final Edge edge5C = new Edge(EDGE_GROUP);
-        edge5C.setSource("5");
-        edge5C.setDestination("C");
-        edge5C.setDirected(false);
-        edge5C.putProperty("count", 4);
+        results.addAll(Arrays.asList(returnedElements));
+        final Edge edge5C = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("5")
+                .dest("C")
+                .directed(false)
+                .property("count", 4)
+                .build();
         expectedElements.clear();
         expectedElements.add(edge1B);
         expectedElements.add(edge5C);

--- a/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/scalardd/ImportKeyValuePairRDDToAccumuloHandlerTest.java
+++ b/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/scalardd/ImportKeyValuePairRDDToAccumuloHandlerTest.java
@@ -71,20 +71,25 @@ public class ImportKeyValuePairRDDToAccumuloHandlerTest {
 
         final ArrayBuffer<Element> elements = new ArrayBuffer<>();
         for (int i = 0; i < 10; i++) {
-            final Entity entity = new Entity(TestGroups.ENTITY);
-            entity.setVertex("" + i);
+            final Entity entity = new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("" + i)
+                    .build();
 
-            final Edge edge1 = new Edge(TestGroups.EDGE);
-            edge1.setSource("" + i);
-            edge1.setDestination("B");
-            edge1.setDirected(false);
-            edge1.putProperty(TestPropertyNames.COUNT, 2);
+            final Edge edge1 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("B").directed(false)
+                    .property(TestPropertyNames.COUNT, 2)
+                    .build();
 
-            final Edge edge2 = new Edge(TestGroups.EDGE);
-            edge2.setSource("" + i);
-            edge2.setDestination("C");
-            edge2.setDirected(false);
-            edge2.putProperty(TestPropertyNames.COUNT, 4);
+            final Edge edge2 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("C")
+                    .directed(false)
+                    .property(TestPropertyNames.COUNT, 4)
+                    .build();
 
             elements.$plus$eq(edge1);
             elements.$plus$eq(edge2);

--- a/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/scalardd/ImportRDDOfElementsHandlerTest.java
+++ b/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/scalardd/ImportRDDOfElementsHandlerTest.java
@@ -61,20 +61,26 @@ public class ImportRDDOfElementsHandlerTest {
 
         final ArrayBuffer<Element> elements = new ArrayBuffer<>();
         for (int i = 0; i < 10; i++) {
-            final Entity entity = new Entity(TestGroups.ENTITY);
-            entity.setVertex("" + i);
+            final Entity entity = new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("" + i)
+                    .build();
 
-            final Edge edge1 = new Edge(TestGroups.EDGE);
-            edge1.setSource("" + i);
-            edge1.setDestination("B");
-            edge1.setDirected(false);
-            edge1.putProperty(TestPropertyNames.COUNT, 2);
+            final Edge edge1 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("B")
+                    .directed(false)
+                    .property(TestPropertyNames.COUNT, 2)
+                    .build();
 
-            final Edge edge2 = new Edge(TestGroups.EDGE);
-            edge2.setSource("" + i);
-            edge2.setDestination("C");
-            edge2.setDirected(false);
-            edge2.putProperty(TestPropertyNames.COUNT, 4);
+            final Edge edge2 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("C")
+                    .directed(false)
+                    .property(TestPropertyNames.COUNT, 4)
+                    .build();
 
             elements.$plus$eq(edge1);
             elements.$plus$eq(edge2);

--- a/library/spark/spark-library/src/test/java/uk/gov/gchq/gaffer/spark/serialisation/kryo/impl/TestEdgeKryoSerializer.java
+++ b/library/spark/spark-library/src/test/java/uk/gov/gchq/gaffer/spark/serialisation/kryo/impl/TestEdgeKryoSerializer.java
@@ -38,11 +38,13 @@ public class TestEdgeKryoSerializer {
     @Test
     public void testEdge() {
         // Given
-        final Edge edge = new Edge("group");
-        edge.setSource("abc");
-        edge.setDestination("xyz");
-        edge.setDirected(true);
-        edge.putProperty("property1", 1);
+        final Edge edge = new Edge.Builder()
+                .group("group")
+                .source("abc")
+                .dest("xyz")
+                .directed(true)
+                .property("property1", 1)
+                .build();
 
         // When
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/library/spark/spark-library/src/test/java/uk/gov/gchq/gaffer/spark/serialisation/kryo/impl/TestEntityKryoSerializer.java
+++ b/library/spark/spark-library/src/test/java/uk/gov/gchq/gaffer/spark/serialisation/kryo/impl/TestEntityKryoSerializer.java
@@ -38,9 +38,11 @@ public class TestEntityKryoSerializer {
     @Test
     public void testEntity() {
         // Given
-        Entity entity = new Entity("group");
-        entity.setVertex("abc");
-        entity.putProperty("property1", 1);
+        Entity entity = new Entity.Builder()
+                .group("group")
+                .vertex("abc")
+                .property("property1", 1)
+                .build();
 
         // When
         ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/example/ExampleElementGenerator.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/example/ExampleElementGenerator.java
@@ -25,18 +25,20 @@ public class ExampleElementGenerator implements OneToOneElementGenerator<Example
     @Override
     public Element _apply(final ExampleDomainObject obj) {
         if (obj.getIds().length > 1) {
-            final Edge edge = new Edge(obj.getType());
-            edge.setSource(obj.getIds()[0]);
-            edge.setDestination(obj.getIds()[1]);
+            final Edge.Builder builder = new Edge.Builder()
+                    .group(obj.getType())
+                    .source(obj.getIds()[0])
+                    .dest(obj.getIds()[1]);
             if (obj.getIds().length > 2) {
-                edge.setDirected(Boolean.TRUE.equals(obj.getIds()[2]));
+                builder.directed(Boolean.TRUE.equals(obj.getIds()[2]));
             }
 
-            return edge;
+            return builder.build();
         }
 
-        final Entity entity = new Entity(obj.getType());
-        entity.setVertex(obj.getIds()[0]);
-        return entity;
+        return new Entity.Builder()
+                .group(obj.getType())
+                .vertex(obj.getIds()[0])
+                .build();
     }
 }

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/ExamplesService.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/ExamplesService.java
@@ -285,8 +285,11 @@ public class ExamplesService implements IExamplesService {
         final String group = getAnEntityGroup();
         final SchemaElementDefinition entityDef = getSchema().getEntity(group);
 
-        final Entity entity = new Entity(group);
-        entity.setVertex(getExampleVertex(entityDef.getIdentifierClass(IdentifierType.VERTEX), uniqueId));
+        final Entity entity = new Entity.Builder()
+                .group(group)
+                .vertex(getExampleVertex(entityDef
+                        .getIdentifierClass(IdentifierType.VERTEX), uniqueId))
+                .build();
         populateProperties(entity, entityDef, uniqueId);
 
         return entity;
@@ -296,10 +299,13 @@ public class ExamplesService implements IExamplesService {
         final String group = getAnEdgeGroup();
         final SchemaElementDefinition edgeDef = getSchema().getEdge(group);
 
-        final Edge edge = new Edge(group);
-        edge.setSource(getExampleVertex(edgeDef.getIdentifierClass(IdentifierType.SOURCE), uniqueId1));
-        edge.setDestination(getExampleVertex(edgeDef.getIdentifierClass(IdentifierType.DESTINATION), uniqueId2));
-        edge.setDirected(isAnEdgeDirected());
+        final Edge edge = new Edge.Builder()
+                .group(group)
+                .source(getExampleVertex(edgeDef.getIdentifierClass(IdentifierType.SOURCE), uniqueId1))
+                .dest(getExampleVertex(edgeDef
+                        .getIdentifierClass(IdentifierType.DESTINATION), uniqueId2))
+                .directed(isAnEdgeDirected())
+                .build();
 
         populateProperties(edge, edgeDef, uniqueId1);
 

--- a/store-implementation/accumulo-store/compat-1.8/test/java/uk/gov/gchq/gaffer/accumulostore/integration/performance/BloomFilter18IT.java
+++ b/store-implementation/accumulo-store/compat-1.8/test/java/uk/gov/gchq/gaffer/accumulostore/integration/performance/BloomFilter18IT.java
@@ -115,14 +115,18 @@ public class BloomFilter18IT {
         final HashSet<Key> keysSet = new HashSet<>();
         final HashSet<Entity> dataSet = new HashSet<>();
         for (int i = 0; i < 100000; i++) {
-            final Entity source = new Entity(TestGroups.ENTITY);
-            source.setVertex("type" + random.nextInt(Integer.MAX_VALUE));
+            final Entity source = new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("type" + random.nextInt(Integer.MAX_VALUE))
+                    .build();
             final Entity destination = new Entity(TestGroups.ENTITY);
             destination.setVertex("type" + random.nextInt(Integer.MAX_VALUE));
             dataSet.add(source);
             dataSet.add(destination);
-            final Entity sourceEntity = new Entity(source.getGroup());
-            sourceEntity.setVertex(source.getVertex());
+            final Entity sourceEntity = new Entity.Builder()
+                    .group(source.getGroup())
+                    .vertex(source.getVertex())
+                    .build();
             final Entity destinationEntity = new Entity(destination.getGroup());
             destinationEntity.setVertex(destination.getVertex());
             final Edge edge = new Edge(TestGroups.EDGE, source.getVertex(), destination

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/inputformat/InputFormatTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/inputformat/InputFormatTest.java
@@ -77,45 +77,51 @@ public class InputFormatTest {
 
     static {
         for (int i = 0; i < NUM_ENTRIES; i++) {
-            final Entity entity = new Entity(TestGroups.ENTITY);
-            entity.setVertex("" + i);
-            entity.putProperty("property1", 1);
+            final Entity entity = new Entity.Builder().group(TestGroups.ENTITY)
+                                                      .vertex("" + i)
+                                                      .property("property1", 1)
+                                                      .build();
 
-            final Edge edge = new Edge(TestGroups.EDGE);
-            edge.setSource("" + i);
-            edge.setDestination("B");
-            edge.setDirected(true);
-            edge.putProperty("property1", 2);
+            final Edge edge = new Edge.Builder().group(TestGroups.EDGE)
+                                                .source("" + i)
+                                                .dest("B")
+                                                .directed(true)
+                                                .property("property1", 2)
+                                                .build();
 
-            final Edge edge2 = new Edge(TestGroups.EDGE);
-            edge2.setSource("" + i);
-            edge2.setDestination("C");
-            edge2.setDirected(true);
-            edge2.putProperty("property2", 3);
+            final Edge edge2 = new Edge.Builder().group(TestGroups.EDGE)
+                                                 .source("" + i)
+                                                 .dest("C")
+                                                 .directed(true)
+                                                 .property("property2", 3)
+                                                 .build();
 
             DATA.add(edge);
             DATA.add(edge2);
             DATA.add(entity);
         }
         for (int i = 0; i < NUM_ENTRIES; i++) {
-            final Entity entity = new Entity(TestGroups.ENTITY);
-            entity.setVertex("" + i);
-            entity.putProperty("property1", 1);
-            entity.putProperty("visibility", "public");
+            final Entity entity = new Entity.Builder().group(TestGroups.ENTITY)
+                                                      .vertex("" + i)
+                                                      .property("property1", 1)
+                                                      .property("visibility", "public")
+                                                      .build();
 
-            final Edge edge = new Edge(TestGroups.EDGE);
-            edge.setSource("" + i);
-            edge.setDestination("B");
-            edge.setDirected(true);
-            edge.putProperty("property1", 2);
-            edge.putProperty("visibility", "private");
+            final Edge edge = new Edge.Builder().group(TestGroups.EDGE)
+                                                .source("" + i)
+                                                .dest("B")
+                                                .directed(true)
+                                                .property("property1", 2)
+                                                .property("visibility", "private")
+                                                .build();
 
-            final Edge edge2 = new Edge(TestGroups.EDGE);
-            edge2.setSource("" + i);
-            edge2.setDestination("C");
-            edge2.setDirected(true);
-            edge2.putProperty("property2", 3);
-            edge2.putProperty("visibility", "public");
+            final Edge edge2 = new Edge.Builder().group(TestGroups.EDGE)
+                                                 .source("" + i)
+                                                 .dest("C")
+                                                 .directed(true)
+                                                 .property("property2", 3)
+                                                 .property("visibility", "public")
+                                                 .build();
 
             DATA_WITH_VISIBILITIES.add(edge);
             DATA_WITH_VISIBILITIES.add(edge2);

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/performance/BloomFilterIT.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/performance/BloomFilterIT.java
@@ -115,18 +115,25 @@ public class BloomFilterIT {
         final HashSet<Key> keysSet = new HashSet<>();
         final HashSet<Entity> dataSet = new HashSet<>();
         for (int i = 0; i < 100000; i++) {
-            final Entity source = new Entity(TestGroups.ENTITY);
-            source.setVertex("type" + random.nextInt(Integer.MAX_VALUE));
+            final Entity source = new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("type" + random.nextInt(Integer.MAX_VALUE))
+                    .build();
             final Entity destination = new Entity(TestGroups.ENTITY);
             destination.setVertex("type" + random.nextInt(Integer.MAX_VALUE));
             dataSet.add(source);
             dataSet.add(destination);
-            final Entity sourceEntity = new Entity(source.getGroup());
-            sourceEntity.setVertex(source.getVertex());
+            final Entity sourceEntity = new Entity.Builder()
+                    .group(source.getGroup())
+                    .vertex(source.getVertex())
+                    .build();
             final Entity destinationEntity = new Entity(destination.getGroup());
             destinationEntity.setVertex(destination.getVertex());
-            final Edge edge = new Edge(TestGroups.EDGE, source.getVertex(), destination
-                    .getVertex(), true);
+            final Edge edge = new Edge.Builder().group(TestGroups.EDGE)
+                    .source(source.getVertex())
+                    .dest(destination.getVertex())
+                    .directed(true)
+                    .build();
             keysSet.add(elementConverter.getKeyFromEntity(sourceEntity));
             keysSet.add(elementConverter.getKeyFromEntity(destinationEntity));
             final Pair<Key, Key> edgeKeys = elementConverter.getKeysFromEdge(edge);
@@ -213,7 +220,7 @@ public class BloomFilterIT {
     }
 
     private double calculateRandomLookUpRate(final FileSKVIterator reader, final HashSet<Entity> dataSet, final Random random, final RangeFactory rangeFactory) throws IOException, RangeFactoryException {
-        final EntityId[] randomData = new EntityId[5000];
+        final EntityId[] randomData = new EntitySeed[5000];
         for (int i = 0; i < 5000; i++) {
             randomData[i] = new EntitySeed("type" + random.nextInt(Integer.MAX_VALUE));
         }
@@ -248,13 +255,11 @@ public class BloomFilterIT {
     }
 
     private void seek(final FileSKVIterator reader, final EntityId seed, final RangeFactory rangeFactory) throws IOException, RangeFactoryException {
-        final View view = new View.Builder()
-                .edge(TestGroups.EDGE)
-                .entity(TestGroups.ENTITY)
-                .build();
-
         final GetElements operation = new GetElements.Builder()
-                .view(view)
+                .view(new View.Builder()
+                        .edge(TestGroups.EDGE)
+                        .entity(TestGroups.ENTITY)
+                        .build())
                 .build();
         final List<Range> range = rangeFactory.getRange(seed, operation);
         for (final Range ran : range) {

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/key/core/impl/AbstractAccumuloElementConverterTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/key/core/impl/AbstractAccumuloElementConverterTest.java
@@ -15,12 +15,6 @@
  */
 package uk.gov.gchq.gaffer.accumulostore.key.core.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.junit.Before;
@@ -54,6 +48,12 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 public abstract class AbstractAccumuloElementConverterTest {
 
     protected AccumuloElementConverter converter;
@@ -70,10 +70,11 @@ public abstract class AbstractAccumuloElementConverterTest {
     @Test
     public void shouldReturnAccumuloKeyConverterFromBasicEdge() throws SchemaException, IOException {
         // Given
-        final Edge edge = new Edge(TestGroups.EDGE);
-        edge.setDestination("2");
-        edge.setSource("1");
-        edge.setDirected(true);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .dest("2")
+                .source("1")
+                .directed(true).build();
 
         // When
         final Pair<Key, Key> keys = converter.getKeysFromElement(edge);
@@ -102,11 +103,13 @@ public abstract class AbstractAccumuloElementConverterTest {
     @Test
     public void shouldReturnAccumuloKeyConverterFromCFCQPropertyEdge() throws SchemaException, IOException {
         // Given
-        final Edge edge = new Edge(TestGroups.EDGE);
-        edge.setDestination("2");
-        edge.setSource("1");
-        edge.setDirected(false);
-        edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 100);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .dest("2")
+                .source("1")
+                .directed(false)
+                .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 100)
+                .build();
 
         // When
         final Pair<Key, Key> keys = converter.getKeysFromElement(edge);
@@ -122,9 +125,11 @@ public abstract class AbstractAccumuloElementConverterTest {
     @Test
     public void shouldReturnAccumuloKeyConverterFromCFCQPropertyEntity() throws SchemaException, IOException {
         // Given
-        final Entity entity = new Entity(TestGroups.ENTITY);
-        entity.setVertex("3");
-        entity.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 100);
+        final Entity entity = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex("3")
+                .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 100)
+                .build();
 
         // When
         final Pair<Key, Key> keys = converter.getKeysFromElement(entity);
@@ -138,11 +143,13 @@ public abstract class AbstractAccumuloElementConverterTest {
     @Test
     public void shouldReturnAccumuloKeyConverterMultipleCQPropertyEdge() throws SchemaException, IOException {
         // Given
-        final Edge edge = new Edge(TestGroups.EDGE);
-        edge.setDestination("2");
-        edge.setSource("1");
-        edge.setDirected(true);
-        edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 100);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .dest("2")
+                .source("1")
+                .directed(true)
+                .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 100)
+                .build();
 
         // When
         final Pair<Key, Key> keys = converter.getKeysFromElement(edge);
@@ -158,9 +165,11 @@ public abstract class AbstractAccumuloElementConverterTest {
     @Test
     public void shouldReturnAccumuloKeyConverterMultipleCQPropertiesEntity() throws SchemaException, IOException {
         // Given
-        final Entity entity = new Entity(TestGroups.ENTITY);
-        entity.setVertex("3");
-        entity.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 100);
+        final Entity entity = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex("3")
+                .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 100)
+                .build();
 
         // When
         final Pair<Key, Key> keys = converter.getKeysFromElement(entity);
@@ -174,11 +183,13 @@ public abstract class AbstractAccumuloElementConverterTest {
     @Test
     public void shouldGetOriginalEdgeWithMatchAsSourceNotSet() throws SchemaException, IOException {
         // Given
-        final Edge edge = new Edge(TestGroups.EDGE);
-        edge.setDestination("2");
-        edge.setSource("1");
-        edge.setDirected(true);
-        edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 100);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .dest("2")
+                .source("1")
+                .directed(true)
+                .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 100)
+                .build();
 
         final Pair<Key, Key> keys = converter.getKeysFromElement(edge);
         final Map<String, String> options = new HashMap<>();
@@ -196,11 +207,13 @@ public abstract class AbstractAccumuloElementConverterTest {
     @Test
     public void shouldGetFlippedEdgeWithMatchAsSourceFalse() throws SchemaException, IOException {
         // Given
-        final Edge edge = new Edge(TestGroups.EDGE);
-        edge.setDestination("2");
-        edge.setSource("1");
-        edge.setDirected(true);
-        edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 100);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .dest("2")
+                .source("1")
+                .directed(true)
+                .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 100)
+                .build();
 
         final Pair<Key, Key> keys = converter.getKeysFromElement(edge);
         final Map<String, String> options = new HashMap<>();
@@ -219,11 +232,13 @@ public abstract class AbstractAccumuloElementConverterTest {
     @Test
     public void shouldSkipNullPropertyValuesWhenCreatingAccumuloKey() throws SchemaException, IOException {
         // Given
-        final Edge edge = new Edge(TestGroups.EDGE);
-        edge.setSource("1");
-        edge.setDestination("2");
-        edge.setDirected(true);
-        edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, null);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("1")
+                .dest("2")
+                .directed(true)
+                .property(AccumuloPropertyNames.COLUMN_QUALIFIER, null)
+                .build();
 
         // When
         final Pair<Key, Key> keys = converter.getKeysFromElement(edge);
@@ -393,7 +408,9 @@ public abstract class AbstractAccumuloElementConverterTest {
     public void shouldBuildTimestampFromDefaultTimeWhenPropertyIsNull() {
         // Given
         // add extra timestamp property to schema
-        final Schema schema = new Schema.Builder().json(StreamUtil.schemas(getClass())).build();
+        final Schema schema = new Schema.Builder()
+                .json(StreamUtil.schemas(getClass()))
+                .build();
         converter = createConverter(new Schema.Builder(schema)
                 .type("timestamp", Long.class)
                 .edge(TestGroups.EDGE, new SchemaEdgeDefinition.Builder()
@@ -439,7 +456,9 @@ public abstract class AbstractAccumuloElementConverterTest {
     public void shouldGetPropertiesFromTimestamp() {
         // Given
         // add extra timestamp property to schema
-        final Schema schema = new Schema.Builder().json(StreamUtil.schemas(getClass())).build();
+        final Schema schema = new Schema.Builder()
+                .json(StreamUtil.schemas(getClass()))
+                .build();
         converter = createConverter(new Schema.Builder(schema)
                 .type("timestamp", Long.class)
                 .edge(TestGroups.EDGE, new SchemaEdgeDefinition.Builder()
@@ -463,7 +482,9 @@ public abstract class AbstractAccumuloElementConverterTest {
     public void shouldGetEmptyPropertiesFromTimestampWhenNoTimestampPropertyInGroup() {
         // Given
         // add timestamp property name but don't add the property to the edge group
-        final Schema schema = new Schema.Builder().json(StreamUtil.schemas(getClass())).build();
+        final Schema schema = new Schema.Builder()
+                .json(StreamUtil.schemas(getClass()))
+                .build();
         converter = createConverter(new Schema.Builder(schema)
                 .timestampProperty(AccumuloPropertyNames.TIMESTAMP)
                 .build());

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/key/core/impl/CoreKeyGroupByAggregatorIteratorTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/key/core/impl/CoreKeyGroupByAggregatorIteratorTest.java
@@ -106,39 +106,45 @@ public class CoreKeyGroupByAggregatorIteratorTest {
         try {
 
             // Create edge
-            final Edge edge = new Edge(TestGroups.EDGE);
-            edge.setSource("1");
-            edge.setDestination("2");
-            edge.setDirected(true);
-            edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 8);
-            edge.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge.putProperty(AccumuloPropertyNames.COUNT, 1);
+            final Edge edge = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 8)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 1)
+                    .build();
 
             //THIS EDGE WILL BE REDUCED MEANING ITS CQ (columnQualifier) will only occur once because its key is equal.
-            final Edge edge2 = new Edge(TestGroups.EDGE);
-            edge2.setSource("1");
-            edge2.setDestination("2");
-            edge2.setDirected(true);
-            edge2.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge2.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge2.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge2.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge2.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge2.putProperty(AccumuloPropertyNames.COUNT, 2);
+            final Edge edge2 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 2)
+                    .build();
 
-            final Edge edge3 = new Edge(TestGroups.EDGE);
-            edge3.setSource("1");
-            edge3.setDestination("2");
-            edge3.setDirected(true);
-            edge3.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge3.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge3.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge3.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge3.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge3.putProperty(AccumuloPropertyNames.COUNT, 10);
+            final Edge edge3 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 10)
+                    .build();
 
             // Accumulo key
             final Key key = elementConverter.getKeysFromEdge(edge).getFirst();
@@ -194,16 +200,18 @@ public class CoreKeyGroupByAggregatorIteratorTest {
             final Entry<Key, Value> entry = it.next();
             final Element readEdge = elementConverter.getFullElement(entry.getKey(), entry.getValue());
 
-            final Edge expectedEdge = new Edge(TestGroups.EDGE);
-            expectedEdge.setSource("1");
-            expectedEdge.setDestination("2");
-            expectedEdge.setDirected(true);
-            expectedEdge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 9);
-            expectedEdge.putProperty(AccumuloPropertyNames.COUNT, 15);
-            expectedEdge.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            expectedEdge.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            expectedEdge.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            expectedEdge.putProperty(AccumuloPropertyNames.PROP_4, 0);
+            final Edge expectedEdge = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 9)
+                    .property(AccumuloPropertyNames.COUNT, 15)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build();
 
             assertEquals(expectedEdge, readEdge);
             assertEquals(9, readEdge.getProperty(AccumuloPropertyNames.COLUMN_QUALIFIER));
@@ -232,12 +240,14 @@ public class CoreKeyGroupByAggregatorIteratorTest {
         String visibilityString = "public";
         try {
             // Create edge
-            final Edge edge = new Edge(TestGroups.EDGE);
-            edge.setSource("1");
-            edge.setDestination("2");
-            edge.setDirected(true);
-            edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 8);
-            edge.putProperty(AccumuloPropertyNames.COUNT, 1);
+            final Edge edge = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 8)
+                    .property(AccumuloPropertyNames.COUNT, 1)
+                    .build();
 
             final Properties properties1 = new Properties();
             properties1.put(AccumuloPropertyNames.COUNT, 1);
@@ -261,12 +271,14 @@ public class CoreKeyGroupByAggregatorIteratorTest {
             writer.addMutation(m1);
             writer.close();
 
-            final Edge expectedEdge = new Edge(TestGroups.EDGE);
-            expectedEdge.setSource("1");
-            expectedEdge.setDestination("2");
-            expectedEdge.setDirected(true);
-            expectedEdge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 8);
-            expectedEdge.putProperty(AccumuloPropertyNames.COUNT, 1);
+            final Edge expectedEdge = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 8)
+                    .property(AccumuloPropertyNames.COUNT, 1)
+                    .build();
 
             // Read data back and check we get one merged element
             final Authorizations authorizations = new Authorizations(visibilityString);
@@ -313,37 +325,43 @@ public class CoreKeyGroupByAggregatorIteratorTest {
         final String visibilityString = "public";
         try {
             // Create edge
-            final Edge edge = new Edge(TestGroups.EDGE);
-            edge.setSource("1");
-            edge.setDestination("2");
-            edge.setDirected(true);
-            edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 8);
-            edge.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge.putProperty(AccumuloPropertyNames.COUNT, 1);
+            final Edge edge = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 8)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 1)
+                    .build();
 
             //THIS EDGE WILL BE REDUCED MEANING ITS CQ (columnQualifier) will only occur once because its key is equal.
-            final Edge edge2 = new Edge(TestGroups.EDGE);
-            edge2.setSource("1");
-            edge2.setDestination("2");
-            edge2.setDirected(true);
-            edge2.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge2.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge2.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge2.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge2.putProperty(AccumuloPropertyNames.COUNT, 2);
+            final Edge edge2 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 2)
+                    .build();
 
-            final Edge edge3 = new Edge(TestGroups.EDGE);
-            edge3.setSource("1");
-            edge3.setDestination("2");
-            edge3.setDirected(true);
-            edge3.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge3.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge3.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge3.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge3.putProperty(AccumuloPropertyNames.COUNT, 10);
+            final Edge edge3 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 10)
+                    .build();
 
             // Accumulo key
             final Key key = elementConverter.getKeysFromEdge(edge).getFirst();
@@ -380,16 +398,18 @@ public class CoreKeyGroupByAggregatorIteratorTest {
             writer.addMutation(m5);
             writer.close();
 
-            Edge expectedEdge = new Edge(TestGroups.EDGE);
-            expectedEdge.setSource("1");
-            expectedEdge.setDestination("2");
-            expectedEdge.setDirected(true);
-            expectedEdge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 8);
-            expectedEdge.putProperty(AccumuloPropertyNames.COUNT, 15);
-            expectedEdge.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            expectedEdge.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            expectedEdge.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            expectedEdge.putProperty(AccumuloPropertyNames.PROP_4, 0);
+            Edge expectedEdge = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 8)
+                    .property(AccumuloPropertyNames.COUNT, 15)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build();
 
             // Read data back and check we get one merged element
             final Authorizations authorizations = new Authorizations(visibilityString);
@@ -436,79 +456,91 @@ public class CoreKeyGroupByAggregatorIteratorTest {
         final String visibilityString = "public";
         try {
             // Create edge
-            final Edge edge = new Edge(TestGroups.EDGE);
-            edge.setSource("1");
-            edge.setDestination("2");
-            edge.setDirected(true);
-            edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 1);
-            edge.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge.putProperty(AccumuloPropertyNames.COUNT, 1);
+            final Edge edge = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 1)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 1)
+                    .build();
 
-            final Edge edge2 = new Edge(TestGroups.EDGE);
-            edge2.setSource("1");
-            edge2.setDestination("2");
-            edge2.setDirected(true);
-            edge2.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge2.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 2);
-            edge2.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge2.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge2.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge2.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge2.putProperty(AccumuloPropertyNames.COUNT, 1);
+            final Edge edge2 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 2)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 1)
+                    .build();
 
-            final Edge edge3 = new Edge(TestGroups.EDGE);
-            edge3.setSource("1");
-            edge3.setDestination("2");
-            edge3.setDirected(true);
-            edge3.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge3.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 3);
-            edge3.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge3.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge3.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge3.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge3.putProperty(AccumuloPropertyNames.COUNT, 1);
+            final Edge edge3 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 3)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 1)
+                    .build();
 
 
             //THIS EDGE WILL BE REDUCED MEANING ITS CQ (columnQualifier) will only occur once because its key is equal.
-            final Edge edge4 = new Edge(TestGroups.EDGE);
-            edge4.setSource("1");
-            edge4.setDestination("2");
-            edge4.setDirected(true);
-            edge4.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 2);
-            edge4.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 4);
-            edge4.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge4.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge4.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge4.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge4.putProperty(AccumuloPropertyNames.COUNT, 2);
+            final Edge edge4 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 2)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 4)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 2)
+                    .build();
 
-            final Edge edge5 = new Edge(TestGroups.EDGE);
-            edge5.setSource("1");
-            edge5.setDestination("2");
-            edge5.setDirected(true);
-            edge5.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 3);
-            edge5.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 5);
-            edge5.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge5.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge5.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge5.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge5.putProperty(AccumuloPropertyNames.COUNT, 10);
+            final Edge edge5 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 3)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 5)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 10)
+                    .build();
 
-            final Edge edge6 = new Edge(TestGroups.EDGE);
-            edge6.setSource("1");
-            edge6.setDestination("2");
-            edge6.setDirected(true);
-            edge6.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 4);
-            edge6.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 6);
-            edge6.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge6.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge6.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge6.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge6.putProperty(AccumuloPropertyNames.COUNT, 5);
+            final Edge edge6 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 4)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 6)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 5)
+                    .build();
 
             // Accumulo key
             final Key key = elementConverter.getKeysFromEdge(edge).getFirst();
@@ -554,53 +586,61 @@ public class CoreKeyGroupByAggregatorIteratorTest {
             writer.addMutation(m6);
             writer.close();
 
-            Edge expectedEdge1 = new Edge(TestGroups.EDGE);
-            expectedEdge1.setSource("1");
-            expectedEdge1.setDestination("2");
-            expectedEdge1.setDirected(true);
-            expectedEdge1.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            expectedEdge1.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 6);
-            expectedEdge1.putProperty(AccumuloPropertyNames.COUNT, 3);
-            expectedEdge1.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            expectedEdge1.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            expectedEdge1.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            expectedEdge1.putProperty(AccumuloPropertyNames.PROP_4, 0);
+            Edge expectedEdge1 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 6)
+                    .property(AccumuloPropertyNames.COUNT, 3)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build();
 
-            Edge expectedEdge2 = new Edge(TestGroups.EDGE);
-            expectedEdge2.setSource("1");
-            expectedEdge2.setDestination("2");
-            expectedEdge2.setDirected(true);
-            expectedEdge2.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 2);
-            expectedEdge2.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 4);
-            expectedEdge2.putProperty(AccumuloPropertyNames.COUNT, 2);
-            expectedEdge2.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            expectedEdge2.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            expectedEdge2.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            expectedEdge2.putProperty(AccumuloPropertyNames.PROP_4, 0);
+            Edge expectedEdge2 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 2)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 4)
+                    .property(AccumuloPropertyNames.COUNT, 2)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build();
 
-            Edge expectedEdge3 = new Edge(TestGroups.EDGE);
-            expectedEdge3.setSource("1");
-            expectedEdge3.setDestination("2");
-            expectedEdge3.setDirected(true);
-            expectedEdge3.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 3);
-            expectedEdge3.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 5);
-            expectedEdge3.putProperty(AccumuloPropertyNames.COUNT, 10);
-            expectedEdge3.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            expectedEdge3.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            expectedEdge3.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            expectedEdge3.putProperty(AccumuloPropertyNames.PROP_4, 0);
+            Edge expectedEdge3 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 3)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 5)
+                    .property(AccumuloPropertyNames.COUNT, 10)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build();
 
-            Edge expectedEdge4 = new Edge(TestGroups.EDGE);
-            expectedEdge4.setSource("1");
-            expectedEdge4.setDestination("2");
-            expectedEdge4.setDirected(true);
-            expectedEdge4.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 4);
-            expectedEdge4.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 6);
-            expectedEdge4.putProperty(AccumuloPropertyNames.COUNT, 5);
-            expectedEdge4.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            expectedEdge4.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            expectedEdge4.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            expectedEdge4.putProperty(AccumuloPropertyNames.PROP_4, 0);
+            Edge expectedEdge4 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 4)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 6)
+                    .property(AccumuloPropertyNames.COUNT, 5)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build();
 
 
             // Read data back and check we get one merged element
@@ -667,79 +707,93 @@ public class CoreKeyGroupByAggregatorIteratorTest {
         final String visibilityString = "public";
         try {
             // Create edge
-            final Edge edge = new Edge(TestGroups.EDGE);
-            edge.setSource("1");
-            edge.setDestination("2");
-            edge.setDirected(true);
-            edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 1);
-            edge.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge.putProperty(AccumuloPropertyNames.COUNT, 1);
+            final Edge edge = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 1)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 1)
+                    .build();
 
-            final Edge edge2 = new Edge(TestGroups.EDGE);
-            edge2.setSource("1");
-            edge2.setDestination("2");
-            edge2.setDirected(true);
-            edge2.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge2.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 1);
-            edge2.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge2.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge2.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge2.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge2.putProperty(AccumuloPropertyNames.COUNT, 1);
+            final Edge edge2 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 1)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 1)
+                    .build();
 
-            final Edge edge3 = new Edge(TestGroups.EDGE);
-            edge3.setSource("1");
-            edge3.setDestination("2");
-            edge3.setDirected(true);
-            edge3.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge3.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 1);
-            edge3.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge3.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge3.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge3.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge3.putProperty(AccumuloPropertyNames.COUNT, 1);
+            final Edge edge3 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 1)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 1)
+                    .build();
 
 
             //THIS EDGE WILL BE REDUCED MEANING ITS CQ (columnQualifier) will only occur once because its key is equal.
-            final Edge edge4 = new Edge(TestGroups.EDGE);
-            edge4.setSource("1");
-            edge4.setDestination("2");
-            edge4.setDirected(true);
-            edge4.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge4.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 4);
-            edge4.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge4.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge4.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge4.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge4.putProperty(AccumuloPropertyNames.COUNT, 2);
+            final Edge edge4 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 4)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 2)
+                    .build();
+            ;
 
-            final Edge edge5 = new Edge(TestGroups.EDGE);
-            edge5.setSource("1");
-            edge5.setDestination("2");
-            edge5.setDirected(true);
-            edge5.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 3);
-            edge5.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 5);
-            edge5.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge5.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge5.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge5.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge5.putProperty(AccumuloPropertyNames.COUNT, 10);
+            final Edge edge5 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 3)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 5)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 10)
+                    .build();
+            ;
 
-            final Edge edge6 = new Edge(TestGroups.EDGE);
-            edge6.setSource("1");
-            edge6.setDestination("2");
-            edge6.setDirected(true);
-            edge6.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 3);
-            edge6.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 5);
-            edge6.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge6.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge6.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge6.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge6.putProperty(AccumuloPropertyNames.COUNT, 5);
+            final Edge edge6 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 3)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 5)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 5)
+                    .build();
 
             // Accumulo key
             final Key key = elementConverter.getKeysFromEdge(edge).getFirst();
@@ -785,41 +839,47 @@ public class CoreKeyGroupByAggregatorIteratorTest {
             writer.addMutation(m6);
             writer.close();
 
-            Edge expectedEdge1 = new Edge(TestGroups.EDGE);
-            expectedEdge1.setSource("1");
-            expectedEdge1.setDestination("2");
-            expectedEdge1.setDirected(true);
-            expectedEdge1.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            expectedEdge1.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 1);
-            expectedEdge1.putProperty(AccumuloPropertyNames.COUNT, 3);
-            expectedEdge1.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            expectedEdge1.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            expectedEdge1.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            expectedEdge1.putProperty(AccumuloPropertyNames.PROP_4, 0);
+            Edge expectedEdge1 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 1)
+                    .property(AccumuloPropertyNames.COUNT, 3)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build();
 
-            Edge expectedEdge2 = new Edge(TestGroups.EDGE);
-            expectedEdge2.setSource("1");
-            expectedEdge2.setDestination("2");
-            expectedEdge2.setDirected(true);
-            expectedEdge2.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            expectedEdge2.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 4);
-            expectedEdge2.putProperty(AccumuloPropertyNames.COUNT, 2);
-            expectedEdge2.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            expectedEdge2.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            expectedEdge2.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            expectedEdge2.putProperty(AccumuloPropertyNames.PROP_4, 0);
+            Edge expectedEdge2 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 4)
+                    .property(AccumuloPropertyNames.COUNT, 2)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build();
 
-            Edge expectedEdge3 = new Edge(TestGroups.EDGE);
-            expectedEdge3.setSource("1");
-            expectedEdge3.setDestination("2");
-            expectedEdge3.setDirected(true);
-            expectedEdge3.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 3);
-            expectedEdge3.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 5);
-            expectedEdge3.putProperty(AccumuloPropertyNames.COUNT, 15);
-            expectedEdge3.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            expectedEdge3.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            expectedEdge3.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            expectedEdge3.putProperty(AccumuloPropertyNames.PROP_4, 0);
+            Edge expectedEdge3 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 3)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 5)
+                    .property(AccumuloPropertyNames.COUNT, 15)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build();
 
             // Read data back and check we get one merged element
             final Authorizations authorizations = new Authorizations(visibilityString);
@@ -879,79 +939,97 @@ public class CoreKeyGroupByAggregatorIteratorTest {
         final String visibilityString = "public";
         try {
             // Create edge
-            final Edge edge = new Edge(TestGroups.EDGE);
-            edge.setSource("1");
-            edge.setDestination("2");
-            edge.setDirected(true);
-            edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 1);
-            edge.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge.putProperty(AccumuloPropertyNames.COUNT, 1);
+            final Edge edge = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 1)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 1)
+                    .build();
+            ;
 
-            final Edge edge2 = new Edge(TestGroups.EDGE);
-            edge2.setSource("1");
-            edge2.setDestination("2");
-            edge2.setDirected(true);
-            edge2.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge2.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 1);
-            edge2.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge2.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge2.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge2.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge2.putProperty(AccumuloPropertyNames.COUNT, 1);
+            final Edge edge2 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 1)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 1)
+                    .build();
+            ;
 
-            final Edge edge3 = new Edge(TestGroups.EDGE);
-            edge3.setSource("1");
-            edge3.setDestination("2");
-            edge3.setDirected(true);
-            edge3.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge3.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 1);
-            edge3.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge3.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge3.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge3.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge3.putProperty(AccumuloPropertyNames.COUNT, 1);
+            final Edge edge3 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 1)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 1)
+                    .build();
+            ;
 
 
             //THIS EDGE WILL BE REDUCED MEANING ITS CQ (columnQualifier) will only occur once because its key is equal.
-            final Edge edge4 = new Edge(TestGroups.EDGE);
-            edge4.setSource("1");
-            edge4.setDestination("2");
-            edge4.setDirected(true);
-            edge4.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge4.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 4);
-            edge4.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge4.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge4.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge4.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge4.putProperty(AccumuloPropertyNames.COUNT, 2);
+            final Edge edge4 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 4)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 2)
+                    .build();
+            ;
 
-            final Edge edge5 = new Edge(TestGroups.EDGE);
-            edge5.setSource("1");
-            edge5.setDestination("2");
-            edge5.setDirected(true);
-            edge5.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 3);
-            edge5.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 5);
-            edge5.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge5.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge5.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge5.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge5.putProperty(AccumuloPropertyNames.COUNT, 10);
+            final Edge edge5 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 3)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 5)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 10)
+                    .build();
+            ;
 
-            final Edge edge6 = new Edge(TestGroups.EDGE);
-            edge6.setSource("1");
-            edge6.setDestination("2");
-            edge6.setDirected(true);
-            edge6.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 3);
-            edge6.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 5);
-            edge6.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge6.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge6.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge6.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            edge6.putProperty(AccumuloPropertyNames.COUNT, 5);
+            final Edge edge6 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 3)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 5)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .property(AccumuloPropertyNames.COUNT, 5)
+                    .build();
+            ;
 
             // Accumulo key
             final Key key = elementConverter.getKeysFromEdge(edge).getFirst();
@@ -997,17 +1075,19 @@ public class CoreKeyGroupByAggregatorIteratorTest {
             writer.addMutation(m6);
             writer.close();
 
-            Edge expectedEdge1 = new Edge(TestGroups.EDGE);
-            expectedEdge1.setSource("1");
-            expectedEdge1.setDestination("2");
-            expectedEdge1.setDirected(true);
-            expectedEdge1.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 5);
-            expectedEdge1.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 10);
-            expectedEdge1.putProperty(AccumuloPropertyNames.COUNT, 20);
-            expectedEdge1.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            expectedEdge1.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            expectedEdge1.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            expectedEdge1.putProperty(AccumuloPropertyNames.PROP_4, 0);
+            Edge expectedEdge1 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("1")
+                    .dest("2")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 5)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER_2, 10)
+                    .property(AccumuloPropertyNames.COUNT, 20)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build();
 
             // Read data back and check we get one merged element
             final Authorizations authorizations = new Authorizations(visibilityString);

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/key/impl/AggregatorIteratorTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/key/impl/AggregatorIteratorTest.java
@@ -88,49 +88,57 @@ public class AggregatorIteratorTest {
 
     private void test(final AccumuloStore store) throws OperationException {
         // Given
-        final Edge expectedResult = new Edge(TestGroups.EDGE);
-        expectedResult.setSource("1");
-        expectedResult.setDestination("2");
-        expectedResult.setDirected(true);
-        expectedResult.putProperty(AccumuloPropertyNames.COUNT, 13);
-        expectedResult.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-        expectedResult.putProperty(AccumuloPropertyNames.PROP_1, 0);
-        expectedResult.putProperty(AccumuloPropertyNames.PROP_2, 0);
-        expectedResult.putProperty(AccumuloPropertyNames.PROP_3, 1);
-        expectedResult.putProperty(AccumuloPropertyNames.PROP_4, 1);
+        final Edge expectedResult = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("1")
+                .dest("2")
+                .directed(true)
+                .property(AccumuloPropertyNames.COUNT, 13)
+                .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                .property(AccumuloPropertyNames.PROP_1, 0)
+                .property(AccumuloPropertyNames.PROP_2, 0)
+                .property(AccumuloPropertyNames.PROP_3, 1)
+                .property(AccumuloPropertyNames.PROP_4, 1)
+                .build();
 
-        final Edge edge1 = new Edge(TestGroups.EDGE);
-        edge1.setSource("1");
-        edge1.setDestination("2");
-        edge1.setDirected(true);
-        edge1.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-        edge1.putProperty(AccumuloPropertyNames.COUNT, 1);
-        edge1.putProperty(AccumuloPropertyNames.PROP_1, 0);
-        edge1.putProperty(AccumuloPropertyNames.PROP_2, 0);
-        edge1.putProperty(AccumuloPropertyNames.PROP_3, 1);
-        edge1.putProperty(AccumuloPropertyNames.PROP_4, 0);
+        final Edge edge1 = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("1")
+                .dest("2")
+                .directed(true)
+                .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                .property(AccumuloPropertyNames.COUNT, 1)
+                .property(AccumuloPropertyNames.PROP_1, 0)
+                .property(AccumuloPropertyNames.PROP_2, 0)
+                .property(AccumuloPropertyNames.PROP_3, 1)
+                .property(AccumuloPropertyNames.PROP_4, 0)
+                .build();
 
-        final Edge edge2 = new Edge(TestGroups.EDGE);
-        edge2.setSource("1");
-        edge2.setDestination("2");
-        edge2.setDirected(true);
-        edge2.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-        edge2.putProperty(AccumuloPropertyNames.COUNT, 2);
-        edge2.putProperty(AccumuloPropertyNames.PROP_1, 0);
-        edge2.putProperty(AccumuloPropertyNames.PROP_2, 0);
-        edge2.putProperty(AccumuloPropertyNames.PROP_3, 0);
-        edge2.putProperty(AccumuloPropertyNames.PROP_4, 1);
+        final Edge edge2 = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("1")
+                .dest("2")
+                .directed(true)
+                .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                .property(AccumuloPropertyNames.COUNT, 2)
+                .property(AccumuloPropertyNames.PROP_1, 0)
+                .property(AccumuloPropertyNames.PROP_2, 0)
+                .property(AccumuloPropertyNames.PROP_3, 0)
+                .property(AccumuloPropertyNames.PROP_4, 1)
+                .build();
 
-        final Edge edge3 = new Edge(TestGroups.EDGE);
-        edge3.setSource("1");
-        edge3.setDestination("2");
-        edge3.setDirected(true);
-        edge3.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-        edge3.putProperty(AccumuloPropertyNames.COUNT, 10);
-        edge3.putProperty(AccumuloPropertyNames.PROP_1, 0);
-        edge3.putProperty(AccumuloPropertyNames.PROP_2, 0);
-        edge3.putProperty(AccumuloPropertyNames.PROP_3, 0);
-        edge3.putProperty(AccumuloPropertyNames.PROP_4, 0);
+        final Edge edge3 = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("1")
+                .dest("2")
+                .directed(true)
+                .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                .property(AccumuloPropertyNames.COUNT, 10)
+                .property(AccumuloPropertyNames.PROP_1, 0)
+                .property(AccumuloPropertyNames.PROP_2, 0)
+                .property(AccumuloPropertyNames.PROP_3, 0)
+                .property(AccumuloPropertyNames.PROP_4, 0)
+                .build();
 
         final User user = new User();
         store.execute(new AddElements.Builder()

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/key/impl/ElementPostAggregationFilterTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/key/impl/ElementPostAggregationFilterTest.java
@@ -131,7 +131,12 @@ public class ElementPostAggregationFilterTest {
 
         final ByteEntityAccumuloElementConverter converter = new ByteEntityAccumuloElementConverter(getSchema());
 
-        final Element element = new Edge(TestGroups.EDGE, "source", "dest", true);
+        final Element element = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("source")
+                .dest("dest")
+                .directed(true)
+                .build();
         final Pair<Key, Key> key = converter.getKeysFromElement(element);
         final Value value = converter.getValueFromElement(element);
 
@@ -157,7 +162,12 @@ public class ElementPostAggregationFilterTest {
 
         final ByteEntityAccumuloElementConverter converter = new ByteEntityAccumuloElementConverter(getSchema());
 
-        final Element element = new Edge(TestGroups.EDGE, "source", "dest", true);
+        final Element element = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("source")
+                .dest("dest")
+                .directed(true)
+                .build();
         final Pair<Key, Key> key = converter.getKeysFromElement(element);
         final Value value = converter.getValueFromElement(element);
 

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/key/impl/ElementPreAggregationFilterTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/key/impl/ElementPreAggregationFilterTest.java
@@ -130,7 +130,12 @@ public class ElementPreAggregationFilterTest {
 
         final ByteEntityAccumuloElementConverter converter = new ByteEntityAccumuloElementConverter(getSchema());
 
-        final Element element = new Edge(TestGroups.EDGE, "source", "dest", true);
+        final Element element = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("source")
+                .dest("dest")
+                .directed(true)
+                .build();
         final Pair<Key, Key> key = converter.getKeysFromElement(element);
         final Value value = converter.getValueFromElement(element);
 
@@ -156,7 +161,12 @@ public class ElementPreAggregationFilterTest {
 
         final ByteEntityAccumuloElementConverter converter = new ByteEntityAccumuloElementConverter(getSchema());
 
-        final Element element = new Edge(TestGroups.EDGE, "source", "dest", true);
+        final Element element = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("source")
+                .dest("dest")
+                .directed(true)
+                .build();
         final Pair<Key, Key> key = converter.getKeysFromElement(element);
         final Value value = converter.getValueFromElement(element);
 

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/key/impl/RowIdAggregatorTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/key/impl/RowIdAggregatorTest.java
@@ -127,75 +127,89 @@ public class RowIdAggregatorTest {
             properties3.put(AccumuloPropertyNames.COUNT, 2);
 
             // Create edge
-            final Edge edge = new Edge(TestGroups.EDGE);
-            edge.setSource("2");
-            edge.setDestination("1");
-            edge.setDirected(true);
-            edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_4, 0);
+            final Edge edge = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("2")
+                    .dest("1")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build();
 
-            final Edge edge2 = new Edge(TestGroups.EDGE);
-            edge2.setSource("B");
-            edge2.setDestination("Z");
-            edge2.setDirected(true);
-            edge2.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge2.putProperty(AccumuloPropertyNames.PROP_1, 1);
-            edge2.putProperty(AccumuloPropertyNames.PROP_2, 1);
-            edge2.putProperty(AccumuloPropertyNames.PROP_3, 1);
-            edge2.putProperty(AccumuloPropertyNames.PROP_4, 1);
+            final Edge edge2 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("B")
+                    .dest("Z")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.PROP_1, 1)
+                    .property(AccumuloPropertyNames.PROP_2, 1)
+                    .property(AccumuloPropertyNames.PROP_3, 1)
+                    .property(AccumuloPropertyNames.PROP_4, 1)
+                    .build();
 
-            final Edge edge3 = new Edge(TestGroups.EDGE);
-            edge3.setSource("3");
-            edge3.setDestination("8");
-            edge3.setDirected(true);
-            edge3.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge3.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge3.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge3.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge3.putProperty(AccumuloPropertyNames.PROP_4, 0);
+            final Edge edge3 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("3")
+                    .dest("8")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build();
 
-            final Edge edge6 = new Edge("BasicEdge2");
-            edge6.setSource("1");
-            edge6.setDestination("5");
-            edge6.setDirected(true);
-            edge6.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 2);
-            edge6.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge6.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge6.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge6.putProperty(AccumuloPropertyNames.PROP_4, 0);
+            final Edge edge6 = new Edge.Builder()
+                    .group("BasicEdge2")
+                    .source("1")
+                    .dest("5")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 2)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build();
 
-            final Edge edge7 = new Edge("BasicEdge2");
-            edge7.setSource("2");
-            edge7.setDestination("6");
-            edge7.setDirected(true);
-            edge7.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge7.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge7.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge7.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge7.putProperty(AccumuloPropertyNames.PROP_4, 0);
+            final Edge edge7 = new Edge.Builder()
+                    .group("BasicEdge2")
+                    .source("2")
+                    .dest("6")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build();
 
-            final Edge edge8 = new Edge("BasicEdge2");
-            edge8.setSource("4");
-            edge8.setDestination("8");
-            edge8.setDirected(true);
-            edge8.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 2);
-            edge8.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge8.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge8.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge8.putProperty(AccumuloPropertyNames.PROP_4, 0);
+            final Edge edge8 = new Edge.Builder()
+                    .group("BasicEdge2")
+                    .source("4")
+                    .dest("8")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 2)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build();
 
-            final Edge edge9 = new Edge("BasicEdge2");
-            edge9.setSource("5");
-            edge9.setDestination("9");
-            edge9.setDirected(true);
-            edge9.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 2);
-            edge9.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge9.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge9.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge9.putProperty(AccumuloPropertyNames.PROP_4, 0);
+            final Edge edge9 = new Edge.Builder()
+                    .group("BasicEdge2")
+                    .source("5")
+                    .dest("9")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 2)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build();
 
             // Accumulo key
             final Key key = elementConverter.getKeysFromEdge(edge).getFirst();
@@ -272,11 +286,13 @@ public class RowIdAggregatorTest {
             Entry<Key, Value> entry = it.next();
             Element readEdge = elementConverter.getFullElement(entry.getKey(), entry.getValue());
 
-            Edge expectedEdge = new Edge("BasicEdge2");
-            expectedEdge.setSource("4");
-            expectedEdge.setDestination("8");
-            expectedEdge.setDirected(true);
-            expectedEdge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 5);
+            Edge expectedEdge = new Edge.Builder()
+                    .group("BasicEdge2")
+                    .source("4")
+                    .dest("8")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 5)
+                    .build();
             expectedEdge.putProperty(AccumuloPropertyNames.COUNT, 3);
 
             assertEquals(expectedEdge, readEdge);
@@ -286,12 +302,14 @@ public class RowIdAggregatorTest {
             assertTrue(it.hasNext());
             entry = it.next();
             readEdge = elementConverter.getFullElement(entry.getKey(), entry.getValue());
-            expectedEdge = new Edge("BasicEdge2");
-            expectedEdge.setSource("5");
-            expectedEdge.setDestination("9");
-            expectedEdge.setDirected(true);
-            expectedEdge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 2);
-            expectedEdge.putProperty(AccumuloPropertyNames.COUNT, 1);
+            expectedEdge = new Edge.Builder()
+                    .group("BasicEdge2")
+                    .source("5")
+                    .dest("9")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 2)
+                    .property(AccumuloPropertyNames.COUNT, 1)
+                    .build();
             assertEquals(expectedEdge, readEdge);
             //Check no additional rows are found. (For a table of this size we shouldn't see this)
             if (it.hasNext()) {

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/key/impl/ValidatorFilterTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/key/impl/ValidatorFilterTest.java
@@ -105,7 +105,12 @@ public class ValidatorFilterTest {
 
         final ByteEntityAccumuloElementConverter converter = new ByteEntityAccumuloElementConverter(getSchema());
 
-        final Element element = new Edge(TestGroups.EDGE, "source", "dest", true);
+        final Element element = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("source")
+                .dest("dest")
+                .directed(true)
+                .build();
         final Pair<Key, Key> key = converter.getKeysFromElement(element);
         final Value value = converter.getValueFromElement(element);
 
@@ -130,7 +135,11 @@ public class ValidatorFilterTest {
 
         final ByteEntityAccumuloElementConverter converter = new ByteEntityAccumuloElementConverter(getSchema());
 
-        final Element element = new Edge(TestGroups.EDGE, "invalid", "dest", true);
+        final Element element = new Edge.Builder().group(TestGroups.EDGE)
+                .source("invalid")
+                .dest("dest")
+                .directed(true)
+                .build();
         final Pair<Key, Key> key = converter.getKeysFromElement(element);
         final Value value = converter.getValueFromElement(element);
 

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/key/impl/byteEntity/ByteEntityRangeElementPropertyFilterIteratorTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/key/impl/byteEntity/ByteEntityRangeElementPropertyFilterIteratorTest.java
@@ -55,14 +55,44 @@ public class ByteEntityRangeElementPropertyFilterIteratorTest {
             .vertexSerialiser(new StringSerialiser())
             .build();
 
-    private static final List<Element> ELEMENTS = Arrays.asList(new Element[]{
-            new Edge(TestGroups.EDGE, "vertexA", "vertexB", true),
-            new Edge(TestGroups.EDGE, "vertexD", "vertexC", true),
-            new Edge(TestGroups.EDGE, "vertexE", "vertexE", true),
-            new Edge(TestGroups.EDGE, "vertexF", "vertexG", false),
-            new Edge(TestGroups.EDGE, "vertexH", "vertexH", false),
-            new Entity(TestGroups.ENTITY, "vertexI")}
-    );
+    private static final List<Element> ELEMENTS = Arrays.asList(
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("vertexA")
+                    .dest("vertexB")
+                    .directed(true)
+                    .build(),
+
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("vertexD")
+                    .dest("vertexC")
+                    .directed(true)
+                    .build(),
+
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("vertexE")
+                    .dest("vertexE")
+                    .directed(true)
+                    .build(),
+
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("vertexF")
+                    .dest("vertexG")
+                    .directed(false)
+                    .build(),
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("vertexH")
+                    .dest("vertexH")
+                    .directed(false)
+                    .build(),
+            new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("vertexI")
+                    .build());
 
     private final ByteEntityAccumuloElementConverter converter = new ByteEntityAccumuloElementConverter(SCHEMA);
 

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/key/impl/classic/ClassicEdgeDirectedUndirectedFilterIteratorTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/key/impl/classic/ClassicEdgeDirectedUndirectedFilterIteratorTest.java
@@ -54,11 +54,36 @@ public class ClassicEdgeDirectedUndirectedFilterIteratorTest {
             .build();
 
     private static final List<Edge> EDGES = Arrays.asList(
-            new Edge(TestGroups.EDGE, "vertexA", "vertexB", true),
-            new Edge(TestGroups.EDGE, "vertexD", "vertexC", true),
-            new Edge(TestGroups.EDGE, "vertexE", "vertexE", true),
-            new Edge(TestGroups.EDGE, "vertexF", "vertexG", false),
-            new Edge(TestGroups.EDGE, "vertexH", "vertexH", false)
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("vertexA")
+                    .dest("vertexB")
+                    .directed(true)
+                    .build(),
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("vertexD")
+                    .dest("vertexC")
+                    .directed(true)
+                    .build(),
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("vertexE")
+                    .dest("vertexE")
+                    .directed(true)
+                    .build(),
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("vertexF")
+                    .dest("vertexG")
+                    .directed(false)
+                    .build(),
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("vertexH")
+                    .dest("vertexH")
+                    .directed(false)
+                    .build()
     );
 
     private final ClassicAccumuloElementConverter converter = new ClassicAccumuloElementConverter(SCHEMA);

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/operation/handler/GetElementsBetweenSetsHandlerTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/operation/handler/GetElementsBetweenSetsHandlerTest.java
@@ -65,11 +65,39 @@ public class GetElementsBetweenSetsHandlerTest {
     private static final AccumuloProperties PROPERTIES = AccumuloProperties.loadStoreProperties(StreamUtil.storeProps(GetElementsBetweenSetsHandlerTest.class));
     private static final AccumuloProperties CLASSIC_PROPERTIES = AccumuloProperties.loadStoreProperties(StreamUtil.openStream(GetElementsBetweenSetsHandlerTest.class, "/accumuloStoreClassicKeys.properties"));
 
-    private static final Element expectedEdge1 = new Edge(TestGroups.EDGE, "A0", "A23", true);
-    private static final Element expectedEdge2 = new Edge(TestGroups.EDGE, "A0", "A23", true);
-    private static final Element expectedEdge3 = new Edge(TestGroups.EDGE, "A0", "A23", true);
-    private static final Element expectedEntity1 = new Entity(TestGroups.ENTITY, "A0");
-    private static final Element expectedSummarisedEdge = new Edge(TestGroups.EDGE, "A0", "A23", true);
+    private static final Element expectedEdge1 =
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("A0")
+                    .dest("A23")
+                    .directed(true)
+                    .build();
+    private static final Element expectedEdge2 =
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("A0")
+                    .dest("A23")
+                    .directed(true)
+                    .build();
+    private static final Element expectedEdge3 =
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("A0")
+                    .dest("A23")
+                    .directed(true)
+                    .build();
+    private static final Element expectedEntity1 =
+            new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("A0")
+                    .build();
+    private static final Element expectedSummarisedEdge =
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("A0")
+                    .dest("A23")
+                    .directed(true)
+                    .build();
 
     private User user = new User();
 
@@ -305,28 +333,45 @@ public class GetElementsBetweenSetsHandlerTest {
         entity.putProperty(AccumuloPropertyNames.COUNT, 10000);
         data.add(entity);
         for (int i = 1; i < 100; i++) {
-            final Edge edge = new Edge(TestGroups.EDGE, "A0", "A" + i, true);
-            edge.putProperty(AccumuloPropertyNames.COUNT, 23);
-            edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge.putProperty(AccumuloPropertyNames.PROP_1, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_2, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_3, 0);
-            edge.putProperty(AccumuloPropertyNames.PROP_4, 0);
-            data.add(edge);
+            data.add(new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("A0")
+                    .dest("A" + i)
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COUNT, 23)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build()
+            );
 
-            final Edge edge2 = new Edge(TestGroups.EDGE, "A0", "A" + i, true);
-            edge2.putProperty(AccumuloPropertyNames.COUNT, 23);
-            edge2.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 2);
-            data.add(edge2);
+            data.add(new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("A0")
+                    .dest("A" + i)
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COUNT, 23)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 2)
+                    .build()
+            );
 
-            final Edge edge3 = new Edge(TestGroups.EDGE, "A0", "A" + i, true);
-            edge3.putProperty(AccumuloPropertyNames.COUNT, 23);
-            edge3.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 3);
-            data.add(edge3);
+            data.add(new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("A0")
+                    .dest("A" + i)
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COUNT, 23)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 3)
+                    .build()
+            );
 
-            final Entity edgeEntity = new Entity(TestGroups.ENTITY, "A" + i);
-            edgeEntity.putProperty(AccumuloPropertyNames.COUNT, i);
-            data.add(edgeEntity);
+            data.add(new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("A" + i)
+                    .property(AccumuloPropertyNames.COUNT, i)
+                    .build());
         }
         addElements(data, store, new User());
     }

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/operation/handler/GetElementsWithinSetHandlerTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/operation/handler/GetElementsWithinSetHandlerTest.java
@@ -59,19 +59,46 @@ import static org.junit.Assert.fail;
 
 public class GetElementsWithinSetHandlerTest {
 
+    private static final Schema schema = Schema.fromJson(StreamUtil.schemas(GetElementsWithinSetHandlerTest.class));
+    private static final AccumuloProperties PROPERTIES = AccumuloProperties.loadStoreProperties(StreamUtil
+            .storeProps(GetElementsWithinSetHandlerTest.class));
+    private static final AccumuloProperties CLASSIC_PROPERTIES = AccumuloProperties
+            .loadStoreProperties(StreamUtil.openStream(GetElementsWithinSetHandlerTest.class, "/accumuloStoreClassicKeys.properties"));
     private static View defaultView;
     private static AccumuloStore byteEntityStore;
     private static AccumuloStore gaffer1KeyStore;
-    private static final Schema schema = Schema.fromJson(StreamUtil.schemas(GetElementsWithinSetHandlerTest.class));
-    private static final AccumuloProperties PROPERTIES = AccumuloProperties.loadStoreProperties(StreamUtil.storeProps(GetElementsWithinSetHandlerTest.class));
-    private static final AccumuloProperties CLASSIC_PROPERTIES = AccumuloProperties.loadStoreProperties(StreamUtil.openStream(GetElementsWithinSetHandlerTest.class, "/accumuloStoreClassicKeys.properties"));
-
-    private static Element expectedEdge1 = new Edge(TestGroups.EDGE, "A0", "A23", true);
-    private static Element expectedEdge2 = new Edge(TestGroups.EDGE, "A0", "A23", true);
-    private static Element expectedEdge3 = new Edge(TestGroups.EDGE, "A0", "A23", true);
-    private static Element expectedEntity1 = new Entity(TestGroups.ENTITY, "A0");
-    private static Element expectedEntity2 = new Entity(TestGroups.ENTITY, "A23");
-    private static Element expectedSummarisedEdge = new Edge(TestGroups.EDGE, "A0", "A23", true);
+    private static Edge expectedEdge1 = new Edge.Builder()
+            .group(TestGroups.EDGE)
+            .source("A0")
+            .dest("A23")
+            .directed(true)
+            .build();
+    private static Edge expectedEdge2 = new Edge.Builder()
+            .group(TestGroups.EDGE)
+            .source("A0")
+            .dest("A23")
+            .directed(true)
+            .build();
+    private static Edge expectedEdge3 = new Edge.Builder()
+            .group(TestGroups.EDGE)
+            .source("A0")
+            .dest("A23")
+            .directed(true)
+            .build();
+    private static Entity expectedEntity1 = new Entity.Builder()
+            .group(TestGroups.ENTITY)
+            .vertex("A0")
+            .build();
+    private static Entity expectedEntity2 = new Entity.Builder()
+            .group(TestGroups.ENTITY)
+            .vertex("A23")
+            .build();
+    private static Edge expectedSummarisedEdge = new Edge.Builder()
+            .group(TestGroups.EDGE)
+            .source("A0")
+            .dest("A23")
+            .directed(true)
+            .build();
     final Set<EntityId> seeds = new HashSet<>(Arrays.asList(new EntitySeed("A0"), new EntitySeed("A23")));
 
     private User user = new User();
@@ -260,47 +287,54 @@ public class GetElementsWithinSetHandlerTest {
             entity.putProperty(AccumuloPropertyNames.COUNT, 10000);
             data.add(entity);
             for (int i = 1; i < 100; i++) {
-                final Edge edge = new Edge(TestGroups.EDGE);
-                edge.setSource("A0");
-                edge.setDestination("A" + i);
-                edge.setDirected(true);
-                edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-                edge.putProperty(AccumuloPropertyNames.COUNT, i);
-                edge.putProperty(AccumuloPropertyNames.PROP_1, 0);
-                edge.putProperty(AccumuloPropertyNames.PROP_2, 0);
-                edge.putProperty(AccumuloPropertyNames.PROP_3, 0);
-                edge.putProperty(AccumuloPropertyNames.PROP_4, 0);
+                data.add(new Edge.Builder()
+                        .group(TestGroups.EDGE)
+                        .source("A0")
+                        .dest("A" + i)
+                        .directed(true)
+                        .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                        .property(AccumuloPropertyNames.COUNT, i)
+                        .property(AccumuloPropertyNames.PROP_1, 0)
+                        .property(AccumuloPropertyNames.PROP_2, 0)
+                        .property(AccumuloPropertyNames.PROP_3, 0)
+                        .property(AccumuloPropertyNames.PROP_4, 0)
+                        .build()
+                );
 
-                final Edge edge2 = new Edge(TestGroups.EDGE);
-                edge2.setSource("A0");
-                edge2.setDestination("A" + i);
-                edge2.setDirected(true);
-                edge2.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 2);
-                edge2.putProperty(AccumuloPropertyNames.COUNT, i);
-                edge2.putProperty(AccumuloPropertyNames.PROP_1, 0);
-                edge2.putProperty(AccumuloPropertyNames.PROP_2, 0);
-                edge2.putProperty(AccumuloPropertyNames.PROP_3, 0);
-                edge2.putProperty(AccumuloPropertyNames.PROP_4, 0);
+                data.add(new Edge.Builder()
+                        .group(TestGroups.EDGE)
+                        .source("A0")
+                        .dest("A" + i)
+                        .directed(true)
+                        .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 2)
+                        .property(AccumuloPropertyNames.COUNT, i)
+                        .property(AccumuloPropertyNames.PROP_1, 0)
+                        .property(AccumuloPropertyNames.PROP_2, 0)
+                        .property(AccumuloPropertyNames.PROP_3, 0)
+                        .property(AccumuloPropertyNames.PROP_4, 0)
+                        .build()
+                );
 
-                final Edge edge3 = new Edge(TestGroups.EDGE);
-                edge3.setSource("A0");
-                edge3.setDestination("A" + i);
-                edge3.setDirected(true);
-                edge3.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 3);
-                edge3.putProperty(AccumuloPropertyNames.COUNT, i);
-                edge3.putProperty(AccumuloPropertyNames.PROP_1, 0);
-                edge3.putProperty(AccumuloPropertyNames.PROP_2, 0);
-                edge3.putProperty(AccumuloPropertyNames.PROP_3, 0);
-                edge3.putProperty(AccumuloPropertyNames.PROP_4, 0);
+                data.add(new Edge.Builder()
+                        .group(TestGroups.EDGE)
+                        .source("A0")
+                        .dest("A" + i)
+                        .directed(true)
+                        .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 3)
+                        .property(AccumuloPropertyNames.COUNT, i)
+                        .property(AccumuloPropertyNames.PROP_1, 0)
+                        .property(AccumuloPropertyNames.PROP_2, 0)
+                        .property(AccumuloPropertyNames.PROP_3, 0)
+                        .property(AccumuloPropertyNames.PROP_4, 0)
+                        .build()
+                );
 
-                data.add(edge);
-                data.add(edge2);
-                data.add(edge3);
-
-                final Entity edgeEntity = new Entity(TestGroups.ENTITY);
-                edgeEntity.setVertex("A" + i);
-                edgeEntity.putProperty(AccumuloPropertyNames.COUNT, i);
-                data.add(edgeEntity);
+                data.add(new Entity.Builder()
+                        .group(TestGroups.ENTITY)
+                        .vertex("A" + i)
+                        .property(AccumuloPropertyNames.COUNT, i)
+                        .build()
+                );
             }
             final User user = new User();
             addElements(data, user, store);

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/operation/handler/GetElementsinRangesHandlerTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/operation/handler/GetElementsinRangesHandlerTest.java
@@ -309,27 +309,32 @@ public class GetElementsinRangesHandlerTest {
                 s = "0" + s;
             }
 
-            final Edge edge = new Edge(TestGroups.EDGE);
-            edge.setSource(s);
+            elements.add(new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source(s)
+                    .dest("B")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .build()
+            );
 
-            edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-            edge.setDestination("B");
-            edge.setDirected(true);
-            elements.add(edge);
+            elements.add(new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source(s)
+                    .dest("B")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 3)
+                    .build()
+            );
 
-            final Edge edge2 = new Edge(TestGroups.EDGE);
-            edge2.setSource(s);
-            edge2.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 3);
-            edge2.setDestination("B");
-            edge2.setDirected(true);
-            elements.add(edge2);
-
-            final Edge edge3 = new Edge(TestGroups.EDGE);
-            edge3.setSource(s);
-            edge3.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 5);
-            edge3.setDestination("B");
-            edge3.setDirected(true);
-            elements.add(edge3);
+            elements.add(new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source(s)
+                    .dest("B")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 5)
+                    .build()
+            );
         }
 
         try {

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/retriever/impl/AccumuloIDBetweenSetsRetrieverTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/retriever/impl/AccumuloIDBetweenSetsRetrieverTest.java
@@ -327,7 +327,12 @@ public class AccumuloIDBetweenSetsRetrieverTest {
         }
 
         // False positive is "" + count so create an edge from seeds to that
-        final Edge edge = new Edge(TestGroups.EDGE, "A0", "" + count, true);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("A0")
+                .dest("" + count)
+                .directed(true)
+                .build();
         edge.putProperty(AccumuloPropertyNames.COUNT, 1000000);
         Set<Element> data = new HashSet<>();
         data.add(edge);
@@ -492,7 +497,12 @@ public class AccumuloIDBetweenSetsRetrieverTest {
         entity.putProperty(AccumuloPropertyNames.COUNT, 10000);
         data.add(entity);
         for (int i = 1; i < 100; i++) {
-            final Edge edge = new Edge(TestGroups.EDGE, "A0", "A" + i, true);
+            final Edge edge = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("A0")
+                    .dest("A" + i)
+                    .directed(true)
+                    .build();
             edge.putProperty(AccumuloPropertyNames.COUNT, 23);
             edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
             data.add(edge);

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/retriever/impl/AccumuloIDWithinSetRetrieverTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/retriever/impl/AccumuloIDWithinSetRetrieverTest.java
@@ -477,18 +477,21 @@ public class AccumuloIDWithinSetRetrieverTest {
             entity.putProperty(AccumuloPropertyNames.COUNT, 10000);
             data.add(entity);
             for (int i = 1; i < 100; i++) {
-                final Edge edge = new Edge(TestGroups.EDGE);
-                edge.setSource("A0");
-                edge.setDestination("A" + i);
-                edge.setDirected(true);
-                edge.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-                edge.putProperty(AccumuloPropertyNames.COUNT, i);
-                data.add(edge);
+                data.add(new Edge.Builder()
+                        .group(TestGroups.EDGE)
+                        .source("A0")
+                        .dest("A" + i)
+                        .directed(true)
+                        .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                        .property(AccumuloPropertyNames.COUNT, i)
+                        .build());
 
-                final Entity edgeEntity = new Entity(TestGroups.ENTITY);
-                edgeEntity.setVertex("A" + i);
-                edgeEntity.putProperty(AccumuloPropertyNames.COUNT, i);
-                data.add(edgeEntity);
+                data.add(new Entity.Builder()
+                        .group(TestGroups.ENTITY)
+                        .vertex("A" + i)
+                        .property(AccumuloPropertyNames.COUNT, i)
+                        .build()
+                );
             }
             data.add(AccumuloTestData.EDGE_C_D_DIRECTED);
             data.add(AccumuloTestData.EDGE_C_D_UNDIRECTED);

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/retriever/impl/AccumuloRangeIDRetrieverTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/retriever/impl/AccumuloRangeIDRetrieverTest.java
@@ -106,15 +106,17 @@ public class AccumuloRangeIDRetrieverTest {
     private static void setupGraph(final AccumuloStore store, final int numEntries) {
         final List<Element> elements = new ArrayList<>();
         for (int i = 0; i < numEntries; i++) {
-            final Edge edge = new Edge(TestGroups.EDGE);
             String s = "" + i;
             while (s.length() < 4) {
                 s = "0" + s;
             }
-            edge.setSource(s);
-            edge.setDestination("B");
-            edge.setDirected(false);
-            elements.add(edge);
+
+            elements.add(new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source(s)
+                    .dest("B")
+                    .directed(false)
+                    .build());
         }
         try {
             final User user = new User();

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/retriever/impl/AccumuloSingleIDRetrieverTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/retriever/impl/AccumuloSingleIDRetrieverTest.java
@@ -307,22 +307,27 @@ public class AccumuloSingleIDRetrieverTest {
     private static void setupGraph(final AccumuloStore store, final int numEntries) {
         final List<Element> elements = new ArrayList<>();
         for (int i = 0; i < numEntries; i++) {
-            final Entity entity = new Entity(TestGroups.ENTITY);
-            entity.setVertex("" + i);
+            elements.add(new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("" + i)
+                    .build()
+            );
 
-            final Edge edge = new Edge(TestGroups.EDGE);
-            edge.setSource("" + i);
-            edge.setDestination("B");
-            edge.setDirected(false);
+            elements.add(new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("B")
+                    .directed(false)
+                    .build()
+            );
 
-            final Edge edge2 = new Edge(TestGroups.EDGE);
-            edge2.setSource("" + i);
-            edge2.setDestination("C");
-            edge2.setDirected(true);
-
-            elements.add(edge);
-            elements.add(edge2);
-            elements.add(entity);
+            elements.add(new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("" + i)
+                    .dest("C")
+                    .directed(true)
+                    .build()
+            );
         }
         try {
             store.execute(new AddElements.Builder().input(elements).build(), new User());

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/test/bloom/ByteEntityBloomElementFunctorTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/test/bloom/ByteEntityBloomElementFunctorTest.java
@@ -59,16 +59,20 @@ public class ByteEntityBloomElementFunctorTest {
     @Test
     public void shouldTransformRangeEntity() {
         // Create Range formed from one entity and shouldRetieveElementsInRangeBetweenSeeds
-        final Entity entity1 = new Entity(TestGroups.ENTITY);
-        entity1.setVertex(1);
+        final Entity entity1 = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex(1)
+                .build();
         final Key key1 = elementConverter.getKeyFromEntity(entity1);
         final Range range1 = new Range(key1, true, key1, true);
         final org.apache.hadoop.util.bloom.Key expectedBloomKey1 = new org.apache.hadoop.util.bloom.Key(Arrays.copyOf(key1.getRowData().getBackingArray(), key1.getRowData().getBackingArray().length - 2));
         assertTrue(elementFunctor.transform(range1).equals(expectedBloomKey1));
 
         // Create Range formed from two entities and shouldRetieveElementsInRangeBetweenSeeds - should get null
-        final Entity entity2 = new Entity(TestGroups.ENTITY);
-        entity2.setVertex(2);
+        final Entity entity2 = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex(2)
+                .build();
         final Key key2 = elementConverter.getKeyFromEntity(entity2);
         final Range range2 = new Range(key1, true, key2, true);
         assertNull(elementFunctor.transform(range2));
@@ -77,8 +81,10 @@ public class ByteEntityBloomElementFunctorTest {
     @Test
     public void shouldTransformKeyEntity() {
         // Create Key formed from entity and shouldRetieveElementsInRangeBetweenSeeds
-        final Entity entity1 = new Entity(TestGroups.ENTITY);
-        entity1.setVertex(1);
+        final Entity entity1 = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex(1)
+                .build();
         final Key key1 = elementConverter.getKeyFromEntity(entity1);
         final org.apache.hadoop.util.bloom.Key expectedBloomKey1 = new org.apache.hadoop.util.bloom.Key(elementFunctor.getVertexFromRangeKey(key1.getRowData().getBackingArray()));
         assertEquals(expectedBloomKey1, elementFunctor.transform(key1));
@@ -87,9 +93,10 @@ public class ByteEntityBloomElementFunctorTest {
     @Test
     public void shouldTransformRangeEdge() {
         // Create Range formed from one edge and shouldRetieveElementsInRangeBetweenSeeds
-        final Edge edge1 = new Edge(TestGroups.EDGE);
-        edge1.setSource(1);
-        edge1.setDestination(2);
+        final Edge edge1 = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source(1)
+                .dest(2).build();
         final Pair<Key, Key> keys = elementConverter.getKeysFromEdge(edge1);
         final Range range1 = new Range(keys.getFirst().getRow(), true, keys.getFirst().getRow(), true);
         final org.apache.hadoop.util.bloom.Key expectedBloomKey1 = new org.apache.hadoop.util.bloom.Key(elementFunctor.getVertexFromRangeKey(keys.getFirst().getRowData().getBackingArray()));
@@ -107,9 +114,10 @@ public class ByteEntityBloomElementFunctorTest {
     @Test
     public void shouldTransformKeyEdge() {
         // Create Key formed from edge and shouldRetieveElementsInRangeBetweenSeeds
-        final Edge edge1 = new Edge(TestGroups.EDGE);
-        edge1.setSource(1);
-        edge1.setDestination(2);
+        final Edge edge1 = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source(1)
+                .dest(2).build();
         final Pair<Key, Key> keys = elementConverter.getKeysFromEdge(edge1);
         final Range range1 = new Range(keys.getFirst().getRow(), true, keys.getFirst().getRow(), true);
         final org.apache.hadoop.util.bloom.Key expectedBloomKey1 = new org.apache.hadoop.util.bloom.Key(elementFunctor.getVertexFromRangeKey(keys.getFirst().getRowData().getBackingArray()));
@@ -122,15 +130,18 @@ public class ByteEntityBloomElementFunctorTest {
     @Test
     public void shouldTransformRangeFromEntityToEntityAndSomeEdges() {
         // Create entity
-        final Entity entity = new Entity(TestGroups.ENTITY);
-        entity.setVertex(1);
+        final Entity entity = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex(1)
+                .build();
         //        String key1 = ConversionUtils.getRowKeyFromEntity(entity1);
         final Key key1 = elementConverter.getKeyFromEntity(entity);
 
         // Create edge from that entity
-        final Edge edge = new Edge(TestGroups.EDGE);
-        edge.setSource(1);
-        edge.setDestination(2);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source(1)
+                .dest(2).build();
         //        String key2 = ConversionUtils.getRowKeysFromEdge(edge).getFirst();
         final Key key2 = elementConverter.getKeysFromEdge(edge).getFirst();
 
@@ -149,8 +160,9 @@ public class ByteEntityBloomElementFunctorTest {
     public void shouldTransformRangeWhenUsingRangeNotExact() {
         try {
             // Create SimpleEntity
-            final Entity simpleEntity = new Entity(TestGroups.ENTITY);
-            simpleEntity.setVertex("1");
+            final Entity simpleEntity = new Entity.Builder().group(TestGroups.ENTITY)
+                    .vertex("1")
+                    .build();
             final Key key = elementConverter.getKeyFromEntity(simpleEntity);
             final Range range = Range.exact(key.getRow());
             final org.apache.hadoop.util.bloom.Key expectedBloomKey1 = new org.apache.hadoop.util.bloom.Key(elementFunctor.getVertexFromRangeKey(key.getRowData().getBackingArray()));
@@ -165,9 +177,10 @@ public class ByteEntityBloomElementFunctorTest {
     public void shouldTransformRangeWhenRangeHasUnspecifiedStartOrEndKey() {
         try {
             // Create Range with unspecified start key and shouldRetieveElementsInRangeBetweenSeeds - should get null
-            final Edge edge1 = new Edge(TestGroups.EDGE);
-            edge1.setSource("3");
-            edge1.setDestination("4");
+            final Edge edge1 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("3")
+                    .dest("4").build();
             final Pair<Key, Key> keys = elementConverter.getKeysFromEdge(edge1);
             final Range range1 = new Range(null, true, keys.getFirst().getRow(), true);
             assertNull(elementFunctor.transform(range1));

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/test/bloom/Gaffer1BloomElementFunctorTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/test/bloom/Gaffer1BloomElementFunctorTest.java
@@ -58,16 +58,20 @@ public class Gaffer1BloomElementFunctorTest {
     @Test
     public void shouldTransformRangeEntity() {
         // Create Range formed from one entity and shouldRetieveElementsInRangeBetweenSeeds
-        final Entity entity1 = new Entity(TestGroups.ENTITY);
-        entity1.setVertex(1);
+        final Entity entity1 = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex(1)
+                .build();
         final Key key1 = elementConverter.getKeyFromEntity(entity1);
         final Range range1 = new Range(key1, true, key1, true);
         final org.apache.hadoop.util.bloom.Key expectedBloomKey1 = new org.apache.hadoop.util.bloom.Key(Arrays.copyOf(key1.getRowData().getBackingArray(), key1.getRowData().getBackingArray().length));
         assertTrue(elementFunctor.transform(range1).equals(expectedBloomKey1));
 
         // Create Range formed from two entities and shouldRetieveElementsInRangeBetweenSeeds - should get null
-        final Entity entity2 = new Entity(TestGroups.ENTITY);
-        entity2.setVertex(2);
+        final Entity entity2 = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex(2)
+                .build();
         final Key key2 = elementConverter.getKeyFromEntity(entity2);
         final Range range2 = new Range(key1, true, key2, true);
         assertNull(elementFunctor.transform(range2));
@@ -76,8 +80,10 @@ public class Gaffer1BloomElementFunctorTest {
     @Test
     public void shouldTransformKeyEntity() {
         // Create Key formed from entity and shouldRetieveElementsInRangeBetweenSeeds
-        final Entity entity1 = new Entity(TestGroups.ENTITY);
-        entity1.setVertex(1);
+        final Entity entity1 = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex(1)
+                .build();
         final Key key1 = elementConverter.getKeyFromEntity(entity1);
         final org.apache.hadoop.util.bloom.Key expectedBloomKey1 = new org.apache.hadoop.util.bloom.Key(elementFunctor.getVertexFromRangeKey(key1.getRowData().getBackingArray()));
         assertEquals(expectedBloomKey1, elementFunctor.transform(key1));
@@ -86,9 +92,10 @@ public class Gaffer1BloomElementFunctorTest {
     @Test
     public void shouldTransformRangeEdge() {
         // Create Range formed from one edge and shouldRetieveElementsInRangeBetweenSeeds
-        final Edge edge1 = new Edge(TestGroups.EDGE);
-        edge1.setSource(1);
-        edge1.setDestination(2);
+        final Edge edge1 = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source(1)
+                .dest(2).build();
         final Pair<Key, Key> keys = elementConverter.getKeysFromEdge(edge1);
         final Range range1 = new Range(keys.getFirst().getRow(), true, keys.getFirst().getRow(), true);
         final org.apache.hadoop.util.bloom.Key expectedBloomKey1 = new org.apache.hadoop.util.bloom.Key(elementFunctor.getVertexFromRangeKey(keys.getFirst().getRowData().getBackingArray()));
@@ -106,9 +113,10 @@ public class Gaffer1BloomElementFunctorTest {
     @Test
     public void shouldTransformKeyEdge() {
         // Create Key formed from edge and shouldRetieveElementsInRangeBetweenSeeds
-        final Edge edge1 = new Edge(TestGroups.EDGE);
-        edge1.setSource(1);
-        edge1.setDestination(2);
+        final Edge edge1 = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source(1)
+                .dest(2).build();
         final Pair<Key, Key> keys = elementConverter.getKeysFromEdge(edge1);
         final Range range1 = new Range(keys.getFirst().getRow(), true, keys.getFirst().getRow(), true);
         final org.apache.hadoop.util.bloom.Key expectedBloomKey1 = new org.apache.hadoop.util.bloom.Key(elementFunctor.getVertexFromRangeKey(keys.getFirst().getRowData().getBackingArray()));
@@ -121,15 +129,17 @@ public class Gaffer1BloomElementFunctorTest {
     @Test
     public void shouldTransformRangeFromEntityToEntityAndSomeEdges() {
         // Create entity
-        final Entity entity = new Entity(TestGroups.ENTITY);
-        entity.setVertex(1);
+        final Entity entity = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex(1).build();
         //        String key1 = ConversionUtils.getRowKeyFromEntity(entity1);
         final Key key1 = elementConverter.getKeyFromEntity(entity);
 
         // Create edge from that entity
-        final Edge edge = new Edge(TestGroups.EDGE);
-        edge.setSource(1);
-        edge.setDestination(2);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source(1)
+                .dest(2).build();
         //        String key2 = ConversionUtils.getRowKeysFromEdge(edge).getFirst();
         final Key key2 = elementConverter.getKeysFromEdge(edge).getFirst();
 
@@ -148,8 +158,10 @@ public class Gaffer1BloomElementFunctorTest {
     public void shouldTransformRangeWhenUsingRangeNotExact() {
         try {
             // Create SimpleEntity
-            final Entity simpleEntity = new Entity(TestGroups.ENTITY);
-            simpleEntity.setVertex("1");
+            final Entity simpleEntity = new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("1")
+                    .build();
             final Key key = elementConverter.getKeyFromEntity(simpleEntity);
             final Range range = Range.exact(key.getRow());
             final org.apache.hadoop.util.bloom.Key expectedBloomKey1 = new org.apache.hadoop.util.bloom.Key(elementFunctor.getVertexFromRangeKey(key.getRowData().getBackingArray()));
@@ -164,9 +176,10 @@ public class Gaffer1BloomElementFunctorTest {
     public void shouldTransformRangeWhenRangeHasUnspecifiedStartOrEndKey() {
         try {
             // Create Range with unspecified start key and shouldRetieveElementsInRangeBetweenSeeds - should get null
-            final Edge edge1 = new Edge(TestGroups.EDGE);
-            edge1.setSource("3");
-            edge1.setDestination("4");
+            final Edge edge1 = new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("3")
+                    .dest("4").build();
             final Pair<Key, Key> keys = elementConverter.getKeysFromEdge(edge1);
             final Range range1 = new Range(null, true, keys.getFirst().getRow(), true);
             assertNull(elementFunctor.transform(range1));

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/utils/AccumuloTestData.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/utils/AccumuloTestData.java
@@ -11,100 +11,127 @@ import java.util.Collections;
 import java.util.Set;
 
 public class AccumuloTestData {
-
     public static final long TIMESTAMP = System.currentTimeMillis();
     public static final String TEST_OPTION_PROPERTY_KEY = "testOption";
 
-    public static EntityId NOT_PRESENT_ENTITY_SEED = new EntitySeed("notpresent");
-    public static Set<EntityId> NOT_PRESENT_ENTITY_SEED_SET = Collections.singleton(NOT_PRESENT_ENTITY_SEED);
+    public static final EntityId NOT_PRESENT_ENTITY_SEED = new EntitySeed("notpresent");
+    public static final Set<EntityId> NOT_PRESENT_ENTITY_SEED_SET = Collections.singleton(NOT_PRESENT_ENTITY_SEED);
 
-    public static EntityId SEED_A = new EntitySeed("A");
-    public static EntityId SEED_A0 = new EntitySeed("A0");
-    public static EntityId SEED_A1 = new EntitySeed("A1");
-    public static EntityId SEED_A2 = new EntitySeed("A2");
-    public static EntityId SEED_A23 = new EntitySeed("A23");
+    public static final EntityId SEED_A = new EntitySeed("A");
+    public static final EntityId SEED_A0 = new EntitySeed("A0");
+    public static final EntityId SEED_A1 = new EntitySeed("A1");
+    public static final EntityId SEED_A2 = new EntitySeed("A2");
+    public static final EntityId SEED_A23 = new EntitySeed("A23");
 
-    public static Set<EntityId> SEED_A_SET = Collections.singleton(SEED_A);
-    public static Set<EntityId> SEED_A0_SET = Collections.singleton(SEED_A0);
-    public static Set<EntityId> SEED_A1_SET = Collections.singleton(SEED_A1);
-    public static Set<EntityId> SEED_A2_SET = Collections.singleton(SEED_A2);
-    public static Set<EntityId> SEED_A23_SET = Collections.singleton(SEED_A23);
-    public static Set<EntityId> SEED_A0_A23_SET = Sets.newHashSet(SEED_A0, SEED_A23);
+    public static final Set<EntityId> SEED_A_SET = Collections.singleton(SEED_A);
+    public static final Set<EntityId> SEED_A0_SET = Collections.singleton(SEED_A0);
+    public static final Set<EntityId> SEED_A1_SET = Collections.singleton(SEED_A1);
+    public static final Set<EntityId> SEED_A2_SET = Collections.singleton(SEED_A2);
+    public static final Set<EntityId> SEED_A23_SET = Collections.singleton(SEED_A23);
+    public static final Set<EntityId> SEED_A0_A23_SET = Sets.newHashSet(SEED_A0, SEED_A23);
 
+    public static final EntityId SEED_B = new EntitySeed("B");
+    public static final EntityId SEED_B1 = new EntitySeed("B1");
+    public static final EntityId SEED_B2 = new EntitySeed("B2");
 
-    public static EntityId SEED_B = new EntitySeed("B");
-    public static EntityId SEED_B1 = new EntitySeed("B1");
-    public static EntityId SEED_B2 = new EntitySeed("B2");
+    public static final EntityId SEED_SOURCE_1 = new EntitySeed("source1");
+    public static final EntityId SEED_DESTINATION_1 = new EntitySeed("destination1");
+    public static final EntityId SEED_SOURCE_2 = new EntitySeed("source2");
+    public static final EntityId SEED_DESTINATION_2 = new EntitySeed("destination2");
 
+    public static final Set<EntityId> SEED_B_SET = Collections.singleton(SEED_B);
+    public static final Set<EntityId> SEED_B1_SET = Collections.singleton(SEED_B1);
+    public static final Set<EntityId> SEED_B2_SET = Collections.singleton(SEED_B2);
 
-    public static EntityId SEED_SOURCE_1 = new EntitySeed("source1");
-    public static EntityId SEED_DESTINATION_1 = new EntitySeed("destination1");
-    public static EntityId SEED_SOURCE_2 = new EntitySeed("source2");
-    public static EntityId SEED_DESTINATION_2 = new EntitySeed("destination2");
+    public static final Edge EDGE_A1_B1 =
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("A1")
+                    .dest("B1")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COUNT, 1)
+                    .build();
 
-    public static Set<EntityId> SEED_B_SET = Collections.singleton(SEED_B);
-    public static Set<EntityId> SEED_B1_SET = Collections.singleton(SEED_B1);
-    public static Set<EntityId> SEED_B2_SET = Collections.singleton(SEED_B2);
+    public static final Edge EDGE_B2_A2 =
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("B2")
+                    .dest("A2")
+                    .directed(true)
+                    .build();
 
-    public static Edge EDGE_A1_B1;
-    public static Edge EDGE_B2_A2;
+    public static final Edge EDGE_A_B_1 =
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("A")
+                    .dest("B")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COUNT, 1)
+                    .build();
 
-    public static Edge EDGE_A_B_1;
-    public static Edge EDGE_A_B_2;
+    public static final Edge EDGE_A_B_2 =
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("A")
+                    .dest("B")
+                    .directed(false)
+                    .property(AccumuloPropertyNames.COUNT, 2)
+                    .build();
 
-    public static Edge EDGE_A0_A23;
+    public static final Edge EDGE_A0_A23 =
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("A0")
+                    .dest("A23")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COUNT, 23)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .build();
 
-    public static Edge EDGE_C_D_UNDIRECTED;
-    public static Edge EDGE_C_D_DIRECTED;
+    public static final Edge EDGE_C_D_UNDIRECTED =
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("C")
+                    .dest("D")
+                    .directed(false)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.COUNT, 1)
+                    .build();
 
-    public static Element A0_ENTITY;
-    public static Element A1_ENTITY;
-    public static Element A2_ENTITY;
-    public static Element A23_ENTITY;
+    public static final Edge EDGE_C_D_DIRECTED =
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("C")
+                    .dest("D")
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 2)
+                    .property(AccumuloPropertyNames.COUNT, 1).build();
 
-    static {
+    public static final Element A0_ENTITY =
+            new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("A0")
+                    .property(AccumuloPropertyNames.COUNT, 10000)
+                    .build();
 
-        EDGE_A1_B1 = new Edge(TestGroups.EDGE, "A1", "B1", true);
-        EDGE_A1_B1.putProperty(AccumuloPropertyNames.COUNT, 1);
+    public static final Element A1_ENTITY =
+            new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("A1")
+                    .property(AccumuloPropertyNames.COUNT, 1)
+                    .build();
 
-        EDGE_B2_A2 = new Edge(TestGroups.EDGE, "B2", "A2", true);
+    public static final Element A2_ENTITY =
+            new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("A2")
+                    .property(AccumuloPropertyNames.COUNT, 2)
+                    .build();
 
-        EDGE_A0_A23 = new Edge(TestGroups.EDGE, "A0", "A23", true);
-        EDGE_A0_A23.putProperty(AccumuloPropertyNames.COUNT, 23);
-        EDGE_A0_A23.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-
-        // Create directed edge A -> B and undirected edge A - B
-        EDGE_A_B_1 = new Edge(TestGroups.EDGE, "A", "B", true);
-        EDGE_A_B_2 = new Edge(TestGroups.EDGE, "A", "B", false);
-
-        EDGE_A_B_1.putProperty(AccumuloPropertyNames.COUNT, 1);
-        EDGE_A_B_2.putProperty(AccumuloPropertyNames.COUNT, 2);
-
-        EDGE_C_D_UNDIRECTED = new Edge(TestGroups.EDGE);
-        EDGE_C_D_UNDIRECTED.setSource("C");
-        EDGE_C_D_UNDIRECTED.setDestination("D");
-        EDGE_C_D_UNDIRECTED.setDirected(false);
-        EDGE_C_D_UNDIRECTED.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
-        EDGE_C_D_UNDIRECTED.putProperty(AccumuloPropertyNames.COUNT, 1);
-
-        EDGE_C_D_DIRECTED = new Edge(TestGroups.EDGE);
-        EDGE_C_D_DIRECTED.setSource("C");
-        EDGE_C_D_DIRECTED.setDestination("D");
-        EDGE_C_D_DIRECTED.setDirected(true);
-        EDGE_C_D_DIRECTED.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 2);
-        EDGE_C_D_DIRECTED.putProperty(AccumuloPropertyNames.COUNT, 1);
-
-        A0_ENTITY = new Entity(TestGroups.ENTITY, "A0");
-        A0_ENTITY.putProperty(AccumuloPropertyNames.COUNT, 10000);
-
-        A1_ENTITY = new Entity(TestGroups.ENTITY, "A1");
-        A1_ENTITY.putProperty(AccumuloPropertyNames.COUNT, 1);
-
-        A2_ENTITY = new Entity(TestGroups.ENTITY, "A2");
-        A2_ENTITY.putProperty(AccumuloPropertyNames.COUNT, 2);
-
-        A23_ENTITY = new Entity(TestGroups.ENTITY, "A23");
-        A23_ENTITY.putProperty(AccumuloPropertyNames.COUNT, 23);
-    }
-
+    public static final Element A23_ENTITY =
+            new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("A23")
+                    .property(AccumuloPropertyNames.COUNT, 23)
+                    .build();
 }

--- a/store-implementation/hbase-store/src/test/java/uk/gov/gchq/gaffer/hbasestore/coprocessor/processor/ElementDedupeFilterProcessorTest.java
+++ b/store-implementation/hbase-store/src/test/java/uk/gov/gchq/gaffer/hbasestore/coprocessor/processor/ElementDedupeFilterProcessorTest.java
@@ -53,12 +53,35 @@ public class ElementDedupeFilterProcessorTest {
             .build();
 
     private static final List<Element> ELEMENTS = Arrays.asList(
-            new Edge(TestGroups.EDGE, "vertexA", "vertexB", true),
-            new Edge(TestGroups.EDGE, "vertexD", "vertexC", true),
-            new Edge(TestGroups.EDGE, "vertexE", "vertexE", true),
-            new Edge(TestGroups.EDGE, "vertexF", "vertexG", false),
-            new Edge(TestGroups.EDGE, "vertexH", "vertexH", false),
-            new Entity(TestGroups.ENTITY, "vertexI")
+            new Edge.Builder().group(TestGroups.EDGE)
+                    .source("vertexA")
+                    .dest("vertexB")
+                    .directed(true)
+                    .build(),
+            new Edge.Builder().group(TestGroups.EDGE)
+                    .source("vertexD")
+                    .dest("vertexC")
+                    .directed(true)
+                    .build(),
+            new Edge.Builder().group(TestGroups.EDGE)
+                    .source("vertexE")
+                    .dest("vertexE")
+                    .directed(true)
+                    .build(),
+            new Edge.Builder().group(TestGroups.EDGE)
+                    .source("vertexF")
+                    .dest("vertexG")
+                    .directed(false)
+                    .build(),
+            new Edge.Builder().group(TestGroups.EDGE)
+                    .source("vertexH")
+                    .dest("vertexH")
+                    .directed(false)
+                    .build(),
+            new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("vertexI")
+                    .build()
     );
 
     private final ElementSerialisation serialisation = new ElementSerialisation(SCHEMA);

--- a/store-implementation/hbase-store/src/test/java/uk/gov/gchq/gaffer/hbasestore/coprocessor/processor/FilterProcessorTest.java
+++ b/store-implementation/hbase-store/src/test/java/uk/gov/gchq/gaffer/hbasestore/coprocessor/processor/FilterProcessorTest.java
@@ -55,12 +55,35 @@ public class FilterProcessorTest {
             .build();
 
     private static final List<Element> ELEMENTS = Arrays.asList(
-            new Entity(TestGroups.ENTITY, "vertexI"),
-            new Edge(TestGroups.EDGE, "vertexA", "vertexB", true),
-            new Edge(TestGroups.EDGE, "vertexD", "vertexC", true),
-            new Edge(TestGroups.EDGE, "vertexE", "vertexE", true),
-            new Edge(TestGroups.EDGE, "vertexF", "vertexG", false),
-            new Edge(TestGroups.EDGE, "vertexH", "vertexH", false)
+            new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("vertexI")
+                    .build(),
+            new Edge.Builder().group(TestGroups.EDGE)
+                    .source("vertexA")
+                    .dest("vertexB")
+                    .directed(true)
+                    .build(),
+            new Edge.Builder().group(TestGroups.EDGE)
+                    .source("vertexD")
+                    .dest("vertexC")
+                    .directed(true)
+                    .build(),
+            new Edge.Builder().group(TestGroups.EDGE)
+                    .source("vertexE")
+                    .dest("vertexE")
+                    .directed(true)
+                    .build(),
+            new Edge.Builder().group(TestGroups.EDGE)
+                    .source("vertexF")
+                    .dest("vertexG")
+                    .directed(false)
+                    .build(),
+            new Edge.Builder().group(TestGroups.EDGE)
+                    .source("vertexH")
+                    .dest("vertexH")
+                    .directed(false)
+                    .build()
     );
 
     private final ElementSerialisation serialisation = new ElementSerialisation(SCHEMA);

--- a/store-implementation/hbase-store/src/test/java/uk/gov/gchq/gaffer/hbasestore/coprocessor/processor/GroupFilterProcessorTest.java
+++ b/store-implementation/hbase-store/src/test/java/uk/gov/gchq/gaffer/hbasestore/coprocessor/processor/GroupFilterProcessorTest.java
@@ -100,7 +100,14 @@ public class GroupFilterProcessorTest {
         final GroupFilterProcessor processor = new GroupFilterProcessor(VIEW);
 
         // When
-        final boolean result = processor.test(CellUtil.getLazyCell(new Edge(TestGroups.EDGE, "A", "B", true), serialisation));
+        final boolean result = processor.test(CellUtil.getLazyCell(
+                new Edge.Builder()
+                        .group(TestGroups.EDGE)
+                        .source("A")
+                        .dest("B")
+                        .directed(true)
+                        .build(),
+                serialisation));
 
         // Then
         assertFalse(result);
@@ -112,7 +119,14 @@ public class GroupFilterProcessorTest {
         final GroupFilterProcessor processor = new GroupFilterProcessor(VIEW);
 
         // When
-        final boolean result = processor.test(CellUtil.getLazyCell(new Edge(TestGroups.EDGE_2, "A", "B", true), serialisation));
+        final boolean result = processor.test(CellUtil.getLazyCell(
+                new Edge.Builder()
+                        .group(TestGroups.EDGE_2)
+                        .source("A")
+                        .dest("B")
+                        .directed(true)
+                        .build(),
+                serialisation));
         // Then
         assertTrue(result);
     }

--- a/store-implementation/hbase-store/src/test/java/uk/gov/gchq/gaffer/hbasestore/coprocessor/processor/PostAggregationFilterProcessorTest.java
+++ b/store-implementation/hbase-store/src/test/java/uk/gov/gchq/gaffer/hbasestore/coprocessor/processor/PostAggregationFilterProcessorTest.java
@@ -117,9 +117,30 @@ public class PostAggregationFilterProcessorTest {
         final PostAggregationFilterProcessor processor = new PostAggregationFilterProcessor(VIEW);
 
         // When / Then
-        assertFalse(processor.test(CellUtil.getLazyCell(new Edge(TestGroups.EDGE, "invalidVertex", "dest", true), serialisation)));
-        assertFalse(processor.test(CellUtil.getLazyCell(new Edge(TestGroups.EDGE, "validPreAggVertex", "dest", true), serialisation)));
-        assertFalse(processor.test(CellUtil.getLazyCell(new Edge(TestGroups.EDGE, "validPostTransformVertex", "dest", true), serialisation)));
+        assertFalse(processor.test(CellUtil.getLazyCell(
+                new Edge.Builder()
+                        .group(TestGroups.EDGE)
+                        .source("invalidVertex")
+                        .dest("dest")
+                        .directed(true)
+                        .build(),
+                serialisation)));
+        assertFalse(processor.test(CellUtil.getLazyCell(
+                new Edge.Builder()
+                        .group(TestGroups.EDGE)
+                        .source("validPreAggVertex")
+                        .dest("dest")
+                        .directed(true)
+                        .build(),
+                serialisation)));
+        assertFalse(processor.test(CellUtil.getLazyCell(
+                new Edge.Builder()
+                        .group(TestGroups.EDGE)
+                        .source("validPostTransformVertex")
+                        .dest("dest")
+                        .directed(true)
+                        .build(),
+                serialisation)));
     }
 
     @Test
@@ -128,7 +149,14 @@ public class PostAggregationFilterProcessorTest {
         final PostAggregationFilterProcessor processor = new PostAggregationFilterProcessor(VIEW);
 
         // When / Then
-        assertTrue(processor.test(CellUtil.getLazyCell(new Edge(TestGroups.EDGE, "validPostAggVertex", "dest", true), serialisation)));
+        assertTrue(processor.test(CellUtil.getLazyCell(
+                new Edge.Builder()
+                        .group(TestGroups.EDGE)
+                        .source("validPostAggVertex")
+                        .dest("dest")
+                        .directed(true)
+                        .build(),
+                serialisation)));
     }
 
 }

--- a/store-implementation/hbase-store/src/test/java/uk/gov/gchq/gaffer/hbasestore/coprocessor/processor/PreAggregationFilterProcessorTest.java
+++ b/store-implementation/hbase-store/src/test/java/uk/gov/gchq/gaffer/hbasestore/coprocessor/processor/PreAggregationFilterProcessorTest.java
@@ -117,9 +117,31 @@ public class PreAggregationFilterProcessorTest {
         final PreAggregationFilterProcessor processor = new PreAggregationFilterProcessor(VIEW);
 
         // When / Then
-        assertFalse(processor.test(CellUtil.getLazyCell(new Edge(TestGroups.EDGE, "invalidVertex", "dest", true), serialisation)));
-        assertFalse(processor.test(CellUtil.getLazyCell(new Edge(TestGroups.EDGE, "validPostAggVertex", "dest", true), serialisation)));
-        assertFalse(processor.test(CellUtil.getLazyCell(new Edge(TestGroups.EDGE, "validPostTransformVertex", "dest", true), serialisation)));
+        assertFalse(processor.test(CellUtil.getLazyCell(
+                new Edge.Builder()
+                        .group(TestGroups.EDGE)
+                        .source("invalidVertex")
+                        .dest("dest")
+                        .directed(true)
+                        .build(),
+                serialisation)));
+
+        assertFalse(processor.test(CellUtil.getLazyCell(
+                new Edge.Builder()
+                        .group(TestGroups.EDGE)
+                        .source("validPostAggVertex")
+                        .dest("dest")
+                        .directed(true)
+                        .build(),
+                serialisation)));
+
+        assertFalse(processor.test(CellUtil.getLazyCell(
+                new Edge.Builder().group(TestGroups.EDGE)
+                        .source("validPostTransformVertex")
+                        .dest("dest")
+                        .directed(true)
+                        .build(),
+                serialisation)));
     }
 
     @Test
@@ -128,7 +150,14 @@ public class PreAggregationFilterProcessorTest {
         final PreAggregationFilterProcessor processor = new PreAggregationFilterProcessor(VIEW);
 
         // When / Then
-        assertTrue(processor.test(CellUtil.getLazyCell(new Edge(TestGroups.EDGE, "validPreAggVertex", "dest", true), serialisation)));
+        assertTrue(processor.test(CellUtil.getLazyCell(
+                new Edge.Builder()
+                        .group(TestGroups.EDGE)
+                        .source("validPreAggVertex")
+                        .dest("dest")
+                        .directed(true)
+                        .build(),
+                serialisation)));
     }
 
 }

--- a/store-implementation/hbase-store/src/test/java/uk/gov/gchq/gaffer/hbasestore/coprocessor/processor/ValidationProcessorTest.java
+++ b/store-implementation/hbase-store/src/test/java/uk/gov/gchq/gaffer/hbasestore/coprocessor/processor/ValidationProcessorTest.java
@@ -90,7 +90,14 @@ public class ValidationProcessorTest {
         final ValidationProcessor processor = new ValidationProcessor(SCHEMA);
 
         // When / Then
-        assertFalse(processor.test(CellUtil.getLazyCell(new Edge(TestGroups.EDGE, "invalidVertex", "dest", true), serialisation)));
+        assertFalse(processor.test(CellUtil.getLazyCell(
+                new Edge.Builder()
+                        .group(TestGroups.EDGE)
+                        .source("invalidVertex")
+                        .dest("dest")
+                        .directed(true)
+                        .build(),
+                serialisation)));
     }
 
     @Test
@@ -99,6 +106,13 @@ public class ValidationProcessorTest {
         final ValidationProcessor processor = new ValidationProcessor(SCHEMA);
 
         // When / Then
-        assertTrue(processor.test(CellUtil.getLazyCell(new Edge(TestGroups.EDGE, "validVertex", "dest", true), serialisation)));
+        assertTrue(processor.test(CellUtil.getLazyCell(
+                new Edge.Builder()
+                        .group(TestGroups.EDGE)
+                        .source("validVertex")
+                        .dest("dest")
+                        .directed(true)
+                        .build(),
+                serialisation)));
     }
 }

--- a/store-implementation/hbase-store/src/test/java/uk/gov/gchq/gaffer/hbasestore/coprocessor/scanner/GafferScannerTest.java
+++ b/store-implementation/hbase-store/src/test/java/uk/gov/gchq/gaffer/hbasestore/coprocessor/scanner/GafferScannerTest.java
@@ -63,8 +63,16 @@ public class GafferScannerTest {
             .build();
 
     private static final List<Element> ELEMENTS = Arrays.asList(
-            new Entity(TestGroups.ENTITY, "a"),
-            new Edge(TestGroups.EDGE, "b", "c", true)
+            new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("a")
+                    .build(),
+            new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("b")
+                    .dest("c")
+                    .directed(true)
+                    .build()
     );
 
     private final ElementSerialisation serialisation = new ElementSerialisation(SCHEMA);

--- a/store-implementation/hbase-store/src/test/java/uk/gov/gchq/gaffer/hbasestore/serialisation/ElementSerialisationTest.java
+++ b/store-implementation/hbase-store/src/test/java/uk/gov/gchq/gaffer/hbasestore/serialisation/ElementSerialisationTest.java
@@ -15,12 +15,6 @@
  */
 package uk.gov.gchq.gaffer.hbasestore.serialisation;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.gchq.gaffer.binaryoperator.FreqMapAggregator;
@@ -46,6 +40,12 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
 /**
  * Copied and adapted from the AcummuloStore ElementConverterTests
  */
@@ -62,10 +62,12 @@ public class ElementSerialisationTest {
     @Test
     public void shouldReturnHBaseKeySerialisationFromBasicEdge() throws SchemaException, IOException {
         // Given
-        final Edge edge = new Edge(TestGroups.EDGE);
-        edge.setDestination("2");
-        edge.setSource("1");
-        edge.setDirected(true);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .dest("2")
+                .source("1")
+                .directed(true)
+                .build();
 
         // When
         final Pair<byte[], byte[]> keys = serialisation.getRowKeys(edge);
@@ -80,8 +82,10 @@ public class ElementSerialisationTest {
     @Test
     public void shouldReturnHBaseKeySerialisationFromBasicEntity() throws SchemaException, IOException {
         // Given
-        final Entity entity = new Entity(TestGroups.ENTITY);
-        entity.setVertex("3");
+        final Entity entity = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex("3")
+                .build();
 
         // When
         final byte[] key = serialisation.getRowKey(entity);
@@ -94,8 +98,10 @@ public class ElementSerialisationTest {
     @Test
     public void shouldReturnHBaseKeySerialisationFromCFCQPropertyEdge() throws SchemaException, IOException {
         // Given
-        final Edge edge = new Edge(TestGroups.EDGE);
-        edge.putProperty(HBasePropertyNames.COLUMN_QUALIFIER, 100);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .property(HBasePropertyNames.COLUMN_QUALIFIER, 100)
+                .build();
 
         // When
         final byte[] columnQualifier = serialisation.getColumnQualifier(edge);
@@ -121,11 +127,13 @@ public class ElementSerialisationTest {
     @Test
     public void shouldReturnHBaseKeySerialisationMultipleCQPropertyEdge() throws SchemaException, IOException {
         // Given
-        final Edge edge = new Edge(TestGroups.EDGE);
-        edge.setDestination("2");
-        edge.setSource("1");
-        edge.setDirected(true);
-        edge.putProperty(HBasePropertyNames.COLUMN_QUALIFIER, 100);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("1")
+                .dest("2")
+                .directed(true)
+                .property(HBasePropertyNames.COLUMN_QUALIFIER, 100)
+                .build();
 
         // When
         final byte[] columnQualifier = serialisation.getColumnQualifier(edge);
@@ -138,9 +146,11 @@ public class ElementSerialisationTest {
     @Test
     public void shouldReturnHBaseKeySerialisationMultipleCQPropertiesEntity() throws SchemaException, IOException {
         // Given
-        final Entity entity = new Entity(TestGroups.ENTITY);
-        entity.setVertex("3");
-        entity.putProperty(HBasePropertyNames.COLUMN_QUALIFIER, 100);
+        final Entity entity = new Entity.Builder()
+                .group(TestGroups.ENTITY)
+                .vertex("3")
+                .property(HBasePropertyNames.COLUMN_QUALIFIER, 100)
+                .build();
 
         // When
         final byte[] columnQualifier = serialisation.getColumnQualifier(entity);
@@ -153,10 +163,12 @@ public class ElementSerialisationTest {
     @Test
     public void shouldGetOriginalEdgeWithMatchAsSourceNotSet() throws SchemaException, IOException {
         // Given
-        final Edge edge = new Edge(TestGroups.EDGE);
-        edge.setDestination("2");
-        edge.setSource("1");
-        edge.setDirected(true);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .dest("2")
+                .source("1")
+                .directed(true)
+                .build();
 
         final Pair<byte[], byte[]> keys = serialisation.getRowKeys(edge);
         final Map<String, String> options = new HashMap<>();
@@ -173,10 +185,12 @@ public class ElementSerialisationTest {
     @Test
     public void shouldGetFlippedEdgeWithMatchAsSourceFalse() throws SchemaException, IOException {
         // Given
-        final Edge edge = new Edge(TestGroups.EDGE);
-        edge.setDestination("2");
-        edge.setSource("1");
-        edge.setDirected(true);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .dest("2")
+                .source("1")
+                .directed(true)
+                .build();
 
         final Pair<byte[], byte[]> keys = serialisation.getRowKeys(edge);
         final Map<String, String> options = new HashMap<>();
@@ -194,11 +208,13 @@ public class ElementSerialisationTest {
     @Test
     public void shouldSkipNullPropertyValuesWhenCreatingHBaseKey() throws SchemaException, IOException {
         // Given
-        final Edge edge = new Edge(TestGroups.EDGE);
-        edge.setSource("1");
-        edge.setDestination("2");
-        edge.setDirected(true);
-        edge.putProperty(HBasePropertyNames.COLUMN_QUALIFIER, null);
+        final Edge edge = new Edge.Builder()
+                .group(TestGroups.EDGE)
+                .source("1")
+                .dest("2")
+                .directed(true)
+                .property(HBasePropertyNames.COLUMN_QUALIFIER, null)
+                .build();
 
         // When
         final byte[] columnQualifier = serialisation.getColumnQualifier(edge);
@@ -488,10 +504,10 @@ public class ElementSerialisationTest {
         // Given 
         final Schema schema = new Schema.Builder()
                 .entity(TestGroups.ENTITY, new SchemaEntityDefinition.Builder()
-                                .vertex("string")
-                                .property(HBasePropertyNames.PROP_1, "map")
-                                .property(HBasePropertyNames.PROP_2, "map")
-                                .build()
+                        .vertex("string")
+                        .property(HBasePropertyNames.PROP_1, "map")
+                        .property(HBasePropertyNames.PROP_2, "map")
+                        .build()
                 )
                 .type("string", String.class)
                 .type("map", new TypeDefinition.Builder()

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/GetAllElementsHandlerTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/GetAllElementsHandlerTest.java
@@ -101,16 +101,31 @@ public class GetAllElementsHandlerTest {
         entity.putProperty(PROPERTY1, "p");
         entity.putProperty(COUNT, NUM_LOOPS);
         expectedResults.add(entity);
-        final Edge edge1 = new Edge(BASIC_EDGE1, "A", "B", true);
+        final Edge edge1 = new Edge.Builder()
+                .group(BASIC_EDGE1)
+                .source("A")
+                .dest("B")
+                .directed(true)
+                .build();
         edge1.putProperty(PROPERTY1, "q");
         edge1.putProperty(COUNT, 2 * NUM_LOOPS);
         expectedResults.add(edge1);
-        final Edge edge2 = new Edge(BASIC_EDGE2, "X", "Y", false);
+        final Edge edge2 = new Edge.Builder()
+                .group(BASIC_EDGE2)
+                .source("X")
+                .dest("Y")
+                .directed(false)
+                .build();
         edge2.putProperty(PROPERTY1, "r");
         edge2.putProperty(PROPERTY2, "s");
         edge2.putProperty(COUNT, 3 * (NUM_LOOPS / 2));
         expectedResults.add(edge2);
-        final Edge edge3 = new Edge(BASIC_EDGE2, "X", "Y", false);
+        final Edge edge3 = new Edge.Builder()
+                .group(BASIC_EDGE2)
+                .source("X")
+                .dest("Y")
+                .directed(false)
+                .build();
         edge3.putProperty(PROPERTY1, "r");
         edge3.putProperty(PROPERTY2, "t");
         edge3.putProperty(COUNT, 3 * (NUM_LOOPS / 2));
@@ -377,19 +392,31 @@ public class GetAllElementsHandlerTest {
         final List<Element> elements = new ArrayList<>();
         IntStream.range(0, NUM_LOOPS)
                 .forEach(i -> {
-                    final Entity entity = new Entity(BASIC_ENTITY, "" + i);
-                    entity.putProperty(PROPERTY1, "p");
-                    entity.putProperty(COUNT, 1);
-                    elements.add(entity);
-                    final Edge edge1 = new Edge(BASIC_EDGE1, "A", "B" + i, true);
-                    edge1.putProperty(PROPERTY1, "q");
-                    edge1.putProperty(COUNT, i);
-                    elements.add(edge1);
-                    final Edge edge2 = new Edge(BASIC_EDGE2, "X", "Y" + i, false);
-                    edge2.putProperty(PROPERTY1, "r");
-                    edge2.putProperty(PROPERTY2, "s");
-                    edge2.putProperty(COUNT, 3);
-                    elements.add(edge2);
+                    elements.add(new Entity.Builder()
+                            .group(BASIC_ENTITY)
+                            .vertex("" + i)
+                            .property(PROPERTY1, "p")
+                            .property(COUNT, 1)
+                            .build());
+
+                    elements.add(new Edge.Builder()
+                            .group(BASIC_EDGE1)
+                            .source("A")
+                            .dest("B" + i)
+                            .directed(true)
+                            .property(PROPERTY1, "q")
+                            .property(COUNT, i)
+                            .build());
+
+                    elements.add(new Edge.Builder()
+                            .group(BASIC_EDGE2)
+                            .source("X")
+                            .dest("Y" + i)
+                            .directed(false)
+                            .property(PROPERTY1, "r")
+                            .property(PROPERTY2, "s")
+                            .property(COUNT, 3)
+                            .build());
                 });
         return elements;
     }
@@ -398,25 +425,38 @@ public class GetAllElementsHandlerTest {
         final List<Element> elements = new ArrayList<>();
         IntStream.range(0, NUM_LOOPS)
                 .forEach(i -> {
-                    final Entity entity = new Entity(BASIC_ENTITY, "0");
-                    entity.putProperty(PROPERTY1, "p");
-                    entity.putProperty(COUNT, 1);
-                    elements.add(entity);
-                    final Edge edge1 = new Edge(BASIC_EDGE1, "A", "B", true);
-                    edge1.putProperty(PROPERTY1, "q");
-                    edge1.putProperty(COUNT, 2);
-                    elements.add(edge1);
-                    final Edge edge2 = new Edge(BASIC_EDGE2, "X", "Y", false);
-                    edge2.putProperty(PROPERTY1, "r");
+                    elements.add(new Entity.Builder()
+                            .group(BASIC_ENTITY)
+                            .vertex("0")
+                            .property(PROPERTY1, "p")
+                            .property(COUNT, 1)
+                            .build());
+
+                    elements.add(new Edge.Builder()
+                            .group(BASIC_EDGE1)
+                            .source("A")
+                            .dest("B")
+                            .directed(true)
+                            .property(PROPERTY1, "q")
+                            .property(COUNT, 2)
+                            .build());
+
                     String property2;
                     if (i % 2 == 0) {
                         property2 = "s";
                     } else {
                         property2 = "t";
                     }
-                    edge2.putProperty(PROPERTY2, property2);
-                    edge2.putProperty(COUNT, 3);
-                    elements.add(edge2);
+
+                    elements.add(new Edge.Builder()
+                            .group(BASIC_EDGE2)
+                            .source("X")
+                            .dest("Y")
+                            .directed(false)
+                            .property(PROPERTY1, "r")
+                            .property(PROPERTY2, property2)
+                            .property(COUNT, 3)
+                            .build());
                 });
         return elements;
     }
@@ -425,19 +465,31 @@ public class GetAllElementsHandlerTest {
         final List<Element> elements = new ArrayList<>();
         IntStream.range(0, NUM_LOOPS)
                 .forEach(i -> {
-                    final Entity entity = new Entity(BASIC_ENTITY, "0");
-                    entity.putProperty(PROPERTY1, "p");
-                    entity.putProperty(COUNT, 1);
-                    elements.add(entity);
-                    final Edge edge1 = new Edge(BASIC_EDGE1, "A", "B", true);
-                    edge1.putProperty(PROPERTY1, "q");
-                    edge1.putProperty(COUNT, 2);
-                    elements.add(edge1);
-                    final Edge edge2 = new Edge(BASIC_EDGE2, "X", "Y", false);
-                    edge2.putProperty(PROPERTY1, "r");
-                    edge2.putProperty(PROPERTY2, "s");
-                    edge2.putProperty(COUNT, 3);
-                    elements.add(edge2);
+                    elements.add(new Entity.Builder()
+                            .group(BASIC_ENTITY)
+                            .vertex("0")
+                            .property(PROPERTY1, "p")
+                            .property(COUNT, 1)
+                            .build());
+
+                    elements.add(new Edge.Builder()
+                            .group(BASIC_EDGE1)
+                            .source("A")
+                            .dest("B")
+                            .directed(true)
+                            .property(PROPERTY1, "q")
+                            .property(COUNT, 2)
+                            .build());
+
+                    elements.add(new Edge.Builder()
+                            .group(BASIC_EDGE2)
+                            .source("X")
+                            .dest("Y")
+                            .directed(false)
+                            .property(PROPERTY1, "r")
+                            .property(PROPERTY2, "s")
+                            .property(COUNT, 3)
+                            .build());
                 });
         return elements;
     }

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/GetElementsHandlerTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/GetElementsHandlerTest.java
@@ -1149,7 +1149,6 @@ public class GetElementsHandlerTest {
                 .build();
         final Edge result = (Edge) graph.execute(getElements, new User()).iterator().next();
         // Change a property
-        result.setDestination("BBB");
         result.putProperty(GetAllElementsHandlerTest.PROPERTY1, "qqq");
 
         // Then
@@ -1169,15 +1168,24 @@ public class GetElementsHandlerTest {
         elements.add(entity1);
         IntStream.range(0, NUM_LOOPS)
                 .forEach(i -> {
-                    final Edge edge1 = new Edge(GetAllElementsHandlerTest.BASIC_EDGE1, "A", "B" + i, true);
-                    edge1.putProperty(GetAllElementsHandlerTest.PROPERTY1, "q");
-                    edge1.putProperty(GetAllElementsHandlerTest.COUNT, i);
-                    elements.add(edge1);
-                    final Edge edge2 = new Edge(GetAllElementsHandlerTest.BASIC_EDGE2, "X", "Y" + i, false);
-                    edge2.putProperty(GetAllElementsHandlerTest.PROPERTY1, "r");
-                    edge2.putProperty(GetAllElementsHandlerTest.PROPERTY2, "s");
-                    edge2.putProperty(GetAllElementsHandlerTest.COUNT, 3);
-                    elements.add(edge2);
+                    elements.add(new Edge.Builder()
+                            .group(GetAllElementsHandlerTest.BASIC_EDGE1)
+                            .source("A")
+                            .dest("B" + i)
+                            .directed(true)
+                            .property(GetAllElementsHandlerTest.PROPERTY1, "q")
+                            .property(GetAllElementsHandlerTest.COUNT, i)
+                            .build());
+
+                    elements.add(new Edge.Builder()
+                            .group(GetAllElementsHandlerTest.BASIC_EDGE2)
+                            .source("X")
+                            .dest("Y" + i)
+                            .directed(false)
+                            .property(GetAllElementsHandlerTest.PROPERTY1, "r")
+                            .property(GetAllElementsHandlerTest.PROPERTY2, "s")
+                            .property(GetAllElementsHandlerTest.COUNT, 3)
+                            .build());
                 });
         return elements;
     }

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/OperationChainTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/OperationChainTest.java
@@ -89,7 +89,11 @@ public class OperationChainTest {
         final Entity entity2 = new Entity("entity", "vertex2");
         entity2.putProperty("count", 2);
         elements.add(entity2);
-        final Edge edge = new Edge("edge", "vertex1", "vertex2", true);
+        final Edge edge = new Edge.Builder().group("edge")
+                .source("vertex1")
+                .dest("vertex2")
+                .directed(true)
+                .build();
         edge.putProperty("count", 1);
         elements.add(edge);
         return elements;


### PR DESCRIPTION
I've just changed all tests to use the Edge.Builder instead of the Edge constructor. Using the builder makes it clearer to see what fields you are setting. The reason for making this change is to help with the migration for the rest of issue #659