### PR TITLE
gh-1601 - JsonPropertyOrder annotation added

### DIFF
--- a/core/data/src/main/java/uk/gov/gchq/gaffer/data/element/Edge.java
+++ b/core/data/src/main/java/uk/gov/gchq/gaffer/data/element/Edge.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.slf4j.Logger;
@@ -42,6 +43,8 @@ import java.util.Comparator;
  *
  * @see uk.gov.gchq.gaffer.data.element.Edge.Builder
  */
+@JsonPropertyOrder(value = {"class", "group", "source", "destination",
+        "directed", "matchedVertex", "properties"}, alphabetic = true)
 public class Edge extends Element implements EdgeId {
     private static final Logger LOGGER = LoggerFactory.getLogger(Edge.class);
     private static final long serialVersionUID = -5596452468277807842L;

--- a/core/data/src/main/java/uk/gov/gchq/gaffer/data/element/Entity.java
+++ b/core/data/src/main/java/uk/gov/gchq/gaffer/data/element/Entity.java
@@ -18,6 +18,7 @@ package uk.gov.gchq.gaffer.data.element;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.slf4j.Logger;
@@ -36,6 +37,7 @@ import uk.gov.gchq.gaffer.data.element.id.EntityId;
  *
  * @see uk.gov.gchq.gaffer.data.element.Entity.Builder
  */
+@JsonPropertyOrder(value = {"class", "group", "vertex", "properties"}, alphabetic = true)
 public class Entity extends Element implements EntityId {
     private static final Logger LOGGER = LoggerFactory.getLogger(Entity.class);
     private static final long serialVersionUID = 2863628004463113755L;

--- a/core/data/src/main/java/uk/gov/gchq/gaffer/data/element/comparison/ElementPropertyComparator.java
+++ b/core/data/src/main/java/uk/gov/gchq/gaffer/data/element/comparison/ElementPropertyComparator.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.data.element.comparison;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.collect.Sets;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -48,6 +49,7 @@ import java.util.Set;
  * There is a reversed option to allow you to flip the comparison value.
  * </p>
  */
+@JsonPropertyOrder(value = {"class", "property", "comparator", "groups"}, alphabetic = true)
 @SuppressFBWarnings(value = "SE_COMPARATOR_SHOULD_BE_SERIALIZABLE",
         justification = "This class should not be serialised")
 public class ElementPropertyComparator implements ElementComparator {

--- a/core/data/src/main/java/uk/gov/gchq/gaffer/data/element/function/ElementFilter.java
+++ b/core/data/src/main/java/uk/gov/gchq/gaffer/data/element/function/ElementFilter.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.data.element.function;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
@@ -34,6 +35,7 @@ import java.util.function.Predicate;
  * An {@code ElementFilter} is a {@link Predicate} which evaluates a condition against
  * a provided {@link Element} object.
  */
+@JsonPropertyOrder(alphabetic = true)
 public class ElementFilter extends TupleAdaptedPredicateComposite<String> {
     private final ElementTuple elementTuple = new ElementTuple();
     private boolean readOnly;

--- a/core/data/src/main/java/uk/gov/gchq/gaffer/data/elementdefinition/view/GlobalViewElementDefinition.java
+++ b/core/data/src/main/java/uk/gov/gchq/gaffer/data/elementdefinition/view/GlobalViewElementDefinition.java
@@ -17,6 +17,7 @@
 package uk.gov.gchq.gaffer.data.elementdefinition.view;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -33,6 +34,18 @@ import java.util.Set;
  * A {@code GlobalViewElementDefinition} is an {@link ViewElementDefinition} containing
  * a {@link Set} of group names.
  */
+@JsonPropertyOrder(value = {
+        "groups",
+        "preAggregationFilter",
+        "groupBy",
+        "aggregator",
+        "postAggregationFilter",
+        "transientProperties",
+        "transformer",
+        "postTransformFilter",
+        "properties",
+        "excludeProperties"
+}, alphabetic = true)
 @JsonDeserialize(builder = GlobalViewElementDefinition.Builder.class)
 public class GlobalViewElementDefinition extends ViewElementDefinition {
     protected Set<String> groups;

--- a/core/data/src/main/java/uk/gov/gchq/gaffer/data/elementdefinition/view/View.java
+++ b/core/data/src/main/java/uk/gov/gchq/gaffer/data/elementdefinition/view/View.java
@@ -17,6 +17,7 @@
 package uk.gov.gchq.gaffer.data.elementdefinition.view;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -57,6 +58,7 @@ import java.util.function.Function;
  * @see uk.gov.gchq.gaffer.data.element.function.ElementTransformer
  */
 @JsonDeserialize(builder = View.Builder.class)
+@JsonPropertyOrder(value = {"class", "edges", "entities"}, alphabetic = true)
 public class View extends ElementDefinitions<ViewElementDefinition, ViewElementDefinition> implements Cloneable {
     private List<GlobalViewElementDefinition> globalElements;
     private List<GlobalViewElementDefinition> globalEntities;

--- a/core/data/src/main/java/uk/gov/gchq/gaffer/data/elementdefinition/view/ViewElementDefinition.java
+++ b/core/data/src/main/java/uk/gov/gchq/gaffer/data/elementdefinition/view/ViewElementDefinition.java
@@ -18,6 +18,7 @@ package uk.gov.gchq.gaffer.data.elementdefinition.view;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -51,6 +52,17 @@ import java.util.Set;
  * A {@code ViewElementDefinition} is an {@link ElementDefinition} containing
  * transient properties, an {@link ElementTransformer} and two {@link ElementFilter}s.
  */
+@JsonPropertyOrder(value = {
+        "preAggregationFilter",
+        "groupBy",
+        "aggregator",
+        "postAggregationFilter",
+        "transientProperties",
+        "transformer",
+        "postTransformFilter",
+        "properties",
+        "excludeProperties"
+}, alphabetic = true)
 @JsonDeserialize(builder = ViewElementDefinition.Builder.class)
 public class ViewElementDefinition implements ElementDefinition {
     protected ElementFilter preAggregationFilter;

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/GraphConfig.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/GraphConfig.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.graph;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.commons.io.FileUtils;
 
@@ -48,6 +49,7 @@ import java.util.List;
  *
  * @see uk.gov.gchq.gaffer.graph.GraphConfig.Builder
  */
+@JsonPropertyOrder(value = {"description", "graphId"}, alphabetic = true)
 public final class GraphConfig {
     private String graphId;
     private View view;

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/hook/AddOperationsToChain.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/hook/AddOperationsToChain.java
@@ -16,6 +16,8 @@
 
 package uk.gov.gchq.gaffer.graph.hook;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.OperationChain;
 import uk.gov.gchq.gaffer.operation.Operations;
@@ -33,6 +35,7 @@ import java.util.Map;
  * A user can also specify authorised Operations to add, and if the user has
  * the opAuths, the additional Operations will be added to the chain.
  */
+@JsonPropertyOrder(value = {"class", "start", "before", "after", "end", "authorisedOps"}, alphabetic = true)
 public class AddOperationsToChain implements GraphHook {
     private final AdditionalOperations defaultOperations = new AdditionalOperations();
     private final LinkedHashMap<String, AdditionalOperations> authorisedOps = new LinkedHashMap<>();

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/hook/AdditionalOperations.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/hook/AdditionalOperations.java
@@ -16,6 +16,8 @@
 
 package uk.gov.gchq.gaffer.graph.hook;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import uk.gov.gchq.gaffer.exception.SerialisationException;
 import uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser;
 import uk.gov.gchq.gaffer.operation.Operation;
@@ -30,6 +32,7 @@ import java.util.Map;
  * Used by the {@link AddOperationsToChain} operation to store details around which
  * operations to add to the chain.
  */
+@JsonPropertyOrder(value = {"class", "start", "before", "after", "end"}, alphabetic = true)
 public class AdditionalOperations {
     private List<byte[]> start;
     private List<byte[]> end;

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/hook/Log4jLogger.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/hook/Log4jLogger.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.graph.hook;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +27,7 @@ import uk.gov.gchq.gaffer.store.Context;
  * A {@code Log4jLogger} is a simple {@link GraphHook} that sends logs of the
  * original operation chains executed by users on a graph to a {@link Logger}.
  */
+@JsonPropertyOrder(alphabetic = true)
 public class Log4jLogger implements GraphHook {
     private static final Logger LOGGER = LoggerFactory.getLogger(Log4jLogger.class);
 

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/hook/OperationAuthoriser.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/hook/OperationAuthoriser.java
@@ -18,6 +18,7 @@ package uk.gov.gchq.gaffer.graph.hook;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
 import uk.gov.gchq.gaffer.commonutil.CollectionUtil;
@@ -41,6 +42,7 @@ import java.util.Set;
  * user is authorised to execute an operation chain. This class requires a map
  * of operation authorisations.
  */
+@JsonPropertyOrder(alphabetic = true)
 public class OperationAuthoriser implements GraphHook {
     private final Set<String> allAuths = new HashSet<>();
     private final Map<Class<?>, Set<String>> auths = new HashMap<>();

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/hook/OperationChainLimiter.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/hook/OperationChainLimiter.java
@@ -16,6 +16,7 @@
 package uk.gov.gchq.gaffer.graph.hook;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
 import uk.gov.gchq.gaffer.commonutil.exception.UnauthorisedException;
@@ -37,14 +38,13 @@ import java.util.Map;
  * And then gaffer.operation.impl.add = 1
  * The add elements will have a score of 1 not 8.
  * So make sure to write your properties file in class hierarchical order.
- *
  * This class also requires a map of authorisation scores,
  * this is the score value someone with that auth can have, the maximum score value of a users auths is used.
- *
  * The class delegates the logic to {@link ScoreOperationChainHandler}. If you
  * wish to use the {@link uk.gov.gchq.gaffer.operation.impl.ScoreOperationChain} operation and this graph hook,
  * then both need to have the same score configuration.
  */
+@JsonPropertyOrder(alphabetic = true)
 public class OperationChainLimiter implements GraphHook {
     private ScoreOperationChainHandler scorer = new ScoreOperationChainHandler();
 
@@ -54,7 +54,7 @@ public class OperationChainLimiter implements GraphHook {
      * Then checking the operation score of all operations in the chain and comparing the total score value of the chain against a users maximum score limit.
      * If an operation cannot be executed then an {@link IllegalAccessError} is thrown.
      *
-     * @param context    the Context containing the user to authorise.
+     * @param context the Context containing the user to authorise.
      * @param opChain the operation chain.
      */
     @Override
@@ -107,6 +107,7 @@ public class OperationChainLimiter implements GraphHook {
     public void setAuthScores(final Map<String, Integer> authScores) {
         scorer.setAuthScores(authScores);
     }
+
     public Map<Class<? extends Operation>, ScoreResolver> getScoreResolvers() {
         return scorer.getScoreResolvers();
     }

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/operation/export/graph/ExportToOtherAuthorisedGraph.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/operation/export/graph/ExportToOtherAuthorisedGraph.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.export.graph;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Lists;
 
@@ -36,6 +37,7 @@ import java.util.Map;
  * The graphs that are available to be exported to are limited to predefined set.
  * This is a more restricted version of {@link ExportToOtherGraph}.
  */
+@JsonPropertyOrder(value = {"class", "graphId", "input"}, alphabetic = true)
 public class ExportToOtherAuthorisedGraph implements
         MultiInput<Element>,
         ExportTo<Iterable<? extends Element>> {

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/operation/export/graph/ExportToOtherGraph.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/operation/export/graph/ExportToOtherGraph.java
@@ -18,6 +18,7 @@ package uk.gov.gchq.gaffer.operation.export.graph;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Lists;
@@ -40,6 +41,7 @@ import java.util.Properties;
  * out a query on a Gaffer {@link uk.gov.gchq.gaffer.graph.Graph} to a different
  * graph.
  */
+@JsonPropertyOrder(value = {"class", "graphId", "input"}, alphabetic = true)
 public class ExportToOtherGraph implements
         MultiInput<Element>,
         ExportTo<Iterable<? extends Element>> {

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/operation/export/graph/ExportToOtherGraph.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/operation/export/graph/ExportToOtherGraph.java
@@ -41,7 +41,7 @@ import java.util.Properties;
  * out a query on a Gaffer {@link uk.gov.gchq.gaffer.graph.Graph} to a different
  * graph.
  */
-@JsonPropertyOrder(value = {"class", "graphId", "input"}, alphabetic = true)
+@JsonPropertyOrder(value = {"class", "input", "graphId"}, alphabetic = true)
 public class ExportToOtherGraph implements
         MultiInput<Element>,
         ExportTo<Iterable<? extends Element>> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/AddNamedOperation.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/AddNamedOperation.java
@@ -18,6 +18,7 @@ package uk.gov.gchq.gaffer.named.operation;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -38,6 +39,7 @@ import java.util.Map;
  * A {@code AddNamedOperation} is an {@link Operation} for creating a new {@link NamedOperation}
  * and adding it to a Gaffer graph.
  */
+@JsonPropertyOrder(value = {"class", "operationName", "description", "score", "operations"}, alphabetic = true)
 public class AddNamedOperation implements Operation {
     private String operations = null;
     private String operationName;

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/DeleteNamedOperation.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/DeleteNamedOperation.java
@@ -16,6 +16,8 @@
 
 package uk.gov.gchq.gaffer.named.operation;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import uk.gov.gchq.gaffer.commonutil.Required;
 import uk.gov.gchq.gaffer.operation.Operation;
 
@@ -25,6 +27,7 @@ import java.util.Map;
  * A {@code DeleteNamedOperation} is an {@link Operation} for removing an existing
  * {@link NamedOperation} from a Gaffer graph.
  */
+@JsonPropertyOrder(value = {"class", "operationName"}, alphabetic = true)
 public class DeleteNamedOperation implements Operation {
     @Required
     private String operationName;

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/GetAllNamedOperations.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/GetAllNamedOperations.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.named.operation;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.commonutil.iterable.CloseableIterable;
@@ -28,6 +29,7 @@ import java.util.Map;
  * A {@link GetAllNamedOperations} is an {@link uk.gov.gchq.gaffer.operation.Operation}
  * for retrieving all {@link NamedOperation}s associated with a Gaffer graph.
  */
+@JsonPropertyOrder(value = {"class"}, alphabetic = true)
 public class GetAllNamedOperations implements
         Output<CloseableIterable<NamedOperationDetail>> {
     private Map<String, String> options;

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/NamedOperation.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/NamedOperation.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.named.operation;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.commonutil.Required;
@@ -41,6 +42,7 @@ import java.util.Map;
  * @param <I_ITEM> the input iterable item type
  * @param <O>      the output type
  */
+@JsonPropertyOrder(value = {"class", "input", "operationName"}, alphabetic = true)
 public class NamedOperation<I_ITEM, O> implements
         InputOutput<Iterable<? extends I_ITEM>, O>,
         MultiInput<I_ITEM> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/OperationChain.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/OperationChain.java
@@ -18,6 +18,7 @@ package uk.gov.gchq.gaffer.operation;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Lists;
@@ -58,6 +59,7 @@ import java.util.stream.Collectors;
  *              {@link uk.gov.gchq.gaffer.operation.Operation} in the chain.
  * @see uk.gov.gchq.gaffer.operation.OperationChain.Builder
  */
+@JsonPropertyOrder(value = {"class", "operations"}, alphabetic = true)
 public class OperationChain<OUT> implements Output<OUT>,
         Operations<Operation> {
     private List<Operation> operations;

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/data/EdgeSeed.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/data/EdgeSeed.java
@@ -18,6 +18,7 @@ package uk.gov.gchq.gaffer.operation.data;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.gaffer.commonutil.ToStringBuilder;
@@ -32,6 +33,7 @@ import java.util.Comparator;
  * {@link uk.gov.gchq.gaffer.data.element.Edge}.
  * It is mainly used as a seed for queries.
  */
+@JsonPropertyOrder(value = {"class", "source", "destination", "directed", "matchedVertex"}, alphabetic = true)
 public class EdgeSeed extends ElementSeed implements EdgeId {
     private static final long serialVersionUID = -8137886975649690000L;
     private static final Comparator<Object> VERTEX_COMPARATOR = new ComparableOrToStringComparator();
@@ -73,7 +75,7 @@ public class EdgeSeed extends ElementSeed implements EdgeId {
     }
 
     @JsonCreator
-    public EdgeSeed(@JsonProperty("source")  final Object source,
+    public EdgeSeed(@JsonProperty("source") final Object source,
                     @JsonProperty("destination") final Object destination,
                     @JsonProperty("directed") final Boolean directed,
                     @JsonProperty("directedType") final DirectedType directedType,

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/data/EntitySeed.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/data/EntitySeed.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.data;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
 import uk.gov.gchq.gaffer.commonutil.ToStringBuilder;
@@ -27,6 +28,7 @@ import java.util.Objects;
  * An {@code EntitySeed} contains a single vertex for an {@link uk.gov.gchq.gaffer.data.element.Entity}.
  * It is mainly used as a seed for queries.
  */
+@JsonPropertyOrder(value = {"class", "vertex"}, alphabetic = true)
 public class EntitySeed extends ElementSeed implements EntityId {
     private static final long serialVersionUID = -1668220155074029644L;
     private Object vertex;

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/Count.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/Count.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.operation.impl;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.operation.Operation;
@@ -29,6 +30,7 @@ import java.util.Map;
  *
  * @see Count.Builder
  */
+@JsonPropertyOrder(value = {"class", "input"}, alphabetic = true)
 public class Count<T> implements
         InputOutput<Iterable<? extends T>, Long>,
         MultiInput<T> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/CountGroups.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/CountGroups.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.data.GroupCounts;
@@ -35,6 +36,7 @@ import java.util.Map;
  *
  * @see CountGroups.Builder
  */
+@JsonPropertyOrder(value = {"class", "input"}, alphabetic = true)
 public class CountGroups implements
         InputOutput<Iterable<? extends Element>, GroupCounts>,
         MultiInput<Element> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/DiscardOutput.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/DiscardOutput.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.commons.lang3.exception.CloneFailedException;
 
 import uk.gov.gchq.gaffer.operation.io.Input;
@@ -26,6 +27,7 @@ import java.util.Map;
  * A {@code DiscardOutput} operation is used as a terminal operation to indicate
  * that the results from the previous operation are not used again.
  */
+@JsonPropertyOrder(value = {"class"}, alphabetic = true)
 public class DiscardOutput implements
         Input<Object> {
 

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/GetWalks.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/GetWalks.java
@@ -17,6 +17,7 @@
 package uk.gov.gchq.gaffer.operation.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.commonutil.stream.Streams;
@@ -49,6 +50,7 @@ import java.util.stream.Collectors;
  * GetElements} operations. These are executed sequentially, with the output of
  * one operation providing the input {@link EntityId}s for the next.
  */
+@JsonPropertyOrder(value = {"class", "input", "operations"}, alphabetic = true)
 public class GetWalks implements
         InputOutput<Iterable<? extends EntityId>, Iterable<Walk>>,
         MultiInput<EntityId>,

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/Limit.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/Limit.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.commonutil.Required;
@@ -34,6 +35,7 @@ import java.util.Map;
  *
  * @see Limit.Builder
  */
+@JsonPropertyOrder(value = {"class", "input", "resultsLimit"}, alphabetic = true)
 public class Limit<T> implements
         InputOutput<Iterable<? extends T>, Iterable<? extends T>>,
         MultiInput<T> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/Map.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/Map.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.operation.impl;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.lang3.exception.CloneFailedException;
@@ -36,6 +37,7 @@ import java.util.function.Function;
  * @param <I> the type of the input object
  * @param <O> the type of the output object
  */
+@JsonPropertyOrder(value = {"class", "input", "functions"}, alphabetic = true)
 public class Map<I, O> implements InputOutput<I, O> {
     private I input;
     private java.util.Map<String, String> options;

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/SampleElementsForSplitPoints.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/SampleElementsForSplitPoints.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.operation.impl;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.data.element.Element;
@@ -57,6 +58,7 @@ import java.util.Map;
  * @param <T> the type of splits
  * @see SampleElementsForSplitPoints.Builder
  */
+@JsonPropertyOrder(value = {"class", "input"}, alphabetic = true)
 public class SampleElementsForSplitPoints<T> implements
         Operation,
         InputOutput<Iterable<? extends Element>, List<T>>,

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/ScoreOperationChain.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/ScoreOperationChain.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.operation.OperationChain;
@@ -29,6 +30,7 @@ import java.util.Map;
  * and is used to determine whether a particular user has the required permissions
  * to execute a given {@link OperationChain}.
  */
+@JsonPropertyOrder(value = {"class", "operationChain"}, alphabetic = true)
 public class ScoreOperationChain implements Output<Integer> {
     private OperationChain operationChain;
     private Map<String, String> options;

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/SplitStore.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/SplitStore.java
@@ -15,6 +15,8 @@
  */
 package uk.gov.gchq.gaffer.operation.impl;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import uk.gov.gchq.gaffer.commonutil.Required;
 import uk.gov.gchq.gaffer.operation.Operation;
 
@@ -28,6 +30,7 @@ import java.util.Map;
  * @deprecated use {@link SplitStoreFromFile} instead
  */
 @Deprecated
+@JsonPropertyOrder(value = {"class"}, alphabetic = true)
 public class SplitStore implements Operation {
     @Required
     private String inputPath;

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/SplitStoreFromFile.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/SplitStoreFromFile.java
@@ -15,6 +15,8 @@
  */
 package uk.gov.gchq.gaffer.operation.impl;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import uk.gov.gchq.gaffer.commonutil.Required;
 import uk.gov.gchq.gaffer.operation.Operation;
 
@@ -30,6 +32,7 @@ import java.util.Map;
  *
  * @see SplitStoreFromFile.Builder
  */
+@JsonPropertyOrder(value = {"class", "inputPath"}, alphabetic = true)
 public class SplitStoreFromFile implements Operation {
     @Required
     private String inputPath;

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/SplitStoreFromIterable.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/SplitStoreFromIterable.java
@@ -15,6 +15,8 @@
  */
 package uk.gov.gchq.gaffer.operation.impl;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.io.MultiInput;
 
@@ -27,6 +29,7 @@ import java.util.Map;
  * @param <T> the type of splits
  * @see SplitStoreFromIterable.Builder
  */
+@JsonPropertyOrder(value = {"class", "input"}, alphabetic = true)
 public class SplitStoreFromIterable<T> implements Operation,
         MultiInput<T> {
     private Iterable<? extends T> input;

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/Validate.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/Validate.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.data.element.Element;
@@ -36,6 +37,7 @@ import java.util.Map;
  *
  * @see uk.gov.gchq.gaffer.operation.impl.Validate.Builder
  */
+@JsonPropertyOrder(value = {"class", "input"}, alphabetic = true)
 public class Validate implements
         Validatable,
         InputOutput<Iterable<? extends Element>, Iterable<? extends Element>>,

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/add/AddElements.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/add/AddElements.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl.add;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -37,6 +38,7 @@ import java.util.Map;
  *
  * @see uk.gov.gchq.gaffer.operation.impl.add.AddElements.Builder
  */
+@JsonPropertyOrder(value = {"class", "elements"}, alphabetic = true)
 public class AddElements implements
         Validatable,
         MultiInput<Element> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/add/AddElementsFromFile.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/add/AddElementsFromFile.java
@@ -15,6 +15,8 @@
  */
 package uk.gov.gchq.gaffer.operation.impl.add;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import uk.gov.gchq.gaffer.commonutil.Required;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.operation.Operation;
@@ -31,6 +33,7 @@ import java.util.function.Function;
  *
  * @see Builder
  */
+@JsonPropertyOrder(value = {"class", "file", "elementGenerator"}, alphabetic = true)
 public class AddElementsFromFile implements
         Operation,
         Validatable {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/add/AddElementsFromFile.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/add/AddElementsFromFile.java
@@ -33,7 +33,7 @@ import java.util.function.Function;
  *
  * @see Builder
  */
-@JsonPropertyOrder(value = {"class", "file", "elementGenerator"}, alphabetic = true)
+@JsonPropertyOrder(value = {"class", "filename", "elementGenerator"}, alphabetic = true)
 public class AddElementsFromFile implements
         Operation,
         Validatable {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/add/AddElementsFromKafka.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/add/AddElementsFromKafka.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.operation.impl.add;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import uk.gov.gchq.gaffer.commonutil.Required;
@@ -35,6 +36,7 @@ import java.util.function.Function;
  *
  * @see Builder
  */
+@JsonPropertyOrder(value = {"class", "topic", "groupId", "bootstrapServers", "elementGenerator"}, alphabetic = true)
 public class AddElementsFromKafka implements
         Operation,
         Validatable {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/add/AddElementsFromSocket.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/add/AddElementsFromSocket.java
@@ -15,6 +15,8 @@
  */
 package uk.gov.gchq.gaffer.operation.impl.add;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import uk.gov.gchq.gaffer.commonutil.Required;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.operation.Operation;
@@ -34,6 +36,7 @@ import java.util.function.Function;
  *
  * @see Builder
  */
+@JsonPropertyOrder(value = {"class", "hostname", "port", "elementGenerator"}, alphabetic = true)
 public class AddElementsFromSocket implements
         Operation,
         Validatable {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/compare/Max.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/compare/Max.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl.compare;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Lists;
@@ -46,6 +47,7 @@ import java.util.Map;
  * @see uk.gov.gchq.gaffer.operation.impl.compare.Max.Builder
  * @see uk.gov.gchq.gaffer.data.element.comparison.ElementPropertyComparator
  */
+@JsonPropertyOrder(value = {"class", "input", "comparators"}, alphabetic = true)
 public class Max implements
         InputOutput<Iterable<? extends Element>, Element>,
         MultiInput<Element>,

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/compare/Min.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/compare/Min.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.operation.impl.compare;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Lists;
@@ -45,6 +46,7 @@ import java.util.Map;
  * @see uk.gov.gchq.gaffer.operation.impl.compare.Min.Builder
  * @see uk.gov.gchq.gaffer.data.element.comparison.ElementPropertyComparator
  */
+@JsonPropertyOrder(value = {"class", "input", "comparators"}, alphabetic = true)
 public class Min implements
         InputOutput<Iterable<? extends Element>, Element>,
         MultiInput<Element>,

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/compare/Sort.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/compare/Sort.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.operation.impl.compare;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Lists;
@@ -47,6 +48,7 @@ import java.util.Map;
  * @see uk.gov.gchq.gaffer.operation.impl.compare.Sort.Builder
  * @see uk.gov.gchq.gaffer.data.element.comparison.ElementPropertyComparator
  */
+@JsonPropertyOrder(value = {"class", "input", "comparators"}, alphabetic = true)
 public class Sort implements
         InputOutput<Iterable<? extends Element>, Iterable<? extends Element>>,
         MultiInput<Element>,

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/export/GetExports.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/export/GetExports.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl.export;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -36,6 +37,7 @@ import java.util.Map;
  * The keys in the map are: "[ExportOperationClassName]: [key]"
  * The values in the map are the exported values.
  */
+@JsonPropertyOrder(value = {"class", "getExports"}, alphabetic = true)
 public class GetExports implements
         Output<Map<String, CloseableIterable<?>>> {
     private List<GetExport> getExports = new ArrayList<>();

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/export/resultcache/ExportToGafferResultCache.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/export/resultcache/ExportToGafferResultCache.java
@@ -32,7 +32,7 @@ import java.util.Set;
  * a cache. The cache is backed by a simple Gaffer graph that can be configured.
  * The results can be of any type - as long as they are json serialisable.
  */
-@JsonPropertyOrder(value = {"class", "key", "input"}, alphabetic = true)
+@JsonPropertyOrder(value = {"class", "input", "key"}, alphabetic = true)
 public class ExportToGafferResultCache<T> implements
         ExportTo<T> {
     private String key;

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/export/resultcache/ExportToGafferResultCache.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/export/resultcache/ExportToGafferResultCache.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl.export.resultcache;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Sets;
 
@@ -31,6 +32,7 @@ import java.util.Set;
  * a cache. The cache is backed by a simple Gaffer graph that can be configured.
  * The results can be of any type - as long as they are json serialisable.
  */
+@JsonPropertyOrder(value = {"class", "key", "input"}, alphabetic = true)
 public class ExportToGafferResultCache<T> implements
         ExportTo<T> {
     private String key;

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/export/resultcache/GetGafferResultCacheExport.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/export/resultcache/GetGafferResultCacheExport.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl.export.resultcache;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.commonutil.iterable.CloseableIterable;
@@ -33,6 +34,7 @@ import java.util.Map;
  *
  * @see ExportToGafferResultCache
  */
+@JsonPropertyOrder(value = {"class"}, alphabetic = true)
 public class GetGafferResultCacheExport implements
         GetExport,
         Output<CloseableIterable<?>> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/export/set/ExportToSet.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/export/set/ExportToSet.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl.export.set;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.operation.Operation;
@@ -30,6 +31,7 @@ import java.util.Map;
  * It cannot be used across multiple separate operation requests.
  * So ExportToSet and GetSetExport must be used inside a single operation chain.
  */
+@JsonPropertyOrder(value = {"class", "key", "input"})
 public class ExportToSet<T> implements
         ExportTo<T> {
     private String key;

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/export/set/ExportToSet.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/export/set/ExportToSet.java
@@ -31,7 +31,7 @@ import java.util.Map;
  * It cannot be used across multiple separate operation requests.
  * So ExportToSet and GetSetExport must be used inside a single operation chain.
  */
-@JsonPropertyOrder(value = {"class", "key", "input"})
+@JsonPropertyOrder(value = {"class", "input", "key"}, alphabetic = true)
 public class ExportToSet<T> implements
         ExportTo<T> {
     private String key;

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/export/set/GetSetExport.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/export/set/GetSetExport.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl.export.set;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.operation.Operation;
@@ -31,6 +32,7 @@ import java.util.Map;
  * It cannot be used across multiple separate operation requests.
  * So ExportToSet and GetSetExport must be used inside a single operation chain.
  */
+@JsonPropertyOrder(value = {"class", "start", "end"}, alphabetic = true)
 public class GetSetExport implements
         GetExport,
         Output<Iterable<?>> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/function/Aggregate.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/function/Aggregate.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.operation.impl.function;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.lang3.exception.CloneFailedException;
 
@@ -32,6 +33,7 @@ import java.util.Map;
  * An <code>Aggregate</code> operation applies {@link uk.gov.gchq.gaffer.data.element.function.ElementAggregator}(s) to the provided
  * {@link Iterable} of {@link Element}s by their group, and returns an {@link Iterable}.
  */
+@JsonPropertyOrder(value = {"class", "input", "edges", "entities"}, alphabetic = true)
 public class Aggregate implements Function,
         InputOutput<Iterable<? extends Element>, Iterable<? extends Element>>,
         MultiInput<Element> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/function/Filter.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/function/Filter.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.operation.impl.function;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.lang3.exception.CloneFailedException;
 
@@ -39,6 +40,7 @@ import java.util.Map;
  * For more complex queries, a {@link Map} of groups to {@link ElementFilter}s can also be provided to either
  * {@link  uk.gov.gchq.gaffer.data.element.Edge}s or {@link uk.gov.gchq.gaffer.data.element.Entity}s.
  */
+@JsonPropertyOrder(value = {"class", "input", "edges", "entities"}, alphabetic = true)
 public class Filter implements Function,
         InputOutput<Iterable<? extends Element>, Iterable<? extends Element>>,
         MultiInput<Element> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/function/Transform.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/function/Transform.java
@@ -36,7 +36,7 @@ import java.util.Map;
  * For multiple groups, a {@link Map} of {@link uk.gov.gchq.gaffer.data.element.Edge}s, or {@link uk.gov.gchq.gaffer.data.element.Entity}s
  * to their relevant {@link ElementTransformer}s can be provided.
  */
-@JsonPropertyOrder(value = {"class", "input"}, alphabetic = true)
+@JsonPropertyOrder(value = {"class", "input", "edges", "entities"}, alphabetic = true)
 public class Transform implements Function,
         InputOutput<Iterable<? extends Element>, Iterable<? extends Element>>,
         MultiInput<Element> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/function/Transform.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/function/Transform.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.operation.impl.function;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.lang3.exception.CloneFailedException;
 
@@ -35,6 +36,7 @@ import java.util.Map;
  * For multiple groups, a {@link Map} of {@link uk.gov.gchq.gaffer.data.element.Edge}s, or {@link uk.gov.gchq.gaffer.data.element.Entity}s
  * to their relevant {@link ElementTransformer}s can be provided.
  */
+@JsonPropertyOrder(value = {"class", "input"}, alphabetic = true)
 public class Transform implements Function,
         InputOutput<Iterable<? extends Element>, Iterable<? extends Element>>,
         MultiInput<Element> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/generate/GenerateElements.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/generate/GenerateElements.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl.generate;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -36,6 +37,7 @@ import java.util.function.Function;
  * @param <OBJ> the type of objects in the input iterable.
  * @see uk.gov.gchq.gaffer.operation.impl.generate.GenerateElements.Builder
  */
+@JsonPropertyOrder(value = {"class", "input", "elementGenerator"}, alphabetic = true)
 public class GenerateElements<OBJ> implements
         InputOutput<Iterable<? extends OBJ>, Iterable<? extends Element>>,
         MultiInput<OBJ> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/generate/GenerateObjects.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/generate/GenerateObjects.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl.generate;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -36,6 +37,7 @@ import java.util.function.Function;
  * @param <OBJ> the type of objects in the output iterable.
  * @see uk.gov.gchq.gaffer.operation.impl.generate.GenerateObjects.Builder
  */
+@JsonPropertyOrder(value = {"class", "input", "elementGenerator"}, alphabetic = true)
 public class GenerateObjects<OBJ> implements
         InputOutput<Iterable<? extends Element>, Iterable<? extends OBJ>>,
         MultiInput<Element> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/get/GetAdjacentIds.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/get/GetAdjacentIds.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl.get;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -38,6 +39,7 @@ import java.util.Map;
  *
  * @see uk.gov.gchq.gaffer.operation.impl.get.GetAdjacentIds.Builder
  */
+@JsonPropertyOrder(value = {"class", "input", "view"}, alphabetic = true)
 public class GetAdjacentIds implements
         InputOutput<Iterable<? extends EntityId>, CloseableIterable<? extends EntityId>>,
         MultiInput<EntityId>,

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/get/GetAllElements.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/get/GetAllElements.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl.get;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.commonutil.iterable.CloseableIterable;
@@ -34,6 +35,7 @@ import java.util.Map;
  * compatible with the provided view.
  * There are also various flags to filter out the elements returned.
  */
+@JsonPropertyOrder(value = {"class", "view"}, alphabetic = true)
 public class GetAllElements implements
         Output<CloseableIterable<? extends Element>>,
         GraphFilters {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/get/GetElements.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/get/GetElements.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl.get;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -60,6 +61,7 @@ import java.util.Map;
  * <li>{@code DirectedType.EITHER} - return both directed or undirected edges</li>
  * </ul>
  */
+@JsonPropertyOrder(value = {"class", "input", "view"}, alphabetic = true)
 public class GetElements implements
         InputOutput<Iterable<? extends ElementId>, CloseableIterable<? extends Element>>,
         MultiInput<ElementId>,

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/job/GetAllJobDetails.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/job/GetAllJobDetails.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl.job;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.commonutil.iterable.CloseableIterable;
@@ -30,6 +31,7 @@ import java.util.Map;
  * A {@code GetAllJobDetails} operation is used to retrieve all of the {@link JobDetail}s
  * related to a Gaffer graph.
  */
+@JsonPropertyOrder(value = {"class"}, alphabetic = true)
 public class GetAllJobDetails implements
         Output<CloseableIterable<JobDetail>> {
     private Map<String, String> options;

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/job/GetJobDetails.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/job/GetJobDetails.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl.job;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.jobtracker.JobDetail;
@@ -29,6 +30,7 @@ import java.util.Map;
  * A {@code GetJobDetails} operation is used to retrieve the details of a single
  * job from a Gaffer graph.
  */
+@JsonPropertyOrder(value = {"class"}, alphabetic = true)
 public class GetJobDetails implements
         Output<JobDetail> {
     private String jobId;

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/job/GetJobResults.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/job/GetJobResults.java
@@ -17,6 +17,7 @@
 package uk.gov.gchq.gaffer.operation.impl.job;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.export.Export;
@@ -29,6 +30,7 @@ import java.util.Map;
  * A {@code GetJobResults} operation is used to retrieve the results of executing
  * a job on a Gaffer graph.
  */
+@JsonPropertyOrder(value = {"class"}, alphabetic = true)
 public class GetJobResults extends GetGafferResultCacheExport {
     private Map<String, String> options;
 

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/output/ToArray.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/output/ToArray.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.operation.impl.output;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.operation.io.InputOutput;
@@ -29,6 +30,7 @@ import java.util.Map;
  *
  * @see uk.gov.gchq.gaffer.operation.impl.output.ToArray.Builder
  */
+@JsonPropertyOrder(value = {"class", "input"}, alphabetic = true)
 public class ToArray<T> implements
         InputOutput<Iterable<? extends T>, T[]>,
         MultiInput<T> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/output/ToCsv.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/output/ToCsv.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.operation.impl.output;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -34,6 +35,7 @@ import java.util.Map;
  *
  * @see ToCsv.Builder
  */
+@JsonPropertyOrder(value = {"class", "input", "elementGenerator"}, alphabetic = true)
 public class ToCsv implements
         InputOutput<Iterable<? extends Element>, Iterable<? extends String>>,
         MultiInput<Element> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/output/ToEntitySeeds.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/output/ToEntitySeeds.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.operation.impl.output;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.operation.data.EntitySeed;
@@ -30,6 +31,7 @@ import java.util.Map;
  *
  * @see uk.gov.gchq.gaffer.operation.impl.output.ToEntitySeeds.Builder
  */
+@JsonPropertyOrder(value = {"class", "input"}, alphabetic = true)
 public class ToEntitySeeds implements
         InputOutput<Iterable<? extends Object>, Iterable<? extends EntitySeed>>,
         MultiInput<Object> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/output/ToList.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/output/ToList.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl.output;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.operation.io.InputOutput;
@@ -31,6 +32,7 @@ import java.util.Map;
  *
  * @see uk.gov.gchq.gaffer.operation.impl.output.ToList.Builder
  */
+@JsonPropertyOrder(value = {"class", "input"}, alphabetic = true)
 public class ToList<T> implements
         InputOutput<Iterable<? extends T>, List<? extends T>>,
         MultiInput<T> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/output/ToMap.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/output/ToMap.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.operation.impl.output;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -34,6 +35,7 @@ import java.util.Map;
  *
  * @see uk.gov.gchq.gaffer.operation.impl.output.ToMap.Builder
  */
+@JsonPropertyOrder(value = {"class", "input", "elementGenerator"}, alphabetic = true)
 public class ToMap implements
         InputOutput<Iterable<? extends Element>, Iterable<? extends Map<String, Object>>>,
         MultiInput<Element> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/output/ToSet.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/output/ToSet.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl.output;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.operation.io.InputOutput;
@@ -32,6 +33,7 @@ import java.util.Set;
  *
  * @see uk.gov.gchq.gaffer.operation.impl.output.ToSet.Builder
  */
+@JsonPropertyOrder(value = {"class", "input"}, alphabetic = true)
 public class ToSet<T> implements
         InputOutput<Iterable<? extends T>, Set<? extends T>>,
         MultiInput<T> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/output/ToStream.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/output/ToStream.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl.output;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.operation.io.InputOutput;
@@ -31,6 +32,7 @@ import java.util.stream.Stream;
  *
  * @see uk.gov.gchq.gaffer.operation.impl.output.ToStream.Builder
  */
+@JsonPropertyOrder(value = {"class", "input"}, alphabetic = true)
 public class ToStream<T> implements
         InputOutput<Iterable<? extends T>, Stream<? extends T>>,
         MultiInput<T> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/output/ToVertices.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/output/ToVertices.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.operation.impl.output;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.data.element.id.ElementId;
@@ -31,6 +32,7 @@ import java.util.Map;
  *
  * @see uk.gov.gchq.gaffer.operation.impl.output.ToVertices.Builder
  */
+@JsonPropertyOrder(value = {"class", "input"}, alphabetic = true)
 public class ToVertices implements
         InputOutput<Iterable<? extends ElementId>, Iterable<? extends Object>>,
         MultiInput<ElementId> {

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/util/AggregatePair.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/util/AggregatePair.java
@@ -15,8 +15,11 @@
  */
 package uk.gov.gchq.gaffer.operation.util;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import uk.gov.gchq.gaffer.data.element.function.ElementAggregator;
 
+@JsonPropertyOrder(value = {"elementAggregator", "groupBy"}, alphabetic = true)
 public class AggregatePair {
     private String[] groupBy = null;
     private ElementAggregator elementAggregator = null;

--- a/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/OperationImpl.java
+++ b/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/OperationImpl.java
@@ -16,6 +16,8 @@
 
 package uk.gov.gchq.gaffer.operation.impl;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import uk.gov.gchq.gaffer.commonutil.Required;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.data.CustomVertex;
@@ -23,6 +25,7 @@ import uk.gov.gchq.gaffer.operation.data.CustomVertex;
 import java.util.Date;
 import java.util.Map;
 
+@JsonPropertyOrder(alphabetic = true)
 public class OperationImpl implements Operation {
     @Required
     private String requiredField1;

--- a/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/add/AddElementsTest.java
+++ b/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/add/AddElementsTest.java
@@ -105,6 +105,7 @@ public class AddElementsTest extends OperationTest<AddElements> {
         JsonAssert.assertEquals(String.format("{%n" +
                 "  \"class\" : \"uk.gov.gchq.gaffer.operation.impl.add.AddElements\",%n" +
                 "  \"validate\" : true,%n" +
+                "  \"options\" : {\"option\": \"value\"},%n" +
                 "  \"skipInvalidElements\" : false%n" +
                 "}"), json);
     }

--- a/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/add/AddElementsTest.java
+++ b/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/add/AddElementsTest.java
@@ -29,8 +29,10 @@ import uk.gov.gchq.gaffer.operation.OperationTest;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -90,6 +92,11 @@ public class AddElementsTest extends OperationTest<AddElements> {
     public void shouldJSONSerialiseAndDeserialise() throws SerialisationException {
         // Given
         final AddElements addElements = getTestObject();
+
+        final Map<String, String> options = new HashMap<>();
+        options.put("option", "value");
+
+        addElements.setOptions(options);
 
         // When
         String json = new String(JSONSerialiser.serialise(addElements, true));

--- a/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/io/InputImpl.java
+++ b/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/io/InputImpl.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.operation.impl.io;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.commons.lang3.exception.CloneFailedException;
 
 import uk.gov.gchq.gaffer.commonutil.Required;
@@ -26,6 +27,7 @@ import uk.gov.gchq.gaffer.operation.io.MultiInput;
 import java.util.Date;
 import java.util.Map;
 
+@JsonPropertyOrder(alphabetic = true)
 public class InputImpl implements MultiInput<String> {
     @Required
     // Public so the validation of the required field can be tested differently

--- a/core/serialisation/src/test/java/uk/gov/gchq/gaffer/JSONSerialisationTest.java
+++ b/core/serialisation/src/test/java/uk/gov/gchq/gaffer/JSONSerialisationTest.java
@@ -15,15 +15,18 @@
  */
 package uk.gov.gchq.gaffer;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.junit.Test;
 
 import uk.gov.gchq.gaffer.exception.SerialisationException;
 import uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Provides a common interface for testing classes that should be JSON serialisable.
+ *
  * @param <T> Object of type T that is to be tested
  */
 public abstract class JSONSerialisationTest<T> {
@@ -40,11 +43,25 @@ public abstract class JSONSerialisationTest<T> {
         assertNotNull(deserialisedObj);
     }
 
+    @Test
+    public void shouldHaveJsonPropertyAnnotation() throws Exception {
+        // Given
+        final T op = getTestObject();
+
+        // When
+        final JsonPropertyOrder annotation = op.getClass().getAnnotation(JsonPropertyOrder.class);
+
+        // Then
+        assumeTrue("Missing JsonPropertyOrder annotation on class. It should de defined and set to alphabetical." + op.getClass().getName(),
+                null != annotation && annotation.alphabetic());
+    }
+
     /**
      * This method should be used to generate an instance of the object under test,
      * eg. return new foo();
      * The object can be no arg, or as complex as is necessary for the test(s),
      * eg. return new bar(arg1, arg2, ...);
+     *
      * @return an instance of the object under test of type T
      */
     protected abstract T getTestObject();

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/GetSchema.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/GetSchema.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.store.operation;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.lang3.exception.CloneFailedException;
 
@@ -29,6 +30,7 @@ import java.util.Map;
  * A {@code GetSchema} is an {@link uk.gov.gchq.gaffer.operation.Operation} which
  * returns either the compact or full {@link Schema} for a Gaffer {@link uk.gov.gchq.gaffer.store.Store}.
  */
+@JsonPropertyOrder(value = {"class"}, alphabetic = true)
 public class GetSchema implements Output<Schema> {
     private Map<String, String> options;
     private boolean compact = false;

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/schema/Schema.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/schema/Schema.java
@@ -17,6 +17,7 @@
 package uk.gov.gchq.gaffer.store.schema;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -66,6 +67,7 @@ import java.util.Set;
  * @see ElementDefinitions
  */
 @JsonDeserialize(builder = Schema.Builder.class)
+@JsonPropertyOrder(value = {"class", "edges", "entities", "vertexSerialiser", "types"}, alphabetic = true)
 public class Schema extends ElementDefinitions<SchemaEntityDefinition, SchemaEdgeDefinition> implements Cloneable {
     private final TypeDefinition unknownType = new TypeDefinition();
 

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/schema/Schema.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/schema/Schema.java
@@ -67,7 +67,7 @@ import java.util.Set;
  * @see ElementDefinitions
  */
 @JsonDeserialize(builder = Schema.Builder.class)
-@JsonPropertyOrder(value = {"class", "edges", "entities", "vertexSerialiser", "types"}, alphabetic = true)
+@JsonPropertyOrder(value = {"class", "edges", "entities", "types"}, alphabetic = true)
 public class Schema extends ElementDefinitions<SchemaEntityDefinition, SchemaEdgeDefinition> implements Cloneable {
     private final TypeDefinition unknownType = new TypeDefinition();
 

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/schema/SchemaEdgeDefinition.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/schema/SchemaEdgeDefinition.java
@@ -17,6 +17,7 @@
 package uk.gov.gchq.gaffer.store.schema;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -30,6 +31,14 @@ import java.util.Set;
  * A {@code SchemaEdgeDefinition} is the representation of a single edge in a
  * {@link Schema}.
  */
+@JsonPropertyOrder(value = {
+        "description",
+        "source",
+        "destination",
+        "directed",
+        "properties",
+        "groupBy"
+}, alphabetic = true)
 @JsonDeserialize(builder = SchemaEdgeDefinition.Builder.class)
 public class SchemaEdgeDefinition extends SchemaElementDefinition {
     public String getSource() {

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/schema/SchemaEntityDefinition.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/schema/SchemaEntityDefinition.java
@@ -17,6 +17,7 @@
 package uk.gov.gchq.gaffer.store.schema;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -30,6 +31,7 @@ import java.util.Set;
  * A {@code SchemaEntityDefinition} is the representation of a single entity in a
  * {@link Schema}.
  */
+@JsonPropertyOrder(value = {"description", "vertex", "properties", "groupBy"}, alphabetic = true)
 @JsonDeserialize(builder = SchemaEntityDefinition.Builder.class)
 public class SchemaEntityDefinition extends SchemaElementDefinition {
     public String getVertex() {

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/schema/TypeDefinition.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/schema/TypeDefinition.java
@@ -19,6 +19,7 @@ package uk.gov.gchq.gaffer.store.schema;
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.collect.Lists;
@@ -41,6 +42,10 @@ import java.util.function.Predicate;
  * A {@code TypeDefinition} contains the an object's java class along with how to validate and aggregate the object.
  * It is used to deserialise/serialise a {@link Schema} to/from JSON.
  */
+@JsonPropertyOrder(value = {
+        "description",
+        "class"
+}, alphabetic = true)
 @JsonFilter(JSONSerialiser.FILTER_FIELDS_BY_NAME)
 public class TypeDefinition {
     private Class<?> clazz;

--- a/library/hdfs-library/src/main/java/uk/gov/gchq/gaffer/hdfs/operation/AddElementsFromHdfs.java
+++ b/library/hdfs-library/src/main/java/uk/gov/gchq/gaffer/hdfs/operation/AddElementsFromHdfs.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.hdfs.operation;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.hadoop.mapreduce.Partitioner;
 
 import uk.gov.gchq.gaffer.commonutil.Required;
@@ -43,6 +44,7 @@ import java.util.Map;
  * @see MapReduce
  * @see Builder
  */
+@JsonPropertyOrder(value = {"class", "failurePath", "workingPath"}, alphabetic = true)
 public class AddElementsFromHdfs implements
         Operation,
         MapReduce {

--- a/library/hdfs-library/src/main/java/uk/gov/gchq/gaffer/hdfs/operation/SampleDataForSplitPoints.java
+++ b/library/hdfs-library/src/main/java/uk/gov/gchq/gaffer/hdfs/operation/SampleDataForSplitPoints.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.hdfs.operation;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.GzipCodec;
 import org.apache.hadoop.mapreduce.Partitioner;
@@ -43,6 +44,7 @@ import java.util.Map;
  *
  * @see SampleDataForSplitPoints.Builder
  */
+@JsonPropertyOrder(value = {"class", "splitsFilePath"}, alphabetic = true)
 public class SampleDataForSplitPoints implements
         Operation,
         MapReduce {

--- a/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/javardd/ImportKeyValueJavaPairRDDToAccumulo.java
+++ b/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/javardd/ImportKeyValueJavaPairRDDToAccumulo.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.sparkaccumulo.operation.javardd;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.spark.api.java.JavaPairRDD;
@@ -25,6 +26,7 @@ import uk.gov.gchq.gaffer.operation.io.Input;
 
 import java.util.Map;
 
+@JsonPropertyOrder(value = {"class", "input", "outputPath", "failurePath"}, alphabetic = true)
 public class ImportKeyValueJavaPairRDDToAccumulo implements
         Input<JavaPairRDD<Key, Value>> {
     @Required

--- a/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/scalardd/ImportKeyValuePairRDDToAccumulo.java
+++ b/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/scalardd/ImportKeyValuePairRDDToAccumulo.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.sparkaccumulo.operation.scalardd;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.spark.rdd.RDD;
@@ -25,6 +26,7 @@ import uk.gov.gchq.gaffer.operation.io.Input;
 
 import java.util.Map;
 
+@JsonPropertyOrder(value = {"class", "input", "outputPath", "failurePath"}, alphabetic = true)
 public class ImportKeyValuePairRDDToAccumulo implements
         Input<RDD<Tuple2<Key, Value>>> {
     private RDD<Tuple2<Key, Value>> input;

--- a/library/spark/spark-library/src/main/java/uk/gov/gchq/gaffer/spark/operation/dataframe/GetDataFrameOfElements.java
+++ b/library/spark/spark-library/src/main/java/uk/gov/gchq/gaffer/spark/operation/dataframe/GetDataFrameOfElements.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.spark.operation.dataframe;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -44,6 +45,7 @@ import java.util.Map;
  * The schema of the {@code Dataframe} is formed of all properties from the first group, followed by all
  * properties from the second group, with the exception of properties already found in the first group, etc.
  */
+@JsonPropertyOrder(value = {"class", "view"}, alphabetic = true)
 public class GetDataFrameOfElements implements
         Output<Dataset<Row>>,
         GraphFilters {

--- a/library/spark/spark-library/src/main/java/uk/gov/gchq/gaffer/spark/operation/javardd/GetJavaRDDOfAllElements.java
+++ b/library/spark/spark-library/src/main/java/uk/gov/gchq/gaffer/spark/operation/javardd/GetJavaRDDOfAllElements.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.spark.operation.javardd;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.spark.api.java.JavaRDD;
 
@@ -32,6 +33,7 @@ import java.util.Map;
  * A {@code GetJavaRDDOfAllElements} operation retrieves all the {@link Element}s
  * from the target store, and returns them inside a {@link JavaRDD}.
  */
+@JsonPropertyOrder(value = {"class", "view"}, alphabetic = true)
 public class GetJavaRDDOfAllElements implements
         Output<JavaRDD<Element>>,
         GraphFilters {

--- a/library/spark/spark-library/src/main/java/uk/gov/gchq/gaffer/spark/operation/javardd/GetJavaRDDOfElements.java
+++ b/library/spark/spark-library/src/main/java/uk/gov/gchq/gaffer/spark/operation/javardd/GetJavaRDDOfElements.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.spark.operation.javardd;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.spark.api.java.JavaRDD;
 
@@ -34,6 +35,7 @@ import java.util.Map;
  * A {@code GetJavaRDDOfElements} operation retrieves all the {@link Element}s
  * for the input seeds from the target store, and returns them inside a {@link JavaRDD}.
  */
+@JsonPropertyOrder(value = {"class", "input", "view"}, alphabetic = true)
 public class GetJavaRDDOfElements implements
         InputOutput<Iterable<? extends ElementId>, JavaRDD<Element>>,
         MultiInput<ElementId>,

--- a/library/spark/spark-library/src/main/java/uk/gov/gchq/gaffer/spark/operation/javardd/ImportJavaRDDOfElements.java
+++ b/library/spark/spark-library/src/main/java/uk/gov/gchq/gaffer/spark/operation/javardd/ImportJavaRDDOfElements.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.spark.operation.javardd;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.spark.api.java.JavaRDD;
 
 import uk.gov.gchq.gaffer.data.element.Element;
@@ -23,7 +24,7 @@ import uk.gov.gchq.gaffer.operation.io.Input;
 
 import java.util.Map;
 
-
+@JsonPropertyOrder(value = {"class", "input"}, alphabetic = true)
 public class ImportJavaRDDOfElements implements
         Operation,
         Input<JavaRDD<Element>> {

--- a/library/spark/spark-library/src/main/java/uk/gov/gchq/gaffer/spark/operation/scalardd/GetRDDOfAllElements.java
+++ b/library/spark/spark-library/src/main/java/uk/gov/gchq/gaffer/spark/operation/scalardd/GetRDDOfAllElements.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.spark.operation.scalardd;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.spark.rdd.RDD;
 
@@ -32,6 +33,7 @@ import java.util.Map;
  * A {@code GetRDDOfAllElements} operation retrieves all the {@link Element}s
  * from the target store, and returns them inside a {@link RDD}.
  */
+@JsonPropertyOrder(value = {"class", "view"}, alphabetic = true)
 public class GetRDDOfAllElements implements
         Output<RDD<Element>>,
         GraphFilters {

--- a/library/spark/spark-library/src/main/java/uk/gov/gchq/gaffer/spark/operation/scalardd/GetRDDOfElements.java
+++ b/library/spark/spark-library/src/main/java/uk/gov/gchq/gaffer/spark/operation/scalardd/GetRDDOfElements.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.spark.operation.scalardd;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.spark.rdd.RDD;
 
@@ -35,6 +36,7 @@ import java.util.Map;
  * A {@code GetRDDOfElements} operation retrieves all the {@link Element}s for the
  * input seeds from the target store, and returns them inside a {@link RDD}.
  */
+@JsonPropertyOrder(value = {"class", "input", "view"}, alphabetic = true)
 public class GetRDDOfElements implements
         InputOutput<Iterable<? extends ElementId>, RDD<Element>>,
         MultiInput<ElementId>,

--- a/library/spark/spark-library/src/main/java/uk/gov/gchq/gaffer/spark/operation/scalardd/ImportRDDOfElements.java
+++ b/library/spark/spark-library/src/main/java/uk/gov/gchq/gaffer/spark/operation/scalardd/ImportRDDOfElements.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.spark.operation.scalardd;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.spark.rdd.RDD;
 
 import uk.gov.gchq.gaffer.data.element.Element;
@@ -27,6 +28,7 @@ import java.util.Map;
  * A {@code ImportRDDOfElements} takes a {@link RDD} containing {@link Element}s
  * and adds them to a target Gaffer store.
  */
+@JsonPropertyOrder(value = {"class", "input"}, alphabetic = true)
 public class ImportRDDOfElements implements
         Input<RDD<Element>> {
     public static final String HADOOP_CONFIGURATION_KEY = "Hadoop_Configuration_Key";

--- a/library/time-library/src/main/java/uk/gov/gchq/gaffer/time/BoundedTimestampSet.java
+++ b/library/time-library/src/main/java/uk/gov/gchq/gaffer/time/BoundedTimestampSet.java
@@ -17,6 +17,7 @@ package uk.gov.gchq.gaffer.time;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.yahoo.sketches.sampling.ReservoirLongsUnion;
@@ -45,6 +46,7 @@ import java.util.TreeSet;
  * more than N timestamps are added then a uniform random sample of size N of the timestamps is retained.
  * </p>
  */
+@JsonPropertyOrder(alphabetic = true)
 @JsonDeserialize(builder = BoundedTimestampSet.Builder.class)
 public class BoundedTimestampSet implements TimestampSet {
     public enum State {

--- a/library/time-library/src/main/java/uk/gov/gchq/gaffer/time/LongTimeSeries.java
+++ b/library/time-library/src/main/java/uk/gov/gchq/gaffer/time/LongTimeSeries.java
@@ -18,6 +18,7 @@ package uk.gov.gchq.gaffer.time;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -51,6 +52,7 @@ import static uk.gov.gchq.gaffer.commonutil.CommonTimeUtil.TimeBucket.YEAR;
  * is added then the seconds are removed so that the value is associated to
  * 12:34.
  */
+@JsonPropertyOrder(alphabetic = true)
 public class LongTimeSeries implements TimeSeries<Long> {
     private static final Set<TimeBucket> VALID_TIME_BUCKETS = Sets.newHashSet(
             MILLISECOND,

--- a/library/time-library/src/main/java/uk/gov/gchq/gaffer/time/RBMBackedTimestampSet.java
+++ b/library/time-library/src/main/java/uk/gov/gchq/gaffer/time/RBMBackedTimestampSet.java
@@ -17,6 +17,7 @@ package uk.gov.gchq.gaffer.time;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang3.StringUtils;
@@ -55,6 +56,7 @@ import static uk.gov.gchq.gaffer.commonutil.CommonTimeUtil.TimeBucket;
  * the epoch.
  * </p>
  */
+@JsonPropertyOrder(alphabetic = true)
 @JsonDeserialize(builder = RBMBackedTimestampSet.Builder.class)
 public class RBMBackedTimestampSet implements TimestampSet {
     private static final Instant MIN_TIME = Instant.ofEpochMilli(0L);

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/operation/hdfs/operation/ImportAccumuloKeyValueFiles.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/operation/hdfs/operation/ImportAccumuloKeyValueFiles.java
@@ -16,11 +16,14 @@
 
 package uk.gov.gchq.gaffer.accumulostore.operation.hdfs.operation;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import uk.gov.gchq.gaffer.commonutil.Required;
 import uk.gov.gchq.gaffer.operation.Operation;
 
 import java.util.Map;
 
+@JsonPropertyOrder(value = {"class", "inputPath", "failurePath"}, alphabetic = true)
 public class ImportAccumuloKeyValueFiles implements
         Operation {
     @Required

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/operation/impl/GetElementsBetweenSets.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/operation/impl/GetElementsBetweenSets.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.accumulostore.operation.impl;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -43,6 +44,7 @@ import java.util.Map;
  * {@link uk.gov.gchq.gaffer.data.element.Entity}s for
  * {@link uk.gov.gchq.gaffer.data.element.id.EntityId}s in set A.
  */
+@JsonPropertyOrder(value = {"class", "input", "inputB", "view"}, alphabetic = true)
 public class GetElementsBetweenSets implements
         InputOutput<Iterable<? extends EntityId>, CloseableIterable<? extends Element>>,
         MultiInput<EntityId>,

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/operation/impl/GetElementsInRanges.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/operation/impl/GetElementsInRanges.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.accumulostore.operation.impl;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.commonutil.iterable.CloseableIterable;
@@ -36,6 +37,7 @@ import java.util.Map;
  * This returns all data between the provided
  * {@link uk.gov.gchq.gaffer.data.element.id.ElementId}s.
  */
+@JsonPropertyOrder(value = {"class", "input", "view"}, alphabetic = true)
 public class GetElementsInRanges
         implements
         InputOutput<Iterable<? extends Pair<? extends ElementId, ? extends ElementId>>, CloseableIterable<? extends Element>>,

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/operation/impl/GetElementsWithinSet.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/operation/impl/GetElementsWithinSet.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.accumulostore.operation.impl;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -37,6 +38,7 @@ import java.util.Map;
  * set and/or {@link uk.gov.gchq.gaffer.data.element.Entity}s where the vertex is in the
  * set.
  **/
+@JsonPropertyOrder(value = {"class", "input", "view"}, alphabetic = true)
 public class GetElementsWithinSet implements
         InputOutput<Iterable<? extends EntityId>, CloseableIterable<? extends Element>>,
         MultiInput<EntityId>,

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/operation/impl/SummariseGroupOverRanges.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/operation/impl/SummariseGroupOverRanges.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.accumulostore.operation.impl;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.commonutil.iterable.CloseableIterable;
@@ -39,6 +40,7 @@ import java.util.Map;
  * For this reason it is recommended your provided ranges do not over-lap as you will be unable to tell for a given result which range the result is from.
  * Standard filtering will still occur before the final aggregation of the vertices.
  */
+@JsonPropertyOrder(value = {"class", "input", "view"}, alphabetic = true)
 public class SummariseGroupOverRanges
         implements
         InputOutput<Iterable<? extends Pair<? extends ElementId, ? extends ElementId>>, CloseableIterable<? extends Element>>,

--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/AddGraph.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/AddGraph.java
@@ -17,6 +17,7 @@
 package uk.gov.gchq.gaffer.federatedstore.operation;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.exception.CloneFailedException;
@@ -58,6 +59,7 @@ import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreConstants.KEY_OPER
  * @see uk.gov.gchq.gaffer.data.element.Properties
  * @see uk.gov.gchq.gaffer.graph.Graph
  */
+@JsonPropertyOrder(value = {"class", "graphId"}, alphabetic = true)
 public class AddGraph implements FederatedOperation {
 
     @Required

--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/FederatedOperationChain.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/FederatedOperationChain.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -48,6 +49,7 @@ import java.util.Map;
  *
  * @param <O_ITEM> the output iterable type of the {@code FederatedOperationChain}.
  **/
+@JsonPropertyOrder(value = {"class", "operationChain"}, alphabetic = true)
 public class FederatedOperationChain<O_ITEM> implements Output<CloseableIterable<O_ITEM>>,
         Operations<OperationChain> {
     @Required

--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/GetAllGraphIds.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/GetAllGraphIds.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.federatedstore.operation;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.lang3.exception.CloneFailedException;
 
@@ -29,6 +30,7 @@ import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreConstants.KEY_OPER
 /**
  * An Operation to get all the graphIds within scope of the FederatedStore.
  */
+@JsonPropertyOrder(value = {"class"}, alphabetic = true)
 public class GetAllGraphIds implements
         FederatedOperation,
         Output<Iterable<? extends String>> {

--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/RemoveGraph.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/RemoveGraph.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.federatedstore.operation;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.commons.lang3.exception.CloneFailedException;
 
 import uk.gov.gchq.gaffer.commonutil.Required;
@@ -35,6 +36,7 @@ import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreConstants.KEY_OPER
  * @see uk.gov.gchq.gaffer.federatedstore.FederatedStore
  * @see uk.gov.gchq.gaffer.graph.Graph
  */
+@JsonPropertyOrder(value = {"class", "graphId"}, alphabetic = true)
 public class RemoveGraph implements FederatedOperation {
 
     @Required

--- a/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/operation/CountAllElementsDefaultView.java
+++ b/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/operation/CountAllElementsDefaultView.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.mapstore.operation;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.data.element.Element;
@@ -29,6 +30,7 @@ import java.util.Map;
  * A {@code CountAllElementsDefaultView} operation counts all of the {@link Element}s
  * present in a {@link uk.gov.gchq.gaffer.mapstore.MapStore}.
  */
+@JsonPropertyOrder(value = {"class", "input"}, alphabetic = true)
 public class CountAllElementsDefaultView implements
         InputOutput<Iterable<? extends Element>, Long>,
         MultiInput<Element> {


### PR DESCRIPTION
Added the annotation to a number of public classes, including most implementations of Operation; Edge; Entity; Schema; View.
Tested in the REST API, the consistency looks much neater.