### PR TITLE
Gh 792 Spark GraphX operations

### DIFF
--- a/core/common-util/pom.xml
+++ b/core/common-util/pom.xml
@@ -52,5 +52,38 @@
             <artifactId>koryphe</artifactId>
             <version>${koryphe.version}</version>
         </dependency>
+
+        <!-- Scala -->
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_2.11</artifactId>
+            <version>${scalatest.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>${scala-maven-plugin.version}</version>
+                <configuration>
+                    <recompileMode>incremental</recompileMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/core/common-util/src/test/scala/uk/gov/gchq/gaffer/commonutil/spec/UnitSpec.scala
+++ b/core/common-util/src/test/scala/uk/gov/gchq/gaffer/commonutil/spec/UnitSpec.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.commonutil.spec
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FlatSpec, Matchers}
+
+/**
+  * Scalatest spec for running Gaffer unit tests.
+  */
+@RunWith(classOf[JUnitRunner])
+abstract class UnitSpec extends FlatSpec with Matchers {
+  // empty marker class
+}

--- a/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/OperationTest.java
+++ b/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/OperationTest.java
@@ -18,10 +18,12 @@ package uk.gov.gchq.gaffer.operation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.Test;
+import uk.gov.gchq.gaffer.commonutil.Required;
 import uk.gov.gchq.gaffer.exception.SerialisationException;
 import uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser;
 import uk.gov.gchq.koryphe.ValidationResult;
-import java.util.Collections;
+import java.lang.reflect.Field;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -32,7 +34,18 @@ public abstract class OperationTest {
     protected abstract Class<? extends Operation> getOperationClass();
 
     protected Set<String> getRequiredFields() {
-        return Collections.emptySet();
+        final Set<String> requiredFields = new HashSet<>(0);
+
+        final Field[] fields = getOperationClass().getFields();
+
+        for (final Field field :
+                fields) {
+            final Required[] reqAnnotations = field.getAnnotationsByType(Required.class);
+            if (reqAnnotations != null && reqAnnotations.length > 0) {
+                requiredFields.add(field.getName());
+            }
+        }
+        return requiredFields;
     }
 
     @Test

--- a/library/spark/spark-accumulo-library/pom.xml
+++ b/library/spark/spark-accumulo-library/pom.xml
@@ -40,6 +40,11 @@
             <artifactId>sketches-library</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>graphframes</groupId>
+            <artifactId>graphframes</artifactId>
+            <version>0.5.0-spark2.1-s_2.11</version>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>
@@ -50,6 +55,14 @@
             <type>test-jar</type>
         </dependency>
     </dependencies>
+
+    <repositories>
+        <!-- list of other repositories -->
+        <repository>
+            <id>SparkPackagesRepo</id>
+            <url>http://dl.bintray.com/spark-packages/maven</url>
+        </repository>
+    </repositories>
 
     <build>
         <plugins>

--- a/library/spark/spark-accumulo-library/src/main/scala/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/IterableToGraphXHandler.scala
+++ b/library/spark/spark-accumulo-library/src/main/scala/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/IterableToGraphXHandler.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.sparkaccumulo.operation.handler
+
+import org.apache.spark.graphx.{Edge, Graph, VertexRDD}
+import uk.gov.gchq.gaffer.data.element
+import uk.gov.gchq.gaffer.spark.operation.graphx.IterableToGraphX
+import uk.gov.gchq.gaffer.store.operation.handler.OutputOperationHandler
+import uk.gov.gchq.gaffer.store.{Context, Store}
+
+import scala.collection.JavaConverters._
+
+class IterableToGraphXHandler extends OutputOperationHandler[IterableToGraphX, Graph[_, _]] {
+
+  override def doOperation(operation: IterableToGraphX, context: Context, store: Store): Graph[_, _] = {
+
+    val edges: Iterable[element.Edge] = operation.getInput.asScala.filter(e => e.isInstanceOf[element.Edge]).map(e => e.asInstanceOf[element.Edge])
+    val entities: Iterable[element.Entity] = operation.getInput.asScala.filter(e => e.isInstanceOf[element.Entity]).map(e => e.asInstanceOf[element.Entity])
+
+    val graphxVertices: VertexRDD[element.Entity] = VertexRDD(operation.getSparkContext.parallelize(entities.toSeq).map(e => (e.getVertex.hashCode(), e)))
+    val graphxEdges = operation.getSparkContext.parallelize(edges.map(e => Edge(e.getSource.hashCode(), e.getDestination.hashCode(), e)).toSeq)
+
+    Graph(graphxVertices, graphxEdges)
+  }
+}

--- a/library/spark/spark-accumulo-library/src/main/scala/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/PageRankHandler.scala
+++ b/library/spark/spark-accumulo-library/src/main/scala/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/PageRankHandler.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.sparkaccumulo.operation.handler
+
+import org.apache.spark.graphx.Graph
+import uk.gov.gchq.gaffer.spark.operation.graphx.PageRank
+import uk.gov.gchq.gaffer.store.operation.handler.OutputOperationHandler
+import uk.gov.gchq.gaffer.store.{Context, Store}
+
+class PageRankHandler extends OutputOperationHandler[PageRank, Graph[Double, Double]] {
+
+  override def doOperation(operation: PageRank, context: Context, store: Store): Graph[Double, Double] = {
+    val tol = operation.getTolerance()
+    operation.getInput.pageRank(tol)
+  }
+}

--- a/library/spark/spark-accumulo-library/src/main/scala/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/RddToGraphXHandler.scala
+++ b/library/spark/spark-accumulo-library/src/main/scala/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/RddToGraphXHandler.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.sparkaccumulo.operation.handler
+
+import org.apache.spark.graphx.{Edge, Graph, VertexRDD}
+import org.apache.spark.rdd.RDD
+import uk.gov.gchq.gaffer.data.element
+import uk.gov.gchq.gaffer.spark.operation.graphx.RddToGraphX
+import uk.gov.gchq.gaffer.store.operation.handler.OutputOperationHandler
+import uk.gov.gchq.gaffer.store.{Context, Store}
+
+class RddToGraphXHandler extends OutputOperationHandler[RddToGraphX, Graph[_, _]] {
+
+  override def doOperation(operation: RddToGraphX, context: Context, store: Store): Graph[_, _] = {
+
+    val edges: RDD[element.Edge] = operation.getInput.filter(e => e.isInstanceOf[element.Edge]).map(e => e.asInstanceOf[element.Edge])
+    val entities: RDD[element.Entity] = operation.getInput.filter(e => e.isInstanceOf[element.Entity]).map(e => e.asInstanceOf[element.Entity])
+
+    val graphxVertices: VertexRDD[element.Entity] = VertexRDD(entities.map(e => (e.getVertex.hashCode(), e)))
+    val graphxEdges = edges.map(e => Edge(e.getSource.hashCode(), e.getDestination.hashCode(), e))
+
+    Graph(graphxVertices, graphxEdges)
+  }
+}

--- a/library/spark/spark-accumulo-library/src/test/scala/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/graphx/IterableToGraphXHandlerSpec.scala
+++ b/library/spark/spark-accumulo-library/src/test/scala/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/graphx/IterableToGraphXHandlerSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.sparkaccumulo.operation.handler.graphx
+
+import org.apache.spark.graphx.{Graph, VertexRDD}
+import org.apache.spark.{SparkConf, SparkContext, graphx}
+import org.scalactic.TolerantNumerics
+import uk.gov.gchq.gaffer.commonutil.spec.UnitSpec
+import uk.gov.gchq.gaffer.data.element.{Edge, Element, Entity}
+import uk.gov.gchq.gaffer.spark.operation.graphx.PageRank
+import uk.gov.gchq.gaffer.sparkaccumulo.operation.handler.PageRankHandler
+
+class IterableToGraphXHandlerSpec extends UnitSpec {
+
+  implicit val doubleEquality = TolerantNumerics.tolerantDoubleEquality(0.01)
+
+  "A PageRank operation" should "create a PageRank graph" in {
+    // Given
+    val graph = iterableToGraphX(createSimpleGraph())
+
+    val pageRank = new PageRank
+    pageRank.setInput(graph)
+
+    val handler = new PageRankHandler
+
+    val result = handler.doOperation(pageRank, null, null).vertices.map(f => f._2).collect().sorted
+
+    result shouldBe sorted
+    result should contain allOf(0.15, 0.78, 1.48, 1.57)
+
+    result.foreach(println)
+  }
+
+  def createSimpleGraph(): Iterable[Element] = {
+    val pageA = new Entity.Builder().group("page").vertex("A").build()
+    val pageB = new Entity.Builder().group("page").vertex("B").build()
+    val pageC = new Entity.Builder().group("page").vertex("C").build()
+    val pageD = new Entity.Builder().group("page").vertex("D").build()
+
+    val edge1 = new Edge.Builder().directed(true).group("edge").source("A").dest("B").build();
+    val edge2 = new Edge.Builder().directed(true).group("edge").source("A").dest("C").build();
+    val edge3 = new Edge.Builder().directed(true).group("edge").source("B").dest("C").build();
+    val edge4 = new Edge.Builder().directed(true).group("edge").source("C").dest("A").build();
+    val edge5 = new Edge.Builder().directed(true).group("edge").source("D").dest("C").build();
+
+    List(pageA, pageB, pageC, pageD, edge1, edge2, edge3, edge4, edge5)
+  }
+
+  def iterableToGraphX(iter: Iterable[Element]): Graph[Entity, Edge] = {
+    val edges: Iterable[Edge] = iter.filter(e => e.isInstanceOf[Edge]).map(e => e.asInstanceOf[Edge])
+    val entities: Iterable[Entity] = iter.filter(e => e.isInstanceOf[Entity]).map(e => e.asInstanceOf[Entity])
+
+    val conf = new SparkConf().setMaster("local[2]").setAppName("PageRankHandlerSpec")
+    val sc = new SparkContext(conf)
+
+    val graphxVertices: VertexRDD[Entity] = VertexRDD(sc.parallelize(entities.toSeq).map(e => (e.getVertex.hashCode(), e)))
+    val graphxEdges = sc.parallelize(edges.map(e => new graphx.Edge(e.getSource.hashCode(), e.getDestination.hashCode(), e)).toSeq)
+
+    Graph(graphxVertices, graphxEdges)
+  }
+
+}

--- a/library/spark/spark-accumulo-library/src/test/scala/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/graphx/PageRankHandlerSpec.scala
+++ b/library/spark/spark-accumulo-library/src/test/scala/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/graphx/PageRankHandlerSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.sparkaccumulo.operation.handler.graphx
+
+import org.apache.spark.graphx.{Graph, VertexRDD}
+import org.apache.spark.{SparkConf, SparkContext, graphx}
+import org.scalactic.TolerantNumerics
+import uk.gov.gchq.gaffer.commonutil.spec.UnitSpec
+import uk.gov.gchq.gaffer.data.element.{Edge, Element, Entity}
+import uk.gov.gchq.gaffer.spark.operation.graphx.PageRank
+import uk.gov.gchq.gaffer.sparkaccumulo.operation.handler.PageRankHandler
+
+class PageRankHandlerSpec extends UnitSpec {
+
+  implicit val doubleEquality = TolerantNumerics.tolerantDoubleEquality(0.01)
+
+  "A PageRank operation" should "create a PageRank graph" in {
+    // Given
+    val graph = iterableToGraphX(createSimpleGraph())
+
+    val pageRank = new PageRank
+    pageRank.setInput(graph)
+
+    val handler = new PageRankHandler
+
+    // When
+    val result = handler.doOperation(pageRank, null, null).vertices.map(f => f._2).collect().sorted
+
+    // Then
+    result shouldBe sorted
+    result should contain allOf(0.15, 0.78, 1.48, 1.57)
+
+    result.foreach(println)
+  }
+
+  def createSimpleGraph(): Iterable[Element] = {
+    val pageA = new Entity.Builder().group("page").vertex("A").build()
+    val pageB = new Entity.Builder().group("page").vertex("B").build()
+    val pageC = new Entity.Builder().group("page").vertex("C").build()
+    val pageD = new Entity.Builder().group("page").vertex("D").build()
+
+    val edge1 = new Edge.Builder().directed(true).group("edge").source("A").dest("B").build();
+    val edge2 = new Edge.Builder().directed(true).group("edge").source("A").dest("C").build();
+    val edge3 = new Edge.Builder().directed(true).group("edge").source("B").dest("C").build();
+    val edge4 = new Edge.Builder().directed(true).group("edge").source("C").dest("A").build();
+    val edge5 = new Edge.Builder().directed(true).group("edge").source("D").dest("C").build();
+
+    List(pageA, pageB, pageC, pageD, edge1, edge2, edge3, edge4, edge5)
+  }
+
+  def iterableToGraphX(iter: Iterable[Element]): Graph[Entity, Edge] = {
+    val edges: Iterable[Edge] = iter.filter(e => e.isInstanceOf[Edge]).map(e => e.asInstanceOf[Edge])
+    val entities: Iterable[Entity] = iter.filter(e => e.isInstanceOf[Entity]).map(e => e.asInstanceOf[Entity])
+
+    val conf = new SparkConf().setMaster("local[2]").setAppName("PageRankHandlerSpec")
+    val sc = new SparkContext(conf)
+
+    val graphxVertices: VertexRDD[Entity] = VertexRDD(sc.parallelize(entities.toSeq).map(e => (e.getVertex.hashCode(), e)))
+    val graphxEdges = sc.parallelize(edges.map(e => new graphx.Edge(e.getSource.hashCode(), e.getDestination.hashCode(), e)).toSeq)
+
+    Graph(graphxVertices, graphxEdges)
+  }
+
+}

--- a/library/spark/spark-accumulo-library/src/test/scala/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/graphx/RddToGraphXHandlerSpec.scala
+++ b/library/spark/spark-accumulo-library/src/test/scala/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/graphx/RddToGraphXHandlerSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.sparkaccumulo.operation.handler.graphx
+
+import org.apache.spark.graphx.{Graph, VertexRDD}
+import org.apache.spark.{SparkConf, SparkContext, graphx}
+import org.scalactic.TolerantNumerics
+import uk.gov.gchq.gaffer.commonutil.spec.UnitSpec
+import uk.gov.gchq.gaffer.data.element.{Edge, Element, Entity}
+import uk.gov.gchq.gaffer.spark.operation.graphx.PageRank
+import uk.gov.gchq.gaffer.sparkaccumulo.operation.handler.PageRankHandler
+
+class RddToGraphXHandlerSpec extends UnitSpec {
+
+  implicit val doubleEquality = TolerantNumerics.tolerantDoubleEquality(0.01)
+
+  "A PageRank operation" should "create a PageRank graph" in {
+    // Given
+    val graph = iterableToGraphX(createSimpleGraph())
+
+    val pageRank = new PageRank
+    pageRank.setInput(graph)
+
+    val handler = new PageRankHandler
+
+    val result = handler.doOperation(pageRank, null, null).vertices.map(f => f._2).collect().sorted
+
+    result shouldBe sorted
+    result should contain allOf(0.15, 0.78, 1.48, 1.57)
+
+    result.foreach(println)
+  }
+
+  def createSimpleGraph(): Iterable[Element] = {
+    val pageA = new Entity.Builder().group("page").vertex("A").build()
+    val pageB = new Entity.Builder().group("page").vertex("B").build()
+    val pageC = new Entity.Builder().group("page").vertex("C").build()
+    val pageD = new Entity.Builder().group("page").vertex("D").build()
+
+    val edge1 = new Edge.Builder().directed(true).group("edge").source("A").dest("B").build();
+    val edge2 = new Edge.Builder().directed(true).group("edge").source("A").dest("C").build();
+    val edge3 = new Edge.Builder().directed(true).group("edge").source("B").dest("C").build();
+    val edge4 = new Edge.Builder().directed(true).group("edge").source("C").dest("A").build();
+    val edge5 = new Edge.Builder().directed(true).group("edge").source("D").dest("C").build();
+
+    List(pageA, pageB, pageC, pageD, edge1, edge2, edge3, edge4, edge5)
+  }
+
+  def iterableToGraphX(iter: Iterable[Element]): Graph[Entity, Edge] = {
+    val edges: Iterable[Edge] = iter.filter(e => e.isInstanceOf[Edge]).map(e => e.asInstanceOf[Edge])
+    val entities: Iterable[Entity] = iter.filter(e => e.isInstanceOf[Entity]).map(e => e.asInstanceOf[Entity])
+
+    val conf = new SparkConf().setMaster("local[2]").setAppName("PageRankHandlerSpec")
+    val sc = new SparkContext(conf)
+
+    val graphxVertices: VertexRDD[Entity] = VertexRDD(sc.parallelize(entities.toSeq).map(e => (e.getVertex.hashCode(), e)))
+    val graphxEdges = sc.parallelize(edges.map(e => new graphx.Edge(e.getSource.hashCode(), e.getDestination.hashCode(), e)).toSeq)
+
+    Graph(graphxVertices, graphxEdges)
+  }
+
+}

--- a/library/spark/spark-doc/pom.xml
+++ b/library/spark/spark-doc/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>${scala-maven-plugin.version}</version>
                 <configuration>
                     <recompileMode>incremental</recompileMode>
                 </configuration>

--- a/library/spark/spark-library/pom.xml
+++ b/library/spark/spark-library/pom.xml
@@ -135,6 +135,11 @@
             <version>${spark.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-graphx_${scala.version}</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro-mapred</artifactId>
             <version>${avro.version}</version>
@@ -157,4 +162,25 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>${scala-maven-plugin.version}</version>
+                <configuration>
+                    <recompileMode>incremental</recompileMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/library/spark/spark-library/src/main/scala/uk/gov/gchq/gaffer/spark/data/graphx/GafferEdge.scala
+++ b/library/spark/spark-library/src/main/scala/uk/gov/gchq/gaffer/spark/data/graphx/GafferEdge.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.spark.data.graphx
+
+import org.apache.spark.graphx
+import uk.gov.gchq.gaffer.data.element.Edge
+
+case class GafferEdge(edge: Edge) {
+
+  def getSource(): Object = {
+    edge.getSource
+  }
+
+  def getDestination(): Object = {
+    edge.getDestination
+  }
+
+  def toGraphX(): graphx.Edge[Edge] = {
+    graphx.Edge(edge.getSource.hashCode(), edge.getDestination.hashCode())
+  }
+
+  object GafferEdge {
+
+    def apply(edge: Edge): graphx.Edge[Edge] =
+      new GafferEdge(edge).toGraphX()
+  }
+}

--- a/library/spark/spark-library/src/main/scala/uk/gov/gchq/gaffer/spark/data/graphx/GafferVertex.scala
+++ b/library/spark/spark-library/src/main/scala/uk/gov/gchq/gaffer/spark/data/graphx/GafferVertex.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.spark.data.graphx
+
+import org.apache.spark.graphx.VertexId
+import uk.gov.gchq.gaffer.data.element.Entity
+
+import scala.reflect.ClassTag
+
+case class GafferVertex(vertex: Entity) {
+
+  def toGraphX(): (VertexId, Entity) = (vertex.getVertex.hashCode(), vertex)
+
+  object GafferVertex {
+    def apply(vertex: Entity): (VertexId, Entity) = {
+      new GafferVertex(vertex).toGraphX
+    }
+  }
+
+}

--- a/library/spark/spark-library/src/main/scala/uk/gov/gchq/gaffer/spark/operation/graphx/IterableToGraphX.scala
+++ b/library/spark/spark-library/src/main/scala/uk/gov/gchq/gaffer/spark/operation/graphx/IterableToGraphX.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.spark.operation.graphx
+
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonTypeInfo}
+import com.fasterxml.jackson.core.`type`.TypeReference
+import org.apache.spark.SparkContext
+import org.apache.spark.graphx.Graph
+import uk.gov.gchq.gaffer.data.element.Element
+import uk.gov.gchq.gaffer.operation.Operation
+import uk.gov.gchq.gaffer.operation.io.InputOutput
+import uk.gov.gchq.gaffer.spark.operation.scalardd.Rdd
+
+class IterableToGraphX extends Operation with InputOutput[java.lang.Iterable[Element], Graph[_, _]] with Rdd{
+
+  private var input: java.lang.Iterable[Element] = null
+  private var sc: SparkContext = null
+
+  override def getOutputTypeReference: TypeReference[Graph[_, _]] =  new TypeReference[Graph[_, _]] {}
+
+  @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
+  override def getInput: java.lang.Iterable[Element] = input
+
+  override def setInput(in: java.lang.Iterable[Element]) = input = in
+
+  @JsonIgnore
+  override def getSparkContext: SparkContext = sc
+
+  override def setSparkContext(sparkContext: SparkContext): Unit = sc = sparkContext
+}
+
+object IterableToGraphX {
+  class Builder() extends Operation.BaseBuilder[IterableToGraphX, IterableToGraphX.Builder](new IterableToGraphX) with InputOutput.Builder[IterableToGraphX, java.lang.Iterable[Element], Graph[_, _], IterableToGraphX.Builder] {}
+}

--- a/library/spark/spark-library/src/main/scala/uk/gov/gchq/gaffer/spark/operation/graphx/PageRank.scala
+++ b/library/spark/spark-library/src/main/scala/uk/gov/gchq/gaffer/spark/operation/graphx/PageRank.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.spark.operation.graphx
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.core.`type`.TypeReference
+import org.apache.spark.graphx.Graph
+import uk.gov.gchq.gaffer.data.element.{Edge, Entity}
+import uk.gov.gchq.gaffer.operation.Operation
+import uk.gov.gchq.gaffer.operation.io.InputOutput
+
+class PageRank extends Operation with InputOutput[Graph[Entity, Edge], Graph[Double, Double]] {
+
+  private var input: Graph[Entity, Edge] = null
+  private var tolerance: Double = 0.001
+
+  def getTolerance(): Double = tolerance
+
+  def setTolerance(tol: Double) = tolerance = tol
+
+  @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
+  override def getInput: Graph[Entity, Edge] = input
+
+  override def setInput(graph: Graph[Entity, Edge]): Unit = input = graph // cannot reassign to val
+
+  override def getOutputTypeReference: TypeReference[Graph[Double, Double]] = new TypeReference[Graph[Double, Double]] {}
+}
+
+object PageRank {
+  class Builder() extends Operation.BaseBuilder[PageRank, PageRank.Builder](new PageRank) with InputOutput.Builder[PageRank, Graph[Entity, Edge], Graph[Double, Double], PageRank.Builder] {}
+}
+

--- a/library/spark/spark-library/src/main/scala/uk/gov/gchq/gaffer/spark/operation/graphx/RddToGraphX.scala
+++ b/library/spark/spark-library/src/main/scala/uk/gov/gchq/gaffer/spark/operation/graphx/RddToGraphX.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.spark.operation.graphx
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.core.`type`.TypeReference
+import org.apache.spark.SparkContext
+import org.apache.spark.graphx.Graph
+import org.apache.spark.rdd.RDD
+import uk.gov.gchq.gaffer.data.element.Element
+import uk.gov.gchq.gaffer.operation.Operation
+import uk.gov.gchq.gaffer.operation.io.InputOutput
+import uk.gov.gchq.gaffer.spark.operation.scalardd.Rdd
+
+class RddToGraphX extends Operation with InputOutput[RDD[Element], Graph[_, _]] with Rdd {
+
+  private var sc: SparkContext = null
+  private var input: RDD[Element] = null
+
+  override def getSparkContext: SparkContext = sc
+
+  override def setSparkContext(sparkContext: SparkContext) = sc = sparkContext
+
+  override def getOutputTypeReference: TypeReference[Graph[_, _]] =  new TypeReference[Graph[_, _]] {}
+
+  @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
+  override def getInput: RDD[Element] = input
+
+  override def setInput(in: RDD[Element]) = input = in
+}
+
+object RddToGraphX {
+  class Builder() extends Operation.BaseBuilder[RddToGraphX, RddToGraphX.Builder](new RddToGraphX) with InputOutput.Builder[RddToGraphX, RDD[Element], Graph[_, _], RddToGraphX.Builder] {}
+}

--- a/library/spark/spark-library/src/test/scala/uk/gov/gchq/gaffer/spark/operation/IterableToGraphXSpec.scala
+++ b/library/spark/spark-library/src/test/scala/uk/gov/gchq/gaffer/spark/operation/IterableToGraphXSpec.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.spark.operation
+
+import uk.gov.gchq.gaffer.commonutil.spec.UnitSpec
+import uk.gov.gchq.gaffer.data.element.{Edge, Element, Entity}
+import uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser
+import uk.gov.gchq.gaffer.spark.operation.graphx.IterableToGraphX
+
+import scala.collection.JavaConverters._
+
+class IterableToGraphXSpec extends UnitSpec {
+
+  "The builder" should "create a populated operation" in {
+    // Given
+    val iter = createIterable()
+
+    // When
+    val op = new IterableToGraphX.Builder().input(iter).build
+
+    val input = op.getInput
+    val entities = input.asScala.filter(e => e.isInstanceOf[Entity])
+    val edges = input.asScala.filter(e => e.isInstanceOf[Edge])
+
+    // Then
+    input shouldBe a[java.lang.Iterable[_]]
+    entities should contain(new Entity.Builder().group("page").vertex("A").build())
+    edges should contain(new Edge.Builder().directed(true).group("edge").source("A").dest("B").build())
+  }
+
+  "The operation" should "serialise and deserialise" in {
+    // Given
+    val op = new IterableToGraphX()
+    val serialiser = new JSONSerialiser()
+
+    // When
+    val json = serialiser.serialise(op, true)
+    val deserialisedOp = serialiser.deserialise(json, classOf[IterableToGraphX])
+
+    // Then
+    deserialisedOp shouldNot be (null)
+  }
+
+  def createIterable(): java.lang.Iterable[Element] = {
+    val pageA = new Entity.Builder().group("page").vertex("A").build()
+    val pageB = new Entity.Builder().group("page").vertex("B").build()
+    val pageC = new Entity.Builder().group("page").vertex("C").build()
+    val pageD = new Entity.Builder().group("page").vertex("D").build()
+
+    val edge1 = new Edge.Builder().directed(true).group("edge").source("A").dest("B").build()
+    val edge2 = new Edge.Builder().directed(true).group("edge").source("A").dest("C").build()
+    val edge3 = new Edge.Builder().directed(true).group("edge").source("B").dest("C").build()
+    val edge4 = new Edge.Builder().directed(true).group("edge").source("C").dest("A").build()
+    val edge5 = new Edge.Builder().directed(true).group("edge").source("D").dest("C").build()
+
+    List(pageA, pageB, pageC, pageD, edge1, edge2, edge3, edge4, edge5).asJava
+  }
+
+}

--- a/library/spark/spark-library/src/test/scala/uk/gov/gchq/gaffer/spark/operation/PageRankSpec.scala
+++ b/library/spark/spark-library/src/test/scala/uk/gov/gchq/gaffer/spark/operation/PageRankSpec.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.spark.operation
+
+import org.apache.spark.graphx.{Graph, VertexRDD}
+import org.apache.spark.{SparkConf, SparkContext}
+import uk.gov.gchq.gaffer.commonutil.spec.UnitSpec
+import uk.gov.gchq.gaffer.data.element.{Edge, Element, Entity}
+import uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser
+import uk.gov.gchq.gaffer.spark.operation.graphx.PageRank
+
+class PageRankSpec extends UnitSpec {
+
+  "The builder" should "create a populated operation" in {
+    // Given
+    val graph = iterableToGraphX(createSimpleGraph)
+
+    // When
+    val op = new PageRank.Builder().input(graph).build
+
+    val input = op.getInput
+    val entities = input.vertices.map(v => v._2).collect
+    val edges = input.edges.map(e => e.attr).collect
+
+    // Then
+    input shouldBe a[Graph[_, _]]
+    entities should contain(new Entity.Builder().group("page").vertex("A").build())
+    edges should contain(new Edge.Builder().directed(true).group("edge").source("A").dest("B").build())
+  }
+
+  "The operation" should "serialise and deserialise" in {
+    // Given
+    val op = new PageRank()
+    val serialiser = new JSONSerialiser()
+
+    // When
+    val json = serialiser.serialise(op, true)
+    val deserialisedOp = serialiser.deserialise(json, classOf[PageRank])
+
+    // Then
+    deserialisedOp shouldNot be (null)
+  }
+
+  def createSimpleGraph(): Iterable[Element] = {
+    val pageA = new Entity.Builder().group("page").vertex("A").build()
+    val pageB = new Entity.Builder().group("page").vertex("B").build()
+    val pageC = new Entity.Builder().group("page").vertex("C").build()
+    val pageD = new Entity.Builder().group("page").vertex("D").build()
+
+    val edge1 = new Edge.Builder().directed(true).group("edge").source("A").dest("B").build()
+    val edge2 = new Edge.Builder().directed(true).group("edge").source("A").dest("C").build()
+    val edge3 = new Edge.Builder().directed(true).group("edge").source("B").dest("C").build()
+    val edge4 = new Edge.Builder().directed(true).group("edge").source("C").dest("A").build()
+    val edge5 = new Edge.Builder().directed(true).group("edge").source("D").dest("C").build()
+
+    List(pageA, pageB, pageC, pageD, edge1, edge2, edge3, edge4, edge5)
+  }
+
+  def iterableToGraphX(iter: Iterable[Element]): Graph[Entity, Edge] = {
+    val edges: Iterable[Edge] = iter.filter(e => e.isInstanceOf[Edge]).map(e => e.asInstanceOf[Edge])
+    val entities: Iterable[Entity] = iter.filter(e => e.isInstanceOf[Entity]).map(e => e.asInstanceOf[Entity])
+
+    val conf = new SparkConf().setMaster("local[2]").setAppName("PageRankHandlerSpec")
+    val sc = new SparkContext(conf)
+
+    val graphxVertices: VertexRDD[Entity] = VertexRDD(sc.parallelize(entities.toSeq).map(e => (e.getVertex.hashCode(), e)))
+    val graphxEdges = sc.parallelize(edges.map(e => new org.apache.spark.graphx.Edge(e.getSource.hashCode(), e.getDestination.hashCode(), e)).toSeq)
+
+    Graph(graphxVertices, graphxEdges)
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <!-- Dependency version properties -->
         <junit.version>4.12</junit.version>
         <mockito.version>1.9.5</mockito.version>
+        <scalatest.version>3.0.3</scalatest.version>
         <failsafe.version>2.18.1</failsafe.version>
         <slf4j.api.version>1.7.5</slf4j.api.version>
 
@@ -102,6 +103,7 @@
         <javadoc.plugin.version>2.10.3</javadoc.plugin.version>
         <nexus.plugin.version>1.6.7</nexus.plugin.version>
         <release.plugin.version>2.5.3</release.plugin.version>
+        <scala-maven-plugin.version>3.2.2</scala-maven-plugin.version>
         <scm.plugin.version>1.1</scm.plugin.version>
         <shade.plugin.version>2.4.1</shade.plugin.version>
         <source.plugin.version>2.4</source.plugin.version>


### PR DESCRIPTION
First pass at including some GraphX operations for Gaffer, including:

* Creation of Graph objects from RDDs and Iterables
* Execution of the built in PageRank implementation from the GraphX library.

There are still some outstanding issues (lack of integration testing, correct setup of the SparkContext for the operations) and the implementation is very basic/simple/naive at the moment.