### PR TITLE
gh-1124 - disabled in out flag for edge ids in get ranges

### DIFF
--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/AbstractCoreKeyRangeFactory.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/AbstractCoreKeyRangeFactory.java
@@ -28,6 +28,7 @@ import uk.gov.gchq.gaffer.data.element.id.ElementId;
 import uk.gov.gchq.gaffer.data.element.id.EntityId;
 import uk.gov.gchq.gaffer.operation.SeedMatching;
 import uk.gov.gchq.gaffer.operation.graph.GraphFilters;
+import uk.gov.gchq.gaffer.operation.graph.SeededGraphFilters;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,6 +39,12 @@ public abstract class AbstractCoreKeyRangeFactory implements RangeFactory {
     @Override
     public List<Range> getRange(final ElementId elementId, final GraphFilters operation)
             throws RangeFactoryException {
+        final SeededGraphFilters.IncludeIncomingOutgoingType inOutType = (operation instanceof SeededGraphFilters) ? ((SeededGraphFilters) operation).getIncludeIncomingOutGoing() : SeededGraphFilters.IncludeIncomingOutgoingType.OUTGOING;
+        return getRange(elementId, operation, inOutType);
+    }
+
+    private List<Range> getRange(final ElementId elementId, final GraphFilters operation, final SeededGraphFilters.IncludeIncomingOutgoingType inOutType)
+            throws RangeFactoryException {
         if (elementId instanceof EntityId) {
             return getRange(((EntityId) elementId).getVertex(), operation, operation.getView().hasEdges());
         } else {
@@ -47,7 +54,7 @@ public abstract class AbstractCoreKeyRangeFactory implements RangeFactory {
                     && DirectedType.areCompatible(operation.getDirectedType(), edgeId.getDirectedType())) {
                 // EQUALS and RELATED seed matching.
                 final DirectedType directed = DirectedType.and(operation.getDirectedType(), edgeId.getDirectedType());
-                ranges.addAll(getRange(edgeId.getSource(), edgeId.getDestination(), directed, operation));
+                ranges.addAll(getRange(edgeId.getSource(), edgeId.getDestination(), directed, operation, inOutType));
             }
 
             // Do related - if operation doesn't have seed matching or it has seed matching equal to RELATED
@@ -67,8 +74,9 @@ public abstract class AbstractCoreKeyRangeFactory implements RangeFactory {
     public Range getRangeFromPair(final Pair<ElementId, ElementId> pairRange, final GraphFilters operation)
             throws RangeFactoryException {
         final ArrayList<Range> ran = new ArrayList<>();
-        ran.addAll(getRange(pairRange.getFirst(), operation));
-        ran.addAll(getRange(pairRange.getSecond(), operation));
+        // set the in out flag to null to disable it
+        ran.addAll(getRange(pairRange.getFirst(), operation, null));
+        ran.addAll(getRange(pairRange.getSecond(), operation, null));
         Range min = null;
         Range max = null;
         for (final Range range : ran) {
@@ -86,7 +94,7 @@ public abstract class AbstractCoreKeyRangeFactory implements RangeFactory {
     }
 
     protected abstract List<Range> getRange(final Object sourceVal, final Object destVal, final DirectedType directed,
-                                            final GraphFilters operation) throws RangeFactoryException;
+                                            final GraphFilters operation, SeededGraphFilters.IncludeIncomingOutgoingType inOutType) throws RangeFactoryException;
 
     protected abstract List<Range> getRange(final Object vertex,
                                             final GraphFilters operation,

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/impl/byteEntity/ByteEntityRangeFactory.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/impl/byteEntity/ByteEntityRangeFactory.java
@@ -48,7 +48,7 @@ public class ByteEntityRangeFactory extends AbstractCoreKeyRangeFactory {
 
     @Override
     protected List<Range> getRange(final Object sourceVal, final Object destVal, final DirectedType directed,
-                                   final GraphFilters operation) throws RangeFactoryException {
+                                   final GraphFilters operation, final IncludeIncomingOutgoingType inOutType) throws RangeFactoryException {
         // To do EITHER we need to create 2 ranges
         if (DirectedType.isEither(directed)) {
             return Arrays.asList(

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/impl/classic/ClassicRangeFactory.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/impl/classic/ClassicRangeFactory.java
@@ -27,7 +27,6 @@ import uk.gov.gchq.gaffer.exception.SerialisationException;
 import uk.gov.gchq.gaffer.operation.SeedMatching;
 import uk.gov.gchq.gaffer.operation.SeedMatching.SeedMatchingType;
 import uk.gov.gchq.gaffer.operation.graph.GraphFilters;
-import uk.gov.gchq.gaffer.operation.graph.SeededGraphFilters;
 import uk.gov.gchq.gaffer.operation.graph.SeededGraphFilters.IncludeIncomingOutgoingType;
 import uk.gov.gchq.gaffer.serialisation.ToBytesSerialiser;
 import uk.gov.gchq.gaffer.store.schema.Schema;
@@ -81,16 +80,14 @@ public class ClassicRangeFactory extends AbstractCoreKeyRangeFactory {
 
     @Override
     protected List<Range> getRange(final Object sourceVal, final Object destVal, final DirectedType directed,
-                                   final GraphFilters operation) throws RangeFactoryException {
-        return Collections.singletonList(new Range(getKeyFromEdgeId(sourceVal, destVal, directed, operation, false), true,
-                getKeyFromEdgeId(sourceVal, destVal, directed, operation, true), true));
+                                   final GraphFilters operation, final IncludeIncomingOutgoingType inOutType) throws RangeFactoryException {
+        return Collections.singletonList(new Range(getKeyFromEdgeId(sourceVal, destVal, directed, inOutType, false), true,
+                getKeyFromEdgeId(sourceVal, destVal, directed, inOutType, true), true));
     }
 
     protected Key getKeyFromEdgeId(final Object sourceVal, final Object destVal, final DirectedType directed,
-                                   final GraphFilters operation,
+                                   final IncludeIncomingOutgoingType inOutType,
                                    final boolean endKey) throws RangeFactoryException {
-        final IncludeIncomingOutgoingType inOutType = (operation instanceof SeededGraphFilters) ? ((SeededGraphFilters) operation).getIncludeIncomingOutGoing() : IncludeIncomingOutgoingType.OUTGOING;
-
         final byte directionFlag1;
         if (DirectedType.isEither(directed)) {
             // Get directed and undirected edges

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/GetElementsInRangesIT.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/GetElementsInRangesIT.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2016-2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.accumulostore.integration;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.junit.Test;
+
+import uk.gov.gchq.gaffer.accumulostore.AccumuloProperties;
+import uk.gov.gchq.gaffer.accumulostore.MockAccumuloStore;
+import uk.gov.gchq.gaffer.accumulostore.key.core.impl.byteEntity.ByteEntityKeyPackage;
+import uk.gov.gchq.gaffer.accumulostore.key.core.impl.classic.ClassicKeyPackage;
+import uk.gov.gchq.gaffer.accumulostore.operation.impl.GetElementsInRanges;
+import uk.gov.gchq.gaffer.commonutil.pair.Pair;
+import uk.gov.gchq.gaffer.data.element.Edge;
+import uk.gov.gchq.gaffer.data.element.Element;
+import uk.gov.gchq.gaffer.graph.Graph;
+import uk.gov.gchq.gaffer.graph.GraphConfig;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.operation.data.EdgeSeed;
+import uk.gov.gchq.gaffer.operation.graph.SeededGraphFilters;
+import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
+import uk.gov.gchq.gaffer.store.schema.Schema;
+import uk.gov.gchq.gaffer.store.schema.SchemaEdgeDefinition;
+import uk.gov.gchq.gaffer.user.User;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class GetElementsInRangesIT {
+    @Test
+    public void shouldReturnSameResultsFromByteEntityAndClassicKeyPackages() throws OperationException {
+        // Given
+        final Schema schema = new Schema.Builder()
+                .edge("EDGE", new SchemaEdgeDefinition.Builder()
+                        .source("string")
+                        .destination("string")
+                        .build())
+                .type("string", String.class)
+                .build();
+
+        final AccumuloProperties propsByteEntity = new AccumuloProperties();
+        propsByteEntity.setStoreClass(MockAccumuloStore.class);
+        propsByteEntity.setKeyPackageClass(ByteEntityKeyPackage.class.getName());
+
+        final AccumuloProperties propsClassic = new AccumuloProperties();
+        propsClassic.setStoreClass(MockAccumuloStore.class);
+        propsClassic.setKeyPackageClass(ClassicKeyPackage.class.getName());
+
+        final Graph graphBE = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId("byteEntity")
+                        .build())
+                .addSchema(schema)
+                .storeProperties(propsByteEntity)
+                .build();
+        final Graph graphClassic = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId("classic")
+                        .build())
+                .addSchema(schema)
+                .storeProperties(propsClassic)
+                .build();
+
+        final List<Element> elements = Arrays.asList(
+                new Edge.Builder()
+                        .group("EDGE")
+                        .source("A")
+                        .dest("B")
+                        .directed(true)
+                        .build(),
+                new Edge.Builder()
+                        .group("EDGE")
+                        .source("A")
+                        .dest("C")
+                        .directed(false)
+                        .build()
+        );
+
+        graphBE.execute(new AddElements.Builder().input(elements).build(), new User());
+        graphClassic.execute(new AddElements.Builder().input(elements).build(), new User());
+
+        // Repeat test for all in/out values
+        final Set<SeededGraphFilters.IncludeIncomingOutgoingType> inOutTypes = Sets.newHashSet(SeededGraphFilters.IncludeIncomingOutgoingType.values());
+        inOutTypes.add(null);
+        for (final SeededGraphFilters.IncludeIncomingOutgoingType inOutType : inOutTypes) {
+
+            final GetElementsInRanges op = new GetElementsInRanges.Builder()
+                    .input(Collections.singletonList(new Pair<>(new EdgeSeed("A", "A"), new EdgeSeed("A", "Z"))))
+                    .inOutType(inOutType)
+                    .build();
+
+            // When
+            final List<? extends Element> byteEntityResults = Lists.newArrayList(graphBE.execute(op, new User()));
+            final List<? extends Element> classicResults = Lists.newArrayList(graphClassic.execute(op, new User()));
+
+            // Then
+            assertEquals(byteEntityResults.size(), classicResults.size());
+            assertEquals(new HashSet<>(byteEntityResults), new HashSet<>(classicResults));
+        }
+    }
+}


### PR DESCRIPTION
It is not perfect, but at least the 2 key packages now return the same results.

The change only affects the classic key package, as the byte entity package seemed to be returning the correct results. When the ranges are constructed, the incoming/outgoing flag is now ignored, but it is still used in an iterator to filter out any edges that are the wrong way around.