### PR TITLE
gh-1485 - Added options for pruning the data stored in the intermediate graph

### DIFF
--- a/core/data/src/main/java/uk/gov/gchq/gaffer/data/graph/adjacency/AdjacencyMap.java
+++ b/core/data/src/main/java/uk/gov/gchq/gaffer/data/graph/adjacency/AdjacencyMap.java
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.gchq.gaffer.data.graph;
+package uk.gov.gchq.gaffer.data.graph.adjacency;
 
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Sets;
 
+import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -26,7 +27,7 @@ import java.util.Set;
  * a format which can easily be interrogated.
  *
  * @param <T> the type of object representing the vertices
- * @param <U> the type of object representing the edge
+ * @param <U> the type of object representing the edges
  */
 public class AdjacencyMap<T, U> {
 
@@ -90,7 +91,7 @@ public class AdjacencyMap<T, U> {
      * @return a {@link Set} of the destination vertices
      */
     public Set<T> getDestinations(final T source) {
-        return graph.row(source).keySet();
+        return Collections.unmodifiableSet(graph.row(source).keySet());
     }
 
     /**
@@ -102,7 +103,31 @@ public class AdjacencyMap<T, U> {
      * @return a {@link Set} of the source vertices
      */
     public Set<T> getSources(final T destination) {
-        return graph.column(destination).keySet();
+        return Collections.unmodifiableSet(graph.column(destination).keySet());
     }
 
+    /**
+     * Get a {@link Set} containing all of the source vertices in this AdjacencyMap.
+     *
+     * @return an immutable set containing the source vertices
+     */
+    public Set<T> getAllSources() {
+        return Collections.unmodifiableSet(graph.rowKeySet());
+    }
+
+    /**
+     * Get a {@link Set} containing all of the destination vertices in this AdjacencyMap.
+     *
+     * @return an immutable set containing the destination vertices
+     */
+    public Set<T> getAllDestinations() {
+        return Collections.unmodifiableSet(graph.columnKeySet());
+    }
+
+    public void removeAllWithDestination(final T destination) {
+        final Set<T> set = graph.column(destination).keySet();
+        for (final T t : set) {
+            graph.remove(t, destination);
+        }
+    }
 }

--- a/core/data/src/main/java/uk/gov/gchq/gaffer/data/graph/adjacency/AdjacencyMaps.java
+++ b/core/data/src/main/java/uk/gov/gchq/gaffer/data/graph/adjacency/AdjacencyMaps.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.data.graph.adjacency;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * An {@code AdjacencyMaps} object contains a number of {@link AdjacencyMap}
+ * objects and can be used to represent the changes in an AdjacencyMap over time
+ * or to track the adjacency components of a graph over some other metric.
+ *
+ * @param <T> the type of object representing the vertices
+ * @param <U> the type of object representing the edges
+ */
+public interface AdjacencyMaps<T, U> extends Iterable<AdjacencyMap<T, U>> {
+
+    /**
+     * Add a new {@link AdjacencyMap}.
+     *
+     * @param adjacencyMap the AdjacencyMap to add
+     */
+    default void add(final AdjacencyMap<T, U> adjacencyMap) {
+        asList().add(adjacencyMap);
+    }
+
+    /**
+     * Retrieve the nth {@link AdjacencyMap}.
+     *
+     * @param n the index of the adjacency map to retrieve
+     *
+     * @return the nth AdjacencyMap
+     */
+    default AdjacencyMap<T, U> get(final int n) {
+        return asList().get(n);
+    }
+
+    /**
+     * Return the number of {@link AdjacencyMaps} present in the AdjacencyMaps
+     * object.
+     * <p>
+     * Depending on the context, this could refer to the number of hops present,
+     * or the number of timesteps etc.
+     *
+     * @return the size of the AdjacencyMaps object
+     */
+    default int size() {
+        return asList().size();
+    }
+
+    @Override
+    default Iterator<AdjacencyMap<T, U>> iterator() {
+        return asImmutableList().iterator();
+    }
+
+    /**
+     * Get a representation of the current AdjacencyMaps object as a {@link
+     * List}.
+     *
+     * @return a {@link List} representation of the current AdjacencyMaps object
+     */
+    List<AdjacencyMap<T, U>> asList();
+
+    /**
+     * Get a representation of the current AdjacencyMaps object as an immutable
+     * {@link List}.
+     *
+     * @return a immutable {@link List} representation of the current
+     * AdjacencyMaps object
+     */
+    List<AdjacencyMap<T, U>> asImmutableList();
+}

--- a/core/data/src/main/java/uk/gov/gchq/gaffer/data/graph/adjacency/PrunedAdjacencyMaps.java
+++ b/core/data/src/main/java/uk/gov/gchq/gaffer/data/graph/adjacency/PrunedAdjacencyMaps.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.data.graph.adjacency;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A {@code PrunedAdjacencyMaps} object represents a collection of {@link
+ * AdjacencyMap}s containing graph adjacency information.
+ * <p>
+ * As the {@link AdjacencyMap}s are added, a comparison is made between the
+ * destination vertices of the previous map and the source vertices of the newly
+ * added map. Any entries in the preceding map which do not join up with a
+ * source vertex in the new map are deemed to be orphaned paths, and are
+ * removed.
+ *
+ * @param <T> the type of object representing the vertices
+ * @param <U> the type of object representing the edges
+ */
+public class PrunedAdjacencyMaps<T, U> implements AdjacencyMaps<T, U> {
+
+    private final List<AdjacencyMap<T, U>> adjacencyMaps = new ArrayList<>();
+
+    @Override
+    public void add(final AdjacencyMap<T, U> adjacencyMap) {
+        if (!adjacencyMaps.isEmpty()) {
+            final AdjacencyMap<T, U> prev = adjacencyMaps.get(adjacencyMaps.size() - 1);
+
+            final Set<T> prevDestinations = prev.getAllDestinations();
+
+            for (final T dest : prevDestinations) {
+                if (!adjacencyMap.getAllSources().contains(dest)) {
+                    prev.removeAllWithDestination(dest);
+                }
+            }
+        }
+
+        adjacencyMaps.add(adjacencyMap);
+    }
+
+    @Override
+    public List<AdjacencyMap<T, U>> asList() {
+        return adjacencyMaps;
+    }
+
+    @Override
+    public List<AdjacencyMap<T, U>> asImmutableList() {
+        return Collections.unmodifiableList(adjacencyMaps);
+    }
+}

--- a/core/data/src/main/java/uk/gov/gchq/gaffer/data/graph/adjacency/SimpleAdjacencyMaps.java
+++ b/core/data/src/main/java/uk/gov/gchq/gaffer/data/graph/adjacency/SimpleAdjacencyMaps.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.data.graph.adjacency;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@code SimpleAdjacencyMaps} object represents a collection of {@link
+ * AdjacencyMap}s containing graph adjacency information.
+ *
+ * @param <T> the type of object representing the vertices
+ * @param <U> the type of object representing the edges
+ */
+public class SimpleAdjacencyMaps<T, U> implements AdjacencyMaps<T, U> {
+
+    private final List<AdjacencyMap<T, U>> adjacencyMaps = new ArrayList<>();
+
+    @Override
+    public void add(final AdjacencyMap<T, U> adjacencyMap) {
+        adjacencyMaps.add(adjacencyMap);
+    }
+
+    @Override
+    public List<AdjacencyMap<T, U>> asList() {
+        return adjacencyMaps;
+    }
+
+    @Override
+    public List<AdjacencyMap<T, U>> asImmutableList() {
+        return Collections.unmodifiableList(adjacencyMaps);
+    }
+}

--- a/core/data/src/main/java/uk/gov/gchq/gaffer/data/graph/adjacency/package-info.java
+++ b/core/data/src/main/java/uk/gov/gchq/gaffer/data/graph/adjacency/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Data objects used by Gaffer which are related to graph adjacency concepts.
+ */
+package uk.gov.gchq.gaffer.data.graph.adjacency;

--- a/core/data/src/test/java/uk/gov/gchq/gaffer/data/graph/WalkTest.java
+++ b/core/data/src/test/java/uk/gov/gchq/gaffer/data/graph/WalkTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.gchq.gaffer.data;
+package uk.gov.gchq.gaffer.data.graph;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.Sets;

--- a/core/data/src/test/java/uk/gov/gchq/gaffer/data/graph/adjacency/AdjacencyMapTest.java
+++ b/core/data/src/test/java/uk/gov/gchq/gaffer/data/graph/adjacency/AdjacencyMapTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.data.graph.adjacency;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.junit.Assert.assertNull;
+
+public class AdjacencyMapTest {
+
+    @Test
+    public void shouldGetDestinations() {
+        // Given
+        final AdjacencyMap<Object, Object> adjacencyMap = getAdjacencyMap();
+
+        // When
+        final Set<Object> results = adjacencyMap.getDestinations(1);
+
+        // Then
+        assertThat(results, hasItems(1, 2, 5));
+    }
+
+    @Test
+    public void shouldGetAllDestinations() {
+        // Given
+        final AdjacencyMap<Object, Object> adjacencyMap = getAdjacencyMap();
+
+        // When
+        final Set<Object> results = adjacencyMap.getAllDestinations();
+
+        // Then
+        assertThat(results, hasItems(1, 2, 3, 4, 5, 6));
+    }
+
+    @Test
+    public void shouldGetSources() {
+        // Given
+        final AdjacencyMap<Object, Object> adjacencyMap = getAdjacencyMap();
+
+        // When
+        final Set<Object> results = adjacencyMap.getSources(1);
+
+        // Then
+        assertThat(results, hasItems(1, 4));
+    }
+
+    @Test
+    public void shouldGetAllSources() {
+        // Given
+        final AdjacencyMap<Object, Object> adjacencyMap = getAdjacencyMap();
+
+        // When
+        final Set<Object> results = adjacencyMap.getAllSources();
+
+        // Then
+        assertThat(results, hasItems(1, 2, 4, 5, 6));
+    }
+
+    @Test
+    public void shouldGetEntry() {
+        // Given
+        final AdjacencyMap<Object, Object> adjacencyMap = getAdjacencyMap();
+
+        // When
+        final Set<Object> results = adjacencyMap.get(1, 2);
+
+        // Then
+        assertThat(results, equalTo(Collections.singleton(1)));
+    }
+
+    @Test
+    public void shouldReturnNullWhenEntryDoesNotExist() {
+        // Given
+        final AdjacencyMap<Object, Object> adjacencyMap = getAdjacencyMap();
+
+        // When
+        final Set<Object> results = adjacencyMap.get(1, 3);
+
+        // Then
+        assertNull(results);
+    }
+
+    private AdjacencyMap<Object, Object> getAdjacencyMap() {
+        final AdjacencyMap<Object, Object> adjacencyMap = new AdjacencyMap<>();
+        adjacencyMap.put(1, 2, 1);
+        adjacencyMap.put(2, 3, 1);
+        adjacencyMap.put(6, 3, 1);
+        adjacencyMap.put(5, 6, 1);
+        adjacencyMap.put(5, 4, 1);
+        adjacencyMap.put(4, 1, 1);
+        adjacencyMap.put(1, 5, 1);
+        adjacencyMap.put(1, 1, 1);
+
+        return adjacencyMap;
+    }
+}

--- a/core/data/src/test/java/uk/gov/gchq/gaffer/data/graph/adjacency/AdjacencyMapsTest.java
+++ b/core/data/src/test/java/uk/gov/gchq/gaffer/data/graph/adjacency/AdjacencyMapsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.data.graph.adjacency;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+
+@RunWith(Parameterized.class)
+public class AdjacencyMapsTest {
+
+    private final AdjacencyMaps<Object, Object> adjacencyMaps;
+
+    @Parameters
+    public static Collection<Object[]> instancesToTest() {
+        return Arrays.asList(new Object[][]{
+                {new SimpleAdjacencyMaps<>()},
+                {new PrunedAdjacencyMaps<>()}
+        });
+    }
+
+    public AdjacencyMapsTest(final AdjacencyMaps<Object, Object> adjacencyMaps) {
+        this.adjacencyMaps = adjacencyMaps;
+    }
+
+    @Test
+    public void shouldIterate() {
+        // When
+        adjacencyMaps.add(getAdjacencyMap(3));
+        adjacencyMaps.add(getAdjacencyMap(4));
+
+        // Then
+        final Iterator<AdjacencyMap<Object, Object>> it = adjacencyMaps.iterator();
+
+        final AdjacencyMap<Object, Object> first = it.next();
+        final AdjacencyMap<Object, Object> second = it.next();
+
+        assertThat(first.getAllDestinations(), hasSize(3));
+        assertThat(second.getAllDestinations(), hasSize(4));
+    }
+
+    private AdjacencyMap<Object, Object> getAdjacencyMap(final int size) {
+
+        final AdjacencyMap<Object, Object> adjacencyMap = new AdjacencyMap<>();
+
+        for (int i = 0; i < size; i++) {
+            adjacencyMap.put(i, i + 1, i);
+        }
+
+        return adjacencyMap;
+    }
+}

--- a/core/data/src/test/java/uk/gov/gchq/gaffer/data/graph/adjacency/PrunedAdjacencyMapsTest.java
+++ b/core/data/src/test/java/uk/gov/gchq/gaffer/data/graph/adjacency/PrunedAdjacencyMapsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.data.graph.adjacency;
+
+import org.hamcrest.collection.IsCollectionWithSize;
+import org.hamcrest.core.IsCollectionContaining;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.*;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.hamcrest.core.IsNot.not;
+
+public class PrunedAdjacencyMapsTest {
+
+    @Test
+    public void shouldPrune() {
+        // Given
+        final AdjacencyMaps<Object, Object> adjacencyMaps = new PrunedAdjacencyMaps<>();
+
+        final AdjacencyMap<Object, Object> first = new AdjacencyMap<>();
+        first.put(1, 2, 1);
+        first.put(1, 3, 1);
+
+        final AdjacencyMap<Object, Object> second = new AdjacencyMap<>();
+        second.put(2, 3, 1);
+        second.put(2, 4, 1);
+
+        // There are no edges which follow on from the edge 1->3 in the first
+        // adjacency map.
+
+        // When
+        adjacencyMaps.add(first);
+        adjacencyMaps.add(second);
+
+        // Then
+        final AdjacencyMap<Object,Object> firstPruned = adjacencyMaps.get(0);
+        final AdjacencyMap<Object,Object> secondPruned = adjacencyMaps.get(1);
+
+        assertThat(firstPruned.getDestinations(1), hasSize(1));
+        assertThat(secondPruned.getDestinations(2), hasSize(2));
+    }
+}

--- a/core/data/src/test/java/uk/gov/gchq/gaffer/data/graph/adjacency/SimpleAdjacencyMapsTest.java
+++ b/core/data/src/test/java/uk/gov/gchq/gaffer/data/graph/adjacency/SimpleAdjacencyMapsTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.data.graph.adjacency;
+
+public class SimpleAdjacencyMapsTest {
+    // Empty
+}

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/GetWalks.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/GetWalks.java
@@ -54,6 +54,7 @@ public class GetWalks implements
     private Iterable<? extends EntityId> input;
     private Map<String, String> options;
     private Integer resultsLimit = 1000000;
+    private boolean prune = false;
 
     @Override
     public Iterable<? extends EntityId> getInput() {
@@ -145,6 +146,14 @@ public class GetWalks implements
         this.resultsLimit = resultsLimit;
     }
 
+    public boolean isPrune() {
+        return prune;
+    }
+
+    public void setPrune(final boolean prune) {
+        this.prune = prune;
+    }
+
     public static final class Builder
             extends Operation.BaseBuilder<GetWalks, Builder>
             implements InputOutput.Builder<GetWalks, Iterable<? extends EntityId>, Iterable<Walk>, Builder>,
@@ -173,6 +182,11 @@ public class GetWalks implements
 
         public Builder resultsLimit(final Integer resultLimit) {
             _getOp().setResultsLimit(resultLimit);
+            return _self();
+        }
+
+        public Builder prune(final boolean prune) {
+            _getOp().setPrune(prune);
             return _self();
         }
     }

--- a/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/GraphAlgorithmsIT.java
+++ b/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/GraphAlgorithmsIT.java
@@ -96,6 +96,35 @@ public class GraphAlgorithmsIT extends AbstractStoreIT {
     }
 
     @Test
+    public void shouldGetPathsWithPruning() throws Exception {
+        // Given
+        final User user = new User();
+
+        final EntitySeed seed = new EntitySeed("A");
+
+        final GetElements operation = new GetElements.Builder()
+                .directedType(DirectedType.DIRECTED)
+                .view(new View.Builder()
+                        .edge(TestGroups.EDGE, new ViewElementDefinition.Builder()
+                                .properties(TestPropertyNames.COUNT)
+                                .build())
+                        .build()).inOutType(SeededGraphFilters.IncludeIncomingOutgoingType.OUTGOING)
+                .build();
+
+        final GetWalks op = new GetWalks.Builder()
+                .input(seed)
+                .operations(operation, operation)
+                .prune(true)
+                .build();
+
+        // When
+        final Iterable<Walk> results = graph.execute(op, user);
+
+        // Then
+        assertThat(getPaths(results), is(equalTo("AED,ABC")));
+    }
+
+    @Test
     public void shouldGetPathsWithMultipleSeeds() throws Exception {
         // Given
         final User user = new User();


### PR DESCRIPTION
Added some functionality to allow the user to specify pruning of orphaned edges when creating a ```Walk``` using the ```GetWalks``` operation.

This has required making some changes to the ```AdjacencyMap``` class (and related classes) to increase the flexibility.