### PR TITLE
gh-1859 - Implement a Reduce operation.

### DIFF
--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/Reduce.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/Reduce.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2017-2018 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.gov.gchq.gaffer.operation.impl;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.commons.lang3.exception.CloneFailedException;
+
+import uk.gov.gchq.gaffer.commonutil.Required;
+import uk.gov.gchq.gaffer.operation.io.InputOutput;
+import uk.gov.gchq.gaffer.operation.io.MultiInput;
+import uk.gov.gchq.gaffer.operation.serialisation.TypeReferenceImpl;
+import uk.gov.gchq.koryphe.Since;
+import uk.gov.gchq.koryphe.Summary;
+
+import java.util.function.BinaryOperator;
+
+/**
+ * A {@code Reduce} is a Gaffer {@code Operation} which reduces an {@link Iterable}
+ * input of T to a single output value by applying a supplied {@link BinaryOperator}.
+ *
+ * @param <T> the type of the output object (and also the type of object held in
+ *           the input {@link Iterable}.
+ */
+@JsonPropertyOrder(value = {"class", "input", "aggregateFunction", "identity"}, alphabetic = true)
+@Since("1.8.0")
+@Summary("Reduces an input to an output with a single value using provided function")
+public class Reduce<T> implements InputOutput<Iterable<? extends T>, T>, MultiInput<T> {
+    private Iterable<? extends T> input;
+    private T identity;
+    private java.util.Map<String, String> options;
+    @Required
+    private BinaryOperator<T> aggregationFunction;
+
+    public Reduce() {
+        // Empty
+    }
+
+    public Reduce(final BinaryOperator<T> aggregationFunction) {
+        this.aggregationFunction = aggregationFunction;
+    }
+
+    @Override
+    public Iterable<? extends T> getInput() {
+        return input;
+    }
+
+    @Override
+    public void setInput(final Iterable<? extends T> input) {
+        this.input = input;
+    }
+
+    public T getIdentity() {
+        return identity;
+    }
+
+    public void setIdentity(final T identity) {
+        this.identity = identity;
+    }
+
+    @Override
+    public TypeReference<T> getOutputTypeReference() {
+        return TypeReferenceImpl.createExplicitT();
+    }
+
+    @Override
+    public Reduce<T> shallowClone() throws CloneFailedException {
+        final Reduce<T> clone = new Reduce<>();
+        clone.setAggreationFunction(aggregationFunction);
+        clone.setIdentity(identity);
+        clone.setInput(input);
+        clone.setOptions(options);
+        return clone;
+    }
+
+    @Override
+    public java.util.Map<String, String> getOptions() {
+        return options;
+    }
+
+    @Override
+    public void setOptions(final java.util.Map<String, String> options) {
+        this.options = options;
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
+    public BinaryOperator<T> getAggregationFunction() {
+        return aggregationFunction;
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
+    public void setAggreationFunction(final BinaryOperator<T> aggregationFunction) {
+        this.aggregationFunction = aggregationFunction;
+    }
+
+    public static final class Builder<T> extends
+            BaseBuilder<Reduce<T>, Builder<T>> implements
+            InputOutput.Builder<Reduce<T>, Iterable<? extends T>, T, Builder<T>> {
+        public Builder() {
+            super(new Reduce<>());
+        }
+
+        public Builder<T> aggregationFunction(final BinaryOperator aggregationFunction) {
+            if (null != aggregationFunction) {
+                _getOp().setAggreationFunction(aggregationFunction);
+            }
+            return _self();
+        }
+
+        public Builder<T> identity(final T identity) {
+            if (null != identity) {
+                _getOp().setIdentity(identity);
+            }
+            return _self();
+        }
+    }
+}

--- a/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/function/ReduceTest.java
+++ b/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/function/ReduceTest.java
@@ -1,0 +1,54 @@
+package uk.gov.gchq.gaffer.operation.impl.function;
+
+import uk.gov.gchq.gaffer.operation.OperationTest;
+import uk.gov.gchq.gaffer.operation.impl.Reduce;
+import uk.gov.gchq.koryphe.impl.binaryoperator.Sum;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+
+public class ReduceTest extends OperationTest<Reduce> {
+    @Override
+    public void builderShouldCreatePopulatedOperation() {
+        // Given
+        final Iterable<Integer> input = Arrays.asList(1, 2, 3);
+
+        final Reduce<Integer> reduce = new Reduce.Builder<Integer>()
+                .input(input)
+                .identity(0)
+                .aggregationFunction(new Sum())
+                .build();
+
+        // Then
+        assertNotNull(reduce.getInput());
+    }
+
+    @Override
+    public void shouldShallowCloneOperation() {
+        // Given
+        final Iterable<Integer> input = Arrays.asList(1, 2, 3);
+
+        final Reduce<Integer> reduce = new Reduce.Builder<Integer>()
+                .input(input)
+                .identity(0)
+                .aggregationFunction(new Sum())
+                .build();
+
+        // When
+        final Reduce<Integer> clone = reduce.shallowClone();
+
+        // Then
+        assertNotSame(reduce, clone);
+        assertEquals(new Integer(1), clone.getInput().iterator().next());
+    }
+
+    @Override
+    protected Reduce getTestObject() {
+        final Reduce reduce = new Reduce(new Sum());
+        reduce.setIdentity(0);
+        return reduce;
+    }
+}

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/Store.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/Store.java
@@ -48,6 +48,7 @@ import uk.gov.gchq.gaffer.operation.impl.DiscardOutput;
 import uk.gov.gchq.gaffer.operation.impl.GetWalks;
 import uk.gov.gchq.gaffer.operation.impl.If;
 import uk.gov.gchq.gaffer.operation.impl.Limit;
+import uk.gov.gchq.gaffer.operation.impl.Reduce;
 import uk.gov.gchq.gaffer.operation.impl.Validate;
 import uk.gov.gchq.gaffer.operation.impl.ValidateOperationChain;
 import uk.gov.gchq.gaffer.operation.impl.While;
@@ -106,6 +107,7 @@ import uk.gov.gchq.gaffer.store.operation.handler.MapHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.OperationChainHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.OutputOperationHandler;
+import uk.gov.gchq.gaffer.store.operation.handler.ReduceHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.ValidateHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.ValidateOperationChainHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.WhileHandler;
@@ -874,7 +876,7 @@ public abstract class Store {
         addOperationHandler(If.class, new IfHandler());
         addOperationHandler(While.class, new WhileHandler());
         addOperationHandler(ToSingletonList.class, new ToSingletonListHandler());
-
+        addOperationHandler(Reduce.class, new ReduceHandler());
 
         // Function
         addOperationHandler(Filter.class, new FilterHandler());

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/ReduceHandler.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/ReduceHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2018 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.gov.gchq.gaffer.store.operation.handler;
+
+import uk.gov.gchq.gaffer.commonutil.stream.Streams;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.operation.impl.Reduce;
+import uk.gov.gchq.gaffer.store.Context;
+import uk.gov.gchq.gaffer.store.Store;
+
+import java.util.function.BinaryOperator;
+
+/**
+ * A {@code ReduceHandler} is a handler for the {@link Reduce} {@link uk.gov.gchq.gaffer.operation.Operation}
+ *
+ * @param <T> The object type of the input object
+ */
+public class ReduceHandler<T> implements OutputOperationHandler<Reduce<T>, T> {
+
+    /**
+     * Handles the {@link Reduce} operation. Applies the {@link BinaryOperator}
+     * function contained within the Reduce operation and returns the resulting
+     * object.
+     *
+     * @param operation the {@link uk.gov.gchq.gaffer.operation.Operation} to be executed
+     * @param context   the operation chain context, containing the user who executed the operation
+     * @param store     the {@link Store} the operation should be run on
+     * @return the resulting object from the function
+     * @throws OperationException if execution of the operation fails
+     */
+    @Override
+    public T doOperation(final Reduce<T> operation, final Context context, final Store store) throws OperationException {
+        if (null == operation) {
+            throw new OperationException("Operation cannot be null");
+        }
+
+        Iterable<? extends T> input = operation.getInput();
+
+        if (null == input) {
+            throw new OperationException("Input cannot be null");
+        }
+
+        final T identity = operation.getIdentity();
+
+        final BinaryOperator aggregationFunction = operation.getAggregationFunction();
+
+        return (T) Streams.toStream(input)
+                          .reduce(identity, aggregationFunction, aggregationFunction);
+
+    }
+}

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/StoreTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/StoreTest.java
@@ -59,6 +59,7 @@ import uk.gov.gchq.gaffer.operation.impl.GetWalks;
 import uk.gov.gchq.gaffer.operation.impl.If;
 import uk.gov.gchq.gaffer.operation.impl.Limit;
 import uk.gov.gchq.gaffer.operation.impl.Map;
+import uk.gov.gchq.gaffer.operation.impl.Reduce;
 import uk.gov.gchq.gaffer.operation.impl.Validate;
 import uk.gov.gchq.gaffer.operation.impl.ValidateOperationChain;
 import uk.gov.gchq.gaffer.operation.impl.While;
@@ -537,6 +538,7 @@ public class StoreTest {
                 GetTraits.class,
                 While.class,
                 ToSingletonList.class,
+                Reduce.class,
 
                 // Function
                 Filter.class,
@@ -637,6 +639,7 @@ public class StoreTest {
                 If.class,
                 While.class,
                 ToSingletonList.class,
+                Reduce.class,
 
                 // Function
                 Filter.class,

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/ReduceHandlerTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/ReduceHandlerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2016-2018 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.store.operation.handler;
+
+import org.junit.Test;
+
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.operation.impl.Reduce;
+import uk.gov.gchq.koryphe.impl.binaryoperator.Max;
+import uk.gov.gchq.koryphe.impl.binaryoperator.Sum;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class ReduceHandlerTest {
+    @Test
+    public void shouldAggregateResults() throws Exception {
+        // Given
+        final List<Integer> input = Arrays.asList(1, 2, 3, 4, 5);
+        final Integer expectedResult = 15;
+        final Reduce<Integer> reduce = new Reduce.Builder<Integer>()
+                .input(input)
+                .aggregationFunction(new Sum())
+                .build();
+
+        final ReduceHandler<Integer> handler = new ReduceHandler<>();
+
+        // When
+        final Integer result = handler.doOperation(reduce, null, null);
+
+        // Then
+        assertTrue(result instanceof Integer);
+        assertEquals(expectedResult,result);
+    }
+
+    @Test
+    public void shouldAggregateResultsWithIdentity() throws Exception {
+        // Given
+        final List<Integer> input = Arrays.asList(1, 2, 3, 4, 5);
+        final Integer identity = 10;
+        final Integer expectedResult = 10;
+        final Reduce<Integer> reduce = new Reduce.Builder<Integer>()
+                .input(input)
+                .identity(10)
+                .aggregationFunction(new Max())
+                .build();
+
+        final ReduceHandler<Integer> handler = new ReduceHandler<>();
+
+        // When
+        final Integer result = handler.doOperation(reduce, null, null);
+
+        // Then
+        assertTrue(result instanceof Integer);
+        assertEquals(expectedResult,result);
+    }
+
+    @Test
+    public void shouldAggregateResultsWithNullIdentity() throws Exception {
+        // Given
+        final List<Integer> input = Arrays.asList(1, 2, 3, 4, 5);
+        final Integer expectedResult = 5;
+        final Reduce<Integer> reduce = new Reduce.Builder<Integer>()
+                .input(input)
+                .identity(null)
+                .aggregationFunction(new Max())
+                .build();
+
+        final ReduceHandler<Integer> handler = new ReduceHandler<>();
+
+        // When
+        final Integer result = handler.doOperation(reduce, null, null);
+
+        // Then
+        assertTrue(result instanceof Integer);
+        assertEquals(expectedResult,result);
+    }
+
+    @Test
+    public void shouldHandleNullInput() throws Exception {
+        // Given
+        final Iterable<Integer> input = null;
+        final Reduce<Integer> reduce = new Reduce.Builder<Integer>()
+                .input(input)
+                .build();
+
+        final ReduceHandler<Integer> handler = new ReduceHandler<>();
+
+        // When
+        try {
+            final Integer result = handler.doOperation(reduce, null, null);
+        } catch(final OperationException oe) {
+
+            // Then
+            assertThat(oe.getMessage(), is("Input cannot be null"));
+        }
+    }
+
+    @Test
+    public void shouldHandleNullOperation() throws Exception {
+        // Given
+        final ReduceHandler<Integer> handler = new ReduceHandler<>();
+
+        // When
+        try {
+            final Integer result = handler.doOperation(null, null, null);
+        } catch(final OperationException oe) {
+
+            // Then
+            assertThat(oe.getMessage(), is("Operation cannot be null"));
+        }
+    }
+}


### PR DESCRIPTION
A simple implementation of a `Reduce` operation which should be compatible with the existing Koryphe `BinaryOperator` classes.

There's an issue with generic invariance on the Java 8 implementation of the `Stream#reduce(BinaryOperator<T> binaryOperator)` method.

A workaround is to "coerce" the types of objects in the stream into the target type by using the three argument `reduce(U identity, BiFunction<U,? super T,U> accumulator, BinaryOperator<U> combiner)` method.

I can provide more examples of the `Reduce` operation as an integration test if that would be helpful.

The `@Since` annotations will also need to be updated, depending on your release schedule.