### PR TITLE
gh-1721 - Endpoint added

### DIFF
--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/IOperationServiceV2.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/IOperationServiceV2.java
@@ -27,7 +27,6 @@ import org.glassfish.jersey.server.ChunkedOutput;
 
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.OperationChain;
-import uk.gov.gchq.gaffer.operation.OperationException;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -158,13 +157,13 @@ public interface IOperationServiceV2 {
     @GET
     @Path("/namedOperation/{opName}/inputType")
     @ApiOperation(value = "Gets the input type for a given named operation",
-    notes = "Attempts to retrieve the input type for a given named operation",
-    produces = APPLICATION_JSON,
-    response = String.class,
-    responseContainer = "map",
-    responseHeaders = {
-            @ResponseHeader(name = GAFFER_MEDIA_TYPE_HEADER, description = GAFFER_MEDIA_TYPE_HEADER_DESCRIPTION)
-    })
+            notes = "Attempts to retrieve the input type for a given named operation",
+            produces = APPLICATION_JSON,
+            response = String.class,
+            responseContainer = "map",
+            responseHeaders = {
+                    @ResponseHeader(name = GAFFER_MEDIA_TYPE_HEADER, description = GAFFER_MEDIA_TYPE_HEADER_DESCRIPTION)
+            })
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = OK),
             @ApiResponse(code = 403, message = FORBIDDEN),

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/IOperationServiceV2.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/IOperationServiceV2.java
@@ -27,6 +27,7 @@ import org.glassfish.jersey.server.ChunkedOutput;
 
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.OperationChain;
+import uk.gov.gchq.gaffer.operation.OperationException;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -154,5 +155,22 @@ public interface IOperationServiceV2 {
             @ApiResponse(code = 500, message = INTERNAL_SERVER_ERROR)})
     Response nextOperations(@ApiParam(value = "The fully qualified class name, for which all possible compatible follow-up operations should be returned") @PathParam("className") final String className);
 
+    @GET
+    @Path("/namedOperation/{opName}/inputType")
+    @ApiOperation(value = "Gets the input type for a given named operation",
+    notes = "Attempts to retrieve the input type for a given named operation",
+    produces = APPLICATION_JSON,
+    response = String.class,
+    responseContainer = "map",
+    responseHeaders = {
+            @ResponseHeader(name = GAFFER_MEDIA_TYPE_HEADER, description = GAFFER_MEDIA_TYPE_HEADER_DESCRIPTION)
+    })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = OK),
+            @ApiResponse(code = 403, message = FORBIDDEN),
+            @ApiResponse(code = 404, message = OPERATION_NOT_FOUND),
+            @ApiResponse(code = 500, message = INTERNAL_SERVER_ERROR)
+    })
+    Response namedOperationInput(@ApiParam(value = "The name of the NamedOperation for which the input type should be retrieved") @PathParam("opName") final String opName);
 }
 

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/OperationServiceV2.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/OperationServiceV2.java
@@ -17,7 +17,6 @@
 package uk.gov.gchq.gaffer.rest.service.v2;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Iterables;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.glassfish.jersey.server.ChunkedOutput;
 import org.slf4j.Logger;
@@ -35,7 +34,6 @@ import uk.gov.gchq.gaffer.exception.SerialisationException;
 import uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser;
 import uk.gov.gchq.gaffer.named.operation.GetAllNamedOperations;
 import uk.gov.gchq.gaffer.named.operation.NamedOperationDetail;
-import uk.gov.gchq.gaffer.named.operation.cache.exception.CacheOperationFailedException;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.OperationChain;
 import uk.gov.gchq.gaffer.operation.OperationException;
@@ -45,7 +43,6 @@ import uk.gov.gchq.gaffer.rest.factory.UserFactory;
 import uk.gov.gchq.gaffer.rest.service.v2.example.ExamplesFactory;
 import uk.gov.gchq.gaffer.serialisation.util.JsonSerialisationUtil;
 import uk.gov.gchq.gaffer.store.Context;
-import uk.gov.gchq.gaffer.store.operation.handler.named.cache.NamedOperationCache;
 import uk.gov.gchq.koryphe.serialisation.json.SimpleClassNameIdResolver;
 
 import javax.inject.Inject;
@@ -225,7 +222,7 @@ public class OperationServiceV2 implements IOperationServiceV2 {
                 throw new IllegalArgumentException("NamedOperation '" + opName + "' contains no implementations of Input");
             }
 
-        } catch (SerialisationException e) {
+        } catch (final SerialisationException e) {
             throw new IllegalArgumentException("Failed to deserialise operations for NamedOperation: " + opName, e);
         }
 


### PR DESCRIPTION
New endpoint added to expose NamedOperation input types.
Delegates to getSerialisedFields after executing a getAllNamedOperations and filtering on the provided NamedOperation name.
This does mean that some operations will end up with input "types" such as Object[] or I_ITEM[], however.