### PR TITLE
Gh-1624 Class Info for GetSerialisedFields

### DIFF
--- a/core/data/src/main/java/uk/gov/gchq/gaffer/data/element/Edge.java
+++ b/core/data/src/main/java/uk/gov/gchq/gaffer/data/element/Edge.java
@@ -139,8 +139,6 @@ public class Edge extends Element implements EdgeId {
         return destination;
     }
 
-    // TODO figure out why this isn't being JSON ignored when serialised (#getSerialisedFields still returns this and it shouldn't)
-
     @JsonIgnore
     @Override
     public DirectedType getDirectedType() {

--- a/core/data/src/main/java/uk/gov/gchq/gaffer/data/element/Edge.java
+++ b/core/data/src/main/java/uk/gov/gchq/gaffer/data/element/Edge.java
@@ -139,6 +139,8 @@ public class Edge extends Element implements EdgeId {
         return destination;
     }
 
+    // TODO figure out why this isn't being JSON ignored when serialised (#getSerialisedFields still returns this and it shouldn't)
+
     @JsonIgnore
     @Override
     public DirectedType getDirectedType() {

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2.java
@@ -75,7 +75,7 @@ public class GraphConfigurationServiceV2 implements IGraphConfigurationServiceV2
     private static Set<Class> getSubClasses(final Class<?> clazz) {
         final Set<URL> urls = new HashSet<>();
         for (final String packagePrefix : System.getProperty(SystemProperty.PACKAGE_PREFIXES, SystemProperty.PACKAGE_PREFIXES_DEFAULT)
-                                                .split(",")) {
+                .split(",")) {
             urls.addAll(ClasspathHelper.forPackage(packagePrefix));
         }
 
@@ -104,15 +104,15 @@ public class GraphConfigurationServiceV2 implements IGraphConfigurationServiceV2
     @Override
     public Response getSchema() {
         return Response.ok(graphFactory.getGraph().getSchema())
-                       .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
-                       .build();
+                .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
+                .build();
     }
 
     @Override
     public Response getFilterFunction() {
         return Response.ok(FILTER_FUNCTIONS)
-                       .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
-                       .build();
+                .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
+                .build();
     }
 
     @SuppressFBWarnings(value = "REC_CATCH_EXCEPTION", justification = "Need to wrap all runtime exceptions before they are given to the user")
@@ -148,8 +148,8 @@ public class GraphConfigurationServiceV2 implements IGraphConfigurationServiceV2
         }
 
         return Response.ok(classes)
-                       .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
-                       .build();
+                .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
+                .build();
     }
 
     @SuppressFBWarnings(value = "REC_CATCH_EXCEPTION", justification = "Need to wrap all runtime exceptions before they are given to the user")
@@ -168,14 +168,29 @@ public class GraphConfigurationServiceV2 implements IGraphConfigurationServiceV2
                                                     .introspect(type);
         final List<BeanPropertyDefinition> properties = introspection.findProperties();
 
+        // TODO convert this to a Set<Map<String, String>> of field name : class type, check that it's displayed correctly in the REST API
         final Set<String> fields = new HashSet<>();
         for (final BeanPropertyDefinition property : properties) {
-            fields.add(property.getName());
+            final StringBuilder propInfo = new StringBuilder(property.getName());
+
+            if (property.getName().equals("class")) {
+                propInfo.append(" : ").append(className);
+            }
+
+            if (null != property.getField()) {
+                propInfo.append(" : ").append(property.getField().getGenericType().getTypeName());
+            }
+
+            // TODO handling of Enums (field instanceof enum?) then add that they are a String since this will be deserialised correctly anyway.
+
+            fields.add(propInfo.toString());
+
+            // TODO test more classes, maybe write an IT?
         }
 
         return Response.ok(fields)
-                       .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
-                       .build();
+                .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
+                .build();
     }
 
     @Override
@@ -188,28 +203,28 @@ public class GraphConfigurationServiceV2 implements IGraphConfigurationServiceV2
     @Override
     public Response getTransformFunctions() {
         return Response.ok(TRANSFORM_FUNCTIONS)
-                       .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
-                       .build();
+                .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
+                .build();
     }
 
     @Override
     public Response getStoreTraits() {
         return Response.ok(graphFactory.getGraph().getStoreTraits())
-                       .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
-                       .build();
+                .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
+                .build();
     }
 
     @Override
     public Response getElementGenerators() {
         return Response.ok(ELEMENT_GENERATORS)
-                       .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
-                       .build();
+                .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
+                .build();
     }
 
     @Override
     public Response getObjectGenerators() {
         return Response.ok(OBJECT_GENERATORS)
-                       .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
-                       .build();
+                .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
+                .build();
     }
 }

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2.java
@@ -171,6 +171,32 @@ public class GraphConfigurationServiceV2 implements IGraphConfigurationServiceV2
                 .introspect(type);
         final List<BeanPropertyDefinition> properties = introspection.findProperties();
 
+        final Set<String> fields = new HashSet<>();
+        for (final BeanPropertyDefinition property : properties) {
+            fields.add(property.getName());
+        }
+
+        return Response.ok(fields)
+                .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
+                .build();
+    }
+
+    @SuppressFBWarnings(value = "REC_CATCH_EXCEPTION", justification = "Need to wrap all runtime exceptions before they are given to the user")
+    @Override
+    public Response getSerialisedFieldClasses(final String className) {
+        final Class<?> clazz;
+        try {
+            clazz = Class.forName(className);
+        } catch (final Exception e) {
+            throw new IllegalArgumentException("Class name was not recognised: " + className, e);
+        }
+
+        final ObjectMapper mapper = new ObjectMapper();
+        final JavaType type = mapper.getTypeFactory().constructType(clazz);
+        final BeanDescription introspection = mapper.getSerializationConfig()
+                .introspect(type);
+        final List<BeanPropertyDefinition> properties = introspection.findProperties();
+
         final Map<String, String> fieldMap = new HashMap<>();
         for (final BeanPropertyDefinition property : properties) {
             final String propName = property.getName();

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2.java
@@ -38,9 +38,11 @@ import javax.ws.rs.core.Response;
 import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -168,27 +170,27 @@ public class GraphConfigurationServiceV2 implements IGraphConfigurationServiceV2
                                                     .introspect(type);
         final List<BeanPropertyDefinition> properties = introspection.findProperties();
 
-        // TODO convert this to a Set<Map<String, String>> of field name : class type, check that it's displayed correctly in the REST API
-        final Set<String> fields = new HashSet<>();
+        final Map<String, String> fieldMap = new HashMap<>();
         for (final BeanPropertyDefinition property : properties) {
-            final StringBuilder propInfo = new StringBuilder(property.getName());
+            final String propName = property.getName();
+            String propClass = "";
 
-            if (property.getName().equals("class")) {
-                propInfo.append(" : ").append(className);
+            if (propName.equals("class")) {
+                propClass = className;
             }
 
             if (null != property.getField()) {
-                propInfo.append(" : ").append(property.getField().getGenericType().getTypeName());
+                propClass = property.getField().getGenericType().getTypeName();
             }
 
-            // TODO handling of Enums (field instanceof enum?) then add that they are a String since this will be deserialised correctly anyway.
-
-            fields.add(propInfo.toString());
-
-            // TODO test more classes, maybe write an IT?
+            fieldMap.put(propName, propClass);
         }
 
-        return Response.ok(fields)
+        // TODO handling of Enums (field instanceof enum?) then add that they are a String since this will be deserialised correctly anyway.
+
+        // TODO test more classes, maybe write an IT?
+
+        return Response.ok(fieldMap)
                 .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
                 .build();
     }

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2.java
@@ -32,6 +32,9 @@ import uk.gov.gchq.gaffer.rest.factory.GraphFactory;
 import uk.gov.gchq.gaffer.rest.factory.UserFactory;
 import uk.gov.gchq.koryphe.signature.Signature;
 
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.net.URL;
@@ -44,9 +47,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
-
-import javax.inject.Inject;
-import javax.ws.rs.core.Response;
 
 import static uk.gov.gchq.gaffer.rest.ServiceConstants.GAFFER_MEDIA_TYPE;
 import static uk.gov.gchq.gaffer.rest.ServiceConstants.GAFFER_MEDIA_TYPE_HEADER;

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/IGraphConfigurationServiceV2.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/IGraphConfigurationServiceV2.java
@@ -158,6 +158,20 @@ public interface IGraphConfigurationServiceV2 {
     Response getSerialisedFields(@ApiParam(value = "a java class name") @PathParam("className") final String className);
 
     @GET
+    @Path("/serialisedFields/{className}/classes")
+    @ApiOperation(value = "Gets all serialised fields and their class type, for a given java class.",
+            response = String.class,
+            responseContainer = "map",
+            produces = APPLICATION_JSON,
+            responseHeaders = {
+                    @ResponseHeader(name = GAFFER_MEDIA_TYPE_HEADER, description = GAFFER_MEDIA_TYPE_HEADER_DESCRIPTION)
+            })
+    @ApiResponses(value = {@ApiResponse(code = 200, message = OK),
+            @ApiResponse(code = 404, message = CLASS_NOT_FOUND),
+            @ApiResponse(code = 500, message = INTERNAL_SERVER_ERROR)})
+    Response getSerialisedFieldClasses(@ApiParam(value = "A java class name") @PathParam("className") final String className);
+
+    @GET
     @Path("/description")
     @Produces(TEXT_PLAIN)
     @ApiOperation(value = "Gets the Graph description",

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2Test.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2Test.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.rest.service.v2;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.hamcrest.core.IsCollectionContaining;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,10 +44,12 @@ import uk.gov.gchq.koryphe.impl.predicate.IsMoreThan;
 import uk.gov.gchq.koryphe.impl.predicate.Not;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -156,17 +159,26 @@ public class GraphConfigurationServiceV2Test {
         assertTrue(fields.keySet().contains("type"));
     }
 
-    // TODO test more classes, maybe write an IT?
-
-
     @Test
-    public void shouldGetSerialisedFieldsForEdgeClass() {
+    public void shouldGetCorrectSerialisedFieldsForEdgeClass() {
         // When
         final Map<String, String> fields = (Map<String, String>) service.getSerialisedFields(Edge.class.getName()).getEntity();
 
+        final Map<String, String> expectedFields = new HashMap<>();
+        expectedFields.put("class", "uk.gov.gchq.gaffer.data.element.Edge");
+        expectedFields.put("source", "java.lang.Object");
+        expectedFields.put("destination", "java.lang.Object");
+        expectedFields.put("matchedVertex", "java.lang.String");
+        expectedFields.put("group", "java.lang.String");
+        expectedFields.put("properties", "uk.gov.gchq.gaffer.data.element.Properties");
+        expectedFields.put("directed", "boolean");
+
         // Then
-        // TODO: finish test
-        assertEquals(1, fields.size());
+        assertEquals(7, fields.size());
+
+        assertTrue(CollectionUtils.isEqualCollection(expectedFields.keySet(), fields.keySet()));
+        assertTrue(CollectionUtils.isEqualCollection(expectedFields.values(), fields.values()));
+        assertFalse(fields.keySet().contains("directedType"));
     }
 
     @Test

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2Test.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2Test.java
@@ -30,7 +30,9 @@ import uk.gov.gchq.gaffer.graph.Graph;
 import uk.gov.gchq.gaffer.graph.GraphConfig;
 import uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser;
 import uk.gov.gchq.gaffer.operation.Operation;
+import uk.gov.gchq.gaffer.operation.impl.GetWalks;
 import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
+import uk.gov.gchq.gaffer.operation.impl.get.GetElements;
 import uk.gov.gchq.gaffer.rest.factory.GraphFactory;
 import uk.gov.gchq.gaffer.rest.factory.UserFactory;
 import uk.gov.gchq.gaffer.store.Context;
@@ -152,17 +154,36 @@ public class GraphConfigurationServiceV2Test {
     @Test
     public void shouldGetSerialisedFields() {
         // When
-        final Map<String, String> fields = (Map<String, String>) service.getSerialisedFields(IsA.class.getName()).getEntity();
+        final Set<String> fields = (Set<String>) service.getSerialisedFields(IsA.class.getName()).getEntity();
 
         // Then
         assertEquals(1, fields.size());
-        assertTrue(fields.keySet().contains("type"));
+        assertTrue(fields.contains("type"));
+    }
+
+    @Test
+    public void shouldGetSerialisedFieldsForGetElementsClass() {
+        // When
+        final Set<String> fields = (Set<String>) service.getSerialisedFields(GetElements.class.getName()).getEntity();
+
+        final Set<String> expectedFields = new HashSet<>();
+        expectedFields.add("input");
+        expectedFields.add("view");
+        expectedFields.add("includeIncomingOutGoing");
+        expectedFields.add("seedMatching");
+        expectedFields.add("options");
+        expectedFields.add("directedType");
+        expectedFields.add("views");
+
+        // Then
+        assertEquals(7, fields.size());
+        assertTrue(expectedFields.containsAll(fields));
     }
 
     @Test
     public void shouldGetCorrectSerialisedFieldsForEdgeClass() {
         // When
-        final Map<String, String> fields = (Map<String, String>) service.getSerialisedFields(Edge.class.getName()).getEntity();
+        final Map<String, String> fields = (Map<String, String>) service.getSerialisedFieldClasses(Edge.class.getName()).getEntity();
 
         final Map<String, String> expectedFields = new HashMap<>();
         expectedFields.put("class", "uk.gov.gchq.gaffer.data.element.Edge");
@@ -179,6 +200,27 @@ public class GraphConfigurationServiceV2Test {
         assertTrue(CollectionUtils.isEqualCollection(expectedFields.keySet(), fields.keySet()));
         assertTrue(CollectionUtils.isEqualCollection(expectedFields.values(), fields.values()));
         assertFalse(fields.keySet().contains("directedType"));
+    }
+
+    @Test
+    public void shouldGetCorrectSerialisedFieldsForGetWalksClass() {
+        // When
+        final Map<String, String> fields = (Map<String, String>) service.getSerialisedFieldClasses(GetWalks.class.getName()).getEntity();
+
+        final Map<String, String> expectedFields = new HashMap<>();
+        expectedFields.put("operations",
+                "java.util.List<uk.gov.gchq.gaffer.operation.OperationChain<java.lang.Iterable<uk.gov.gchq.gaffer.data.element.Element>>>");
+        expectedFields.put("input",
+                "java.lang.Iterable<? extends uk.gov.gchq.gaffer.data.element.id.EntityId>");
+        expectedFields.put("options",
+                "java.util.Map<java.lang.String, java.lang.String>");
+        expectedFields.put("resultsLimit", "java.lang.Integer");
+
+        // Then
+        assertEquals(4, fields.size());
+        assertTrue(CollectionUtils.isEqualCollection(expectedFields.keySet(), fields.keySet()));
+        assertTrue(CollectionUtils.isEqualCollection(expectedFields.values(), fields.values()));
+        assertFalse(fields.keySet().contains("HOP_DEFINITION"));
     }
 
     @Test

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2Test.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2Test.java
@@ -23,6 +23,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import uk.gov.gchq.gaffer.data.element.Edge;
 import uk.gov.gchq.gaffer.exception.SerialisationException;
 import uk.gov.gchq.gaffer.graph.Graph;
 import uk.gov.gchq.gaffer.graph.GraphConfig;
@@ -43,6 +44,7 @@ import uk.gov.gchq.koryphe.impl.predicate.Not;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -147,11 +149,11 @@ public class GraphConfigurationServiceV2Test {
     @Test
     public void shouldGetSerialisedFields() {
         // When
-        final Set<String> fields = (Set<String>) service.getSerialisedFields(IsA.class.getName()).getEntity();
+        final Map<String, String> fields = (Map<String, String>) service.getSerialisedFields(IsA.class.getName()).getEntity();
 
         // Then
         assertEquals(1, fields.size());
-        assertTrue(fields.contains("type"));
+        assertTrue(fields.keySet().contains("type"));
     }
 
     @Test


### PR DESCRIPTION
The GetSerialisedFields endpoint now returns a Map of Serialised Field to corresponding class type.
Any unknown enums are described as a String, since (de)serialisation will handle this.
The full qualified class name is also included.