### PR TITLE
Gh 287 refactor export to other graph handler

### DIFF
--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/operation/export/graph/handler/ExportToOtherGraphHandler.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/operation/export/graph/handler/ExportToOtherGraphHandler.java
@@ -63,19 +63,16 @@ public class ExportToOtherGraphHandler extends ExportToHandler<ExportToOtherGrap
     }
 
     private Graph createGraphAfterResolvingSchemaAndProperties(final ExportToOtherGraph<?> export, final Store store) {
-        final Graph rtn;
-
         StoreProperties storeProperties = resolveStoreProperties(export, store);
 
         Schema schema = resolveSchema(export, store);
 
-        rtn = new Builder()
+        return new Builder()
                 .graphId(export.getGraphId())
                 .library(store.getGraphLibrary())
                 .addSchema(schema)
                 .storeProperties(storeProperties)
                 .build();
-        return rtn;
     }
 
     private StoreProperties resolveStoreProperties(final ExportToOtherGraph<?> export, final Store store) {

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/operation/export/graph/handler/ExportToOtherGraphHandler.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/operation/export/graph/handler/ExportToOtherGraphHandler.java
@@ -39,7 +39,6 @@ public class ExportToOtherGraphHandler extends ExportToHandler<ExportToOtherGrap
 
     @Override
     protected OtherGraphExporter createExporter(final ExportToOtherGraph export, final Context context, final Store store) {
-
         return new OtherGraphExporter(context.getUser(),
                                       context.getJobId(),
                                       createGraph(export, store));
@@ -64,7 +63,6 @@ public class ExportToOtherGraphHandler extends ExportToHandler<ExportToOtherGrap
 
     private Graph createGraphAfterResolvingSchemaAndProperties(final ExportToOtherGraph<?> export, final Store store) {
         StoreProperties storeProperties = resolveStoreProperties(export, store);
-
         Schema schema = resolveSchema(export, store);
 
         return new Builder()

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/operation/export/graph/handler/ExportToOtherGraphHandler.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/operation/export/graph/handler/ExportToOtherGraphHandler.java
@@ -68,24 +68,36 @@ public class ExportToOtherGraphHandler extends ExportToHandler<ExportToOtherGrap
         } else if (graphLibrary.exists(exportGraphId)) {
             rtn = getGraphWithLibraryAndID(exportGraphId, graphLibrary);
         } else {
-            StoreProperties storeProperties = resolveStoreProperties(exportStoreProperties,
-                                                                     exportParentStorePropertiesId,
-                                                                     graphLibrary,
-                                                                     storeStoreProperties);
-
-            Schema schema = resolveSchema(exportSchema,
-                                          exportParentSchemaIds,
-                                          graphLibrary,
-                                          storeSchema);
-
-            rtn = new Graph.Builder()
-                    .graphId(exportGraphId)
-                    .library(graphLibrary)
-                    .addSchema(schema)
-                    .storeProperties(storeProperties)
-                    .build();
-
+            rtn = getGraphAfterResolvingSchemaAndProperties(exportGraphId,
+                                                            exportSchema,
+                                                            exportStoreProperties,
+                                                            exportParentSchemaIds,
+                                                            exportParentStorePropertiesId,
+                                                            graphLibrary,
+                                                            storeStoreProperties,
+                                                            storeSchema);
         }
+        return rtn;
+    }
+
+    private Graph getGraphAfterResolvingSchemaAndProperties(final String exportGraphId, final Schema exportSchema, final StoreProperties exportStoreProperties, final List<String> exportParentSchemaIds, final String exportParentStorePropertiesId, final GraphLibrary graphLibrary, final StoreProperties storeStoreProperties, final Schema storeSchema) {
+        final Graph rtn;
+        StoreProperties storeProperties = resolveStoreProperties(exportStoreProperties,
+                                                                 exportParentStorePropertiesId,
+                                                                 graphLibrary,
+                                                                 storeStoreProperties);
+
+        Schema schema = resolveSchema(exportSchema,
+                                      exportParentSchemaIds,
+                                      graphLibrary,
+                                      storeSchema);
+
+        rtn = new Builder()
+                .graphId(exportGraphId)
+                .library(graphLibrary)
+                .addSchema(schema)
+                .storeProperties(storeProperties)
+                .build();
         return rtn;
     }
 


### PR DESCRIPTION
ExportToOtherGraphHandler#createGraph

potentially the method fields could be removed and the inner three methods be simply passed export & store. this would be in keeping with the clean practice of small method parameter volume.