### PR TITLE
update jackson from 2.3.1 to 2.9.9 CVE-2019-12086

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,9 +64,9 @@
         <hbase.version>1.3.0</hbase.version>
         <avro.version>1.7.7</avro.version>
         <hadoop.version>2.6.5</hadoop.version>
-        <jackson.compile.version>2.6.5</jackson.compile.version>
-        <jackson.max.version>2.9.6</jackson.max.version>
-        <jackson.min.version>2.3.1</jackson.min.version>
+        <jackson.compile.version>2.9.9</jackson.compile.version>
+        <jackson.max.version>2.9.9</jackson.max.version>
+        <jackson.min.version>2.9.9</jackson.min.version>
         <jackson.version>${jackson.compile.version}</jackson.version>
 
         <clearspring.version>2.7.0</clearspring.version>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2019-12086
https://security-tracker.debian.org/tracker/CVE-2019-12086

https://www.cvedetails.com/product/34008/Fasterxml-Jackson.html?vendor_id=15866
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.9
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9

https://github.com/FasterXML/jackson/wiki/Jackson-Releases