### PR TITLE
gh-2047-ViewValidator with static methods

### DIFF
--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/SchemaOperationChainUtil.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/SchemaOperationChainUtil.java
@@ -24,7 +24,6 @@ import uk.gov.gchq.gaffer.operation.Operations;
 import uk.gov.gchq.gaffer.operation.graph.OperationView;
 import uk.gov.gchq.gaffer.store.SchemaOperationChainValidator;
 import uk.gov.gchq.gaffer.store.schema.Schema;
-import uk.gov.gchq.gaffer.store.schema.ViewValidator;
 import uk.gov.gchq.koryphe.ValidationResult;
 
 public final class SchemaOperationChainUtil {

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/SchemaOperationChainUtil.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/SchemaOperationChainUtil.java
@@ -35,7 +35,7 @@ public final class SchemaOperationChainUtil {
 
     public static ValidationResult validate(final Schema schema, final OperationChain operationChain) {
         updateOperationChainViews(operationChain, schema);
-        SchemaOperationChainValidator validator = new SchemaOperationChainValidator(new ViewValidator(), schema);
+        SchemaOperationChainValidator validator = new SchemaOperationChainValidator(schema);
 
         return validator.validate(operationChain, null, null);
     }

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/SchemaOperationChainValidator.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/SchemaOperationChainValidator.java
@@ -28,12 +28,12 @@ public class SchemaOperationChainValidator extends OperationChainValidator {
 
     Schema schema;
 
-    public SchemaOperationChainValidator(final ViewValidator viewValidator) {
-        super(viewValidator);
+    public SchemaOperationChainValidator() {
+        super();
     }
 
-    public SchemaOperationChainValidator(final ViewValidator viewValidator, final Schema schema) {
-        super(viewValidator);
+    public SchemaOperationChainValidator(final Schema schema) {
+        super();
         this.schema = schema;
     }
 

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/SchemaOperationChainValidator.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/SchemaOperationChainValidator.java
@@ -19,7 +19,6 @@ package uk.gov.gchq.gaffer.store;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.store.operation.OperationChainValidator;
 import uk.gov.gchq.gaffer.store.schema.Schema;
-import uk.gov.gchq.gaffer.store.schema.ViewValidator;
 import uk.gov.gchq.gaffer.user.User;
 
 import java.util.Set;

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/Store.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/Store.java
@@ -157,7 +157,6 @@ import uk.gov.gchq.gaffer.store.schema.Schema;
 import uk.gov.gchq.gaffer.store.schema.SchemaElementDefinition;
 import uk.gov.gchq.gaffer.store.schema.SchemaOptimiser;
 import uk.gov.gchq.gaffer.store.schema.TypeDefinition;
-import uk.gov.gchq.gaffer.store.schema.ViewValidator;
 import uk.gov.gchq.gaffer.user.User;
 import uk.gov.gchq.koryphe.ValidationResult;
 import uk.gov.gchq.koryphe.util.ReflectionUtil;

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/Store.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/Store.java
@@ -652,7 +652,7 @@ public abstract class Store {
     }
 
     protected OperationChainValidator createOperationChainValidator() {
-        return new OperationChainValidator(new ViewValidator());
+        return new OperationChainValidator();
     }
 
     public OperationChainValidator getOperationChainValidator() {

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/OperationChainValidator.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/OperationChainValidator.java
@@ -37,11 +37,6 @@ import java.util.Set;
  * Validation class for validating {@link OperationChain}s against {@link ViewValidator}s.
  */
 public class OperationChainValidator {
-    private final ViewValidator viewValidator;
-
-    public OperationChainValidator(final ViewValidator viewValidator) {
-        this.viewValidator = viewValidator;
-    }
 
     /**
      * Validate the provided {@link OperationChain} against the {@link ViewValidator}.
@@ -160,7 +155,7 @@ public class OperationChainValidator {
     protected void validateViews(final Operation op, final User user, final Store store, final ValidationResult validationResult) {
         if (op instanceof GraphFilters) {
             final Schema schema = getSchema(op, user, store);
-            final ValidationResult viewValidationResult = viewValidator.validate(((GraphFilters) op).getView(), schema, getStoreTraits(store));
+            final ValidationResult viewValidationResult = ViewValidator.validate(((GraphFilters) op).getView(), schema, getStoreTraits(store));
             if (!viewValidationResult.isValid()) {
                 validationResult.addError("View for operation "
                         + op.getClass().getName()

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/schema/ViewValidator.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/schema/ViewValidator.java
@@ -47,9 +47,11 @@ import java.util.Set;
  * properties and identifiers in the Schema and the transient properties in the
  * View.
  */
-public class ViewValidator {
+public final class ViewValidator {
     public static final String SKIP_VIEW_VALIDATION = "skipViewValidation";
     private static final Logger LOGGER = LoggerFactory.getLogger(ViewValidator.class);
+
+    private ViewValidator() { }
 
     /**
      * Checks all {@link java.util.function.Predicate}s and {@link java.util.function.Function}s defined are
@@ -74,7 +76,7 @@ public class ViewValidator {
         return result;
     }
 
-    protected static void validateEdge(final View view, final Schema schema, final Set<StoreTrait> storeTraits, final boolean isStoreOrdered, final ValidationResult result) {
+    public static void validateEdge(final View view, final Schema schema, final Set<StoreTrait> storeTraits, final boolean isStoreOrdered, final ValidationResult result) {
         if (null != view.getEdges()) {
             for (final Map.Entry<String, ViewElementDefinition> entry : view.getEdges().entrySet()) {
                 final String group = entry.getKey();
@@ -106,7 +108,7 @@ public class ViewValidator {
         }
     }
 
-    protected static void validateEntities(final View view, final Schema schema, final Set<StoreTrait> storeTraits, final boolean isStoreOrdered, final ValidationResult result) {
+    public static void validateEntities(final View view, final Schema schema, final Set<StoreTrait> storeTraits, final boolean isStoreOrdered, final ValidationResult result) {
         if (null != view.getEntities()) {
             for (final Map.Entry<String, ViewElementDefinition> entry : view.getEntities().entrySet()) {
                 final String group = entry.getKey();

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/schema/ViewValidator.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/schema/ViewValidator.java
@@ -61,7 +61,7 @@ public class ViewValidator {
      * @param storeTraits the store traits
      * @return true if the element definition is valid, otherwise false and an error is logged
      */
-    public ValidationResult validate(final View view, final Schema schema, final Set<StoreTrait> storeTraits) {
+    public static ValidationResult validate(final View view, final Schema schema, final Set<StoreTrait> storeTraits) {
         final boolean isStoreOrdered = storeTraits.contains(StoreTrait.ORDERED);
 
         final ValidationResult result = new ValidationResult();
@@ -74,7 +74,7 @@ public class ViewValidator {
         return result;
     }
 
-    protected void validateEdge(final View view, final Schema schema, final Set<StoreTrait> storeTraits, final boolean isStoreOrdered, final ValidationResult result) {
+    protected static void validateEdge(final View view, final Schema schema, final Set<StoreTrait> storeTraits, final boolean isStoreOrdered, final ValidationResult result) {
         if (null != view.getEdges()) {
             for (final Map.Entry<String, ViewElementDefinition> entry : view.getEdges().entrySet()) {
                 final String group = entry.getKey();
@@ -106,7 +106,7 @@ public class ViewValidator {
         }
     }
 
-    protected void validateEntities(final View view, final Schema schema, final Set<StoreTrait> storeTraits, final boolean isStoreOrdered, final ValidationResult result) {
+    protected static void validateEntities(final View view, final Schema schema, final Set<StoreTrait> storeTraits, final boolean isStoreOrdered, final ValidationResult result) {
         if (null != view.getEntities()) {
             for (final Map.Entry<String, ViewElementDefinition> entry : view.getEntities().entrySet()) {
                 final String group = entry.getKey();
@@ -138,7 +138,7 @@ public class ViewValidator {
         }
     }
 
-    protected ValidationResult validateAgainstStoreTraits(final ViewElementDefinition viewElDef, final Set<StoreTrait> storeTraits) {
+    protected static ValidationResult validateAgainstStoreTraits(final ViewElementDefinition viewElDef, final Set<StoreTrait> storeTraits) {
         final ValidationResult result = new ValidationResult();
 
         if (!storeTraits.contains(StoreTrait.QUERY_AGGREGATION) && null != viewElDef.getAggregator()) {
@@ -152,7 +152,7 @@ public class ViewValidator {
         return result;
     }
 
-    protected ValidationResult validateGroupBy(final boolean isStoreOrdered, final String group, final ViewElementDefinition viewElDef, final SchemaElementDefinition schemaElDef) {
+    protected static ValidationResult validateGroupBy(final boolean isStoreOrdered, final String group, final ViewElementDefinition viewElDef, final SchemaElementDefinition schemaElDef) {
         final ValidationResult result = new ValidationResult();
         final Set<String> viewGroupBy = viewElDef.getGroupBy();
         if (null != viewGroupBy && !viewGroupBy.isEmpty()) {
@@ -172,7 +172,7 @@ public class ViewValidator {
         return result;
     }
 
-    private void validateStoreTrait(final Composite functions, final StoreTrait storeTrait, final Set<StoreTrait> storeTraits, final ValidationResult result) {
+    private static void validateStoreTrait(final Composite functions, final StoreTrait storeTrait, final Set<StoreTrait> storeTraits, final ValidationResult result) {
         if (!storeTraits.contains(storeTrait)
                 && null != functions
                 && null != functions.getComponents()
@@ -181,7 +181,7 @@ public class ViewValidator {
         }
     }
 
-    private ValidationResult validateFunctionArgumentTypes(
+    private static ValidationResult validateFunctionArgumentTypes(
             final ElementAggregator aggregator,
             final ViewElementDefinition viewElDef, final SchemaElementDefinition schemaElDef) {
         final ValidationResult result = new ValidationResult();
@@ -202,7 +202,7 @@ public class ViewValidator {
         return result;
     }
 
-    private ValidationResult validateFunctionArgumentTypes(
+    private static ValidationResult validateFunctionArgumentTypes(
             final ElementFilter filter,
             final ViewElementDefinition viewElDef, final SchemaElementDefinition schemaElDef) {
         final ValidationResult result = new ValidationResult();
@@ -224,7 +224,7 @@ public class ViewValidator {
         return result;
     }
 
-    private ValidationResult validateFunctionArgumentTypes(
+    private static ValidationResult validateFunctionArgumentTypes(
             final ElementTransformer transformer,
             final ViewElementDefinition viewElDef, final SchemaElementDefinition schemaElDef) {
         final ValidationResult result = new ValidationResult();
@@ -251,7 +251,7 @@ public class ViewValidator {
         return result;
     }
 
-    private Class[] getTypeClasses(final String[] keys, final ViewElementDefinition viewElDef, final SchemaElementDefinition schemaElDef) {
+    private static Class[] getTypeClasses(final String[] keys, final ViewElementDefinition viewElDef, final SchemaElementDefinition schemaElDef) {
         final Class[] selectionClasses = new Class[keys.length];
         int i = 0;
         for (final String key : keys) {
@@ -261,7 +261,7 @@ public class ViewValidator {
         return selectionClasses;
     }
 
-    private Class<?> getTypeClass(final String key, final ViewElementDefinition viewElDef, final SchemaElementDefinition schemaElDef) {
+    private static Class<?> getTypeClass(final String key, final ViewElementDefinition viewElDef, final SchemaElementDefinition schemaElDef) {
         final IdentifierType idType = IdentifierType.fromName(key);
         final Class<?> clazz;
         if (null != idType) {

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/OperationChainValidatorTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/OperationChainValidatorTest.java
@@ -67,8 +67,7 @@ public class OperationChainValidatorTest {
     @Test
     public void shouldInValidateNullElementDef() {
         // Given
-        final ViewValidator viewValidator = mock(ViewValidator.class);
-        final OperationChainValidator validator = new OperationChainValidator(viewValidator);
+        final OperationChainValidator validator = new OperationChainValidator();
         final Store store = mock(Store.class);
         Schema schema = mock(Schema.class);
         given(store.getSchema()).willReturn(schema);
@@ -184,14 +183,9 @@ public class OperationChainValidatorTest {
 
     private void validateOperationChain(final OperationChain opChain, final boolean expectedResult) {
         // Given
-        final ViewValidator viewValidator = mock(ViewValidator.class);
-        final OperationChainValidator validator = new OperationChainValidator(viewValidator);
+        final OperationChainValidator validator = new OperationChainValidator();
         final Store store = mock(Store.class);
         final User user = mock(User.class);
-
-
-        given(viewValidator.validate(any(View.class), any(Schema.class), any(Set.class))).willReturn(new ValidationResult());
-
 
         // When
         final ValidationResult validationResult = validator.validate(opChain, user, store);

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/ValidateOperationChainHandlerTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/ValidateOperationChainHandlerTest.java
@@ -53,7 +53,7 @@ public class ValidateOperationChainHandlerTest {
         OperationChain chain = new OperationChain.Builder().first(addElements).then(getAdj).then(getElements).then(discardOutput).build();
         ValidateOperationChain validateOperationChain = new ValidateOperationChain.Builder().operationChain(chain).build();
 
-        given(store.getOperationChainValidator()).willReturn(new OperationChainValidator(new ViewValidator()));
+        given(store.getOperationChainValidator()).willReturn(new OperationChainValidator());
         ValidateOperationChainHandler handler = new ValidateOperationChainHandler();
 
         // When
@@ -71,7 +71,7 @@ public class ValidateOperationChainHandlerTest {
         OperationChain chain = new OperationChain.Builder().first(addElementsFromSocket).build();
         ValidateOperationChain validateOperationChain = new ValidateOperationChain.Builder().operationChain(chain).build();
 
-        given(store.getOperationChainValidator()).willReturn(new OperationChainValidator(new ViewValidator()));
+        given(store.getOperationChainValidator()).willReturn(new OperationChainValidator());
         ValidateOperationChainHandler handler = new ValidateOperationChainHandler();
 
         // When

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/schema/ViewValidatorTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/schema/ViewValidatorTest.java
@@ -54,12 +54,11 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueWhenEmptyFunctions() {
         // Given
-        final ViewValidator validator = new ViewValidator();
         final View view = new View.Builder().build();
         final Schema schema = new Schema();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.isValid());
@@ -68,7 +67,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnFalseWhenEntityTransientPropertyIsInSchema() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .transientProperty(TestPropertyNames.PROP_1, String.class)
@@ -82,7 +81,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertFalse(result.isValid());
@@ -91,7 +90,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueWhenEntityTransientPropertyIsNotInSchema() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .transientProperty(TestPropertyNames.PROP_1, String.class)
@@ -105,7 +104,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.isValid());
@@ -115,7 +114,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueWhenEntityFilterSelectionUnknownProperty() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .transientProperty(TestPropertyNames.PROP_3, String.class)
@@ -131,7 +130,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.isValid());
@@ -140,7 +139,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueWhenEntityTransformerSelectionUnknownProperty() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .transientProperty(TestPropertyNames.PROP_3, String.class)
@@ -159,7 +158,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.isValid());
@@ -168,7 +167,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueWhenEntityTransformerProjectsToUnknownProperty() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .transformer(new ElementTransformer.Builder()
@@ -188,7 +187,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.isValid());
@@ -197,7 +196,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueWhenEntityTransformerResult() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .transformer(new ElementTransformer.Builder()
@@ -219,7 +218,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.isValid());
@@ -228,7 +227,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueWithMatchedVertexFilter() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .edge(TestGroups.EDGE, new ViewElementDefinition.Builder()
                         .preAggregationFilter(new ElementFilter.Builder()
@@ -262,7 +261,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.getErrorString(), result.isValid());
@@ -271,7 +270,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnFalseWhenEdgeTransientPropertyIsInSchema() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .edge(TestGroups.EDGE, new ViewElementDefinition.Builder()
                         .transientProperty(TestPropertyNames.PROP_1, String.class)
@@ -285,7 +284,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertFalse(result.isValid());
@@ -294,7 +293,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueWhenEdgeTransientPropertyIsNotInSchema() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .edge(TestGroups.EDGE, new ViewElementDefinition.Builder()
                         .transientProperty(TestPropertyNames.PROP_1, String.class)
@@ -307,7 +306,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.isValid());
@@ -316,7 +315,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueWhenEdgeFilterSelectionUnknownProperty() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .edge(TestGroups.EDGE, new ViewElementDefinition.Builder()
                         .transientProperty(TestPropertyNames.PROP_3, String.class)
@@ -332,7 +331,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.isValid());
@@ -341,7 +340,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueWhenEdgeTransformerSelectionUnknownProperty() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .edge(TestGroups.EDGE, new ViewElementDefinition.Builder()
                         .transientProperty(TestPropertyNames.PROP_3, String.class)
@@ -359,7 +358,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.isValid());
@@ -368,7 +367,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueWhenEdgeTransformerProjectsToUnknownProperty() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .edge(TestGroups.EDGE, new ViewElementDefinition.Builder()
                         .transformer(new ElementTransformer.Builder()
@@ -388,7 +387,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.isValid());
@@ -397,7 +396,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueWhenEdgeTransformerResult() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .edge(TestGroups.EDGE, new ViewElementDefinition.Builder()
                         .transformer(new ElementTransformer.Builder()
@@ -419,7 +418,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.isValid());
@@ -428,7 +427,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueNoGroupByProperties() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY)
                 .edge(TestGroups.EDGE)
@@ -447,7 +446,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.isValid());
@@ -456,7 +455,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueForNullView() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder().build();
         final Schema schema = new Schema.Builder()
                 .type("vertex", String.class)
@@ -472,7 +471,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.isValid());
@@ -481,7 +480,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueWhenGroupByPropertiesInSchema() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .groupBy(TestPropertyNames.PROP_1)
@@ -519,7 +518,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.isValid());
@@ -528,7 +527,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnFalseWhenTimestampGroupByPropertyUsedInEntity() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .groupBy(TestPropertyNames.PROP_1, TestPropertyNames.PROP_2)
@@ -560,7 +559,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertFalse(result.isValid());
@@ -569,7 +568,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnFalseWhenGroupByPropertyNotInSchema() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .groupBy(TestPropertyNames.PROP_1)
@@ -603,7 +602,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertFalse(result.isValid());
@@ -612,7 +611,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueWhenPostTransformerFilterSet() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .transientProperty(TestPropertyNames.PROP_3, String.class)
@@ -636,7 +635,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.isValid());
@@ -645,7 +644,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueWhenPostTransformerSelectionIsUnknown() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .transientProperty(TestPropertyNames.PROP_3, String.class)
@@ -669,7 +668,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.isValid());
@@ -678,7 +677,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueForOrFilter() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .preAggregationFilter(new ElementFilter.Builder()
@@ -702,7 +701,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.getErrorString(), result.isValid());
@@ -711,7 +710,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnFalseForOrFilterWithIncompatibleProperties() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .preAggregationFilter(new ElementFilter.Builder()
@@ -735,7 +734,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertFalse(result.isValid());
@@ -744,7 +743,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueForAndFilter() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .preAggregationFilter(new ElementFilter.Builder()
@@ -768,7 +767,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.getErrorString(), result.isValid());
@@ -777,7 +776,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnFalseForAndFilterWithIncompatibleProperties() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .preAggregationFilter(new ElementFilter.Builder()
@@ -801,7 +800,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertFalse(result.isValid());
@@ -810,7 +809,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueForNotFilter() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .preAggregationFilter(new ElementFilter.Builder()
@@ -834,7 +833,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.getErrorString(), result.isValid());
@@ -843,7 +842,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnFalseForNotFilterWithIncompatibleProperties() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .preAggregationFilter(new ElementFilter.Builder()
@@ -867,7 +866,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertFalse(result.isValid());
@@ -876,7 +875,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnTrueWhenAggregatorSelectionUnknownProperty() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .aggregator(new ElementAggregator.Builder()
@@ -891,7 +890,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, ALL_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, ALL_STORE_TRAITS);
 
         // Then
         assertTrue(result.isValid());
@@ -901,7 +900,7 @@ public class ViewValidatorTest {
     @Test
     public void shouldValidateAndReturnFalseWhenMissingTraits() {
         // Given
-        final ViewValidator validator = new ViewValidator();
+        
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .transientProperty(TestPropertyNames.PROP_3, String.class)
@@ -939,7 +938,7 @@ public class ViewValidatorTest {
                 .build();
 
         // When
-        final ValidationResult result = validator.validate(view, schema, NO_STORE_TRAITS);
+        final ValidationResult result = ViewValidator.validate(view, schema, NO_STORE_TRAITS);
 
         // Then
         final String errPrefix = "This store does not currently support ";

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v1/ExamplesServiceTest.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v1/ExamplesServiceTest.java
@@ -141,8 +141,7 @@ public class ExamplesServiceTest {
         final View view = builder.build();
         assertNotNull(view);
 
-        final ViewValidator viewValidator = new ViewValidator();
-        assertTrue(viewValidator.validate(view, schema, Sets.newHashSet(StoreTrait.values())).isValid());
+        assertTrue(ViewValidator.validate(view, schema, Sets.newHashSet(StoreTrait.values())).isValid());
     }
 
     private void shouldSerialiseAndDeserialiseOperation(final Operation operation) throws IOException {

--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/FederatedStore.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/FederatedStore.java
@@ -352,7 +352,7 @@ public class FederatedStore extends Store {
 
     @Override
     protected OperationChainValidator createOperationChainValidator() {
-        return new FederatedOperationChainValidator(new FederatedViewValidator());
+        return new FederatedOperationChainValidator();
     }
 
     @Override

--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/FederatedStore.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/FederatedStore.java
@@ -44,7 +44,6 @@ import uk.gov.gchq.gaffer.federatedstore.operation.handler.impl.FederatedGetElem
 import uk.gov.gchq.gaffer.federatedstore.operation.handler.impl.FederatedGetTraitsHandler;
 import uk.gov.gchq.gaffer.federatedstore.operation.handler.impl.FederatedOperationChainHandler;
 import uk.gov.gchq.gaffer.federatedstore.operation.handler.impl.FederatedRemoveGraphHandler;
-import uk.gov.gchq.gaffer.federatedstore.schema.FederatedViewValidator;
 import uk.gov.gchq.gaffer.federatedstore.util.FederatedStoreUtil;
 import uk.gov.gchq.gaffer.graph.Graph;
 import uk.gov.gchq.gaffer.graph.GraphSerialisable;

--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/FederatedOperationChainValidator.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/FederatedOperationChainValidator.java
@@ -41,9 +41,6 @@ import static java.util.Objects.nonNull;
  * the merged schema based on the user context and operation options.
  */
 public class FederatedOperationChainValidator extends OperationChainValidator {
-    public FederatedOperationChainValidator(final ViewValidator viewValidator) {
-        super(viewValidator);
-    }
 
     @Override
     protected Schema getSchema(final Operation operation, final User user, final Store store) {

--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/FederatedOperationChainValidator.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/FederatedOperationChainValidator.java
@@ -22,7 +22,6 @@ import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.store.Store;
 import uk.gov.gchq.gaffer.store.operation.OperationChainValidator;
 import uk.gov.gchq.gaffer.store.schema.Schema;
-import uk.gov.gchq.gaffer.store.schema.ViewValidator;
 import uk.gov.gchq.gaffer.user.User;
 import uk.gov.gchq.koryphe.ValidationResult;
 
@@ -36,7 +35,7 @@ import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
 /**
- * Validation class for validating {@link uk.gov.gchq.gaffer.operation.OperationChain}s against {@link ViewValidator}s using the Federated Store schemas.
+ * Validation class for validating {@link uk.gov.gchq.gaffer.operation.OperationChain}s against {@link uk.gov.gchq.gaffer.store.schema.ViewValidator}s using the Federated Store schemas.
  * Extends {@link OperationChainValidator} and uses the {@link FederatedStore} to get
  * the merged schema based on the user context and operation options.
  */

--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/schema/FederatedViewValidator.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/schema/FederatedViewValidator.java
@@ -26,8 +26,7 @@ import java.util.Set;
 
 public class FederatedViewValidator extends ViewValidator {
 
-    @Override
-    public ValidationResult validate(final View view, final Schema schema, final Set<StoreTrait> storeTraits) {
+    public static ValidationResult validate(final View view, final Schema schema, final Set<StoreTrait> storeTraits) {
         final boolean isStoreOrdered = storeTraits.contains(StoreTrait.ORDERED);
 
         final ValidationResult result = new ValidationResult();

--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/schema/FederatedViewValidator.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/schema/FederatedViewValidator.java
@@ -24,7 +24,9 @@ import uk.gov.gchq.koryphe.ValidationResult;
 
 import java.util.Set;
 
-public class FederatedViewValidator extends ViewValidator {
+public final class FederatedViewValidator {
+
+    private FederatedViewValidator() { }
 
     public static ValidationResult validate(final View view, final Schema schema, final Set<StoreTrait> storeTraits) {
         final boolean isStoreOrdered = storeTraits.contains(StoreTrait.ORDERED);
@@ -33,12 +35,12 @@ public class FederatedViewValidator extends ViewValidator {
 
         if (null != view) {
             final ValidationResult entitiesResult = new ValidationResult();
-            validateEntities(view, schema, storeTraits, isStoreOrdered, result);
+            ViewValidator.validateEntities(view, schema, storeTraits, isStoreOrdered, result);
             if (!entitiesResult.isValid()) {
                 result.add(entitiesResult);
 
                 final ValidationResult edgeResult = new ValidationResult();
-                validateEdge(view, schema, storeTraits, isStoreOrdered, result);
+                ViewValidator.validateEdge(view, schema, storeTraits, isStoreOrdered, result);
 
                 if (!edgeResult.isValid()) {
                     result.add(edgeResult);

--- a/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/operation/FederatedOperationChainValidatorTest.java
+++ b/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/operation/FederatedOperationChainValidatorTest.java
@@ -34,8 +34,7 @@ public class FederatedOperationChainValidatorTest {
     @Test
     public void shouldGetFederatedSchema() {
         // Given
-        final ViewValidator viewValidator = mock(FederatedViewValidator.class);
-        final FederatedOperationChainValidator validator = new FederatedOperationChainValidator(viewValidator);
+        final FederatedOperationChainValidator validator = new FederatedOperationChainValidator();
         final FederatedStore store = mock(FederatedStore.class);
         final User user = mock(User.class);
         final Operation op = mock(Operation.class);


### PR DESCRIPTION
- Made all methods in ViewValidator Static.
- FederatedViewValidator method is now static, removed @Override tag.
- Replaced all instance calls of ViewValidator with static calls.
- Removed Mockito test on (now) static method which was failing.
- OperationChainValidator no longer takes ViewValidator in the constructor.
- SchemaOperationChainValidator additionally no longer takes ViewValidator in the constructor.
      - Consequently, replaced super(viewValidator) with just super().
#2047 