### PR TITLE
Gh-1156 - Parquet test unordering

### DIFF
--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/schema/SchemaElementDefinition.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/schema/SchemaElementDefinition.java
@@ -264,7 +264,7 @@ public abstract class SchemaElementDefinition implements ElementDefinition {
                     viewAggregatorProps = Collections.emptySet();
                 } else {
                     viewAggregatorProps = new HashSet<>(getPropertyMap().size() - mergedGroupBy.size());
-                    for (TupleAdaptedBinaryOperator<String, ?> component : viewAggregator.getComponents()) {
+                    for (final TupleAdaptedBinaryOperator<String, ?> component : viewAggregator.getComponents()) {
                         Collections.addAll(viewAggregatorProps, component.getSelection());
                         queryAggregator.getComponents().add(component);
                     }


### PR DESCRIPTION
Removed expectation of a specific order of the paths provided in the ParquetFileIteratorTest

Small checkstyle issue fixed to ensure project builds successfully.