### PR TITLE
gh-2209: Improve error message for unsupported operations in the federated store

### DIFF
--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/FederatedStore.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/FederatedStore.java
@@ -381,12 +381,6 @@ public class FederatedStore extends Store {
     }
 
     @Override
-    protected Object doUnhandledOperation(final Operation operation,
-                                          final Context context) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     protected void startCacheServiceLoader(final StoreProperties properties) {
         super.startCacheServiceLoader(properties);
         try {

--- a/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreTest.java
+++ b/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreTest.java
@@ -271,7 +271,6 @@ public class FederatedStoreTest {
             assertEquals("Operation class uk.gov.gchq.gaffer.operation.impl.OperationImpl is not supported by the FederatedStore.", e.getMessage());
         }
     }
-    
     @Test
     public void shouldAlwaysReturnSupportedTraits() throws Exception {
         // Given

--- a/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreTest.java
+++ b/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreTest.java
@@ -255,7 +255,22 @@ public class FederatedStoreTest {
             assertContains(e, "GraphId: ", ACC_ID_2);
         }
     }
-
+    @Test
+    public void shouldThrowAppropriateExceptionWhenHandlingAnUnsupportedOperation() {
+        // Given
+        Operation op = new OperationImpl();
+        // When
+        try {
+            store.handleOperation(op, new Context());
+            fail("Exception expected");
+        } catch (final OperationException e) {
+            fail("Expected an UnsupportedOperationException rather than an OperationException");
+        } catch (final UnsupportedOperationException e) {
+            // Then
+            assertEquals("Operation class uk.gov.gchq.gaffer.operation.impl.OperationImpl is not supported by the FederatedStore.", e.getMessage());
+        }
+    }
+    
     @Test
     public void shouldAlwaysReturnSupportedTraits() throws Exception {
         // Given

--- a/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreTest.java
+++ b/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreTest.java
@@ -48,6 +48,7 @@ import uk.gov.gchq.gaffer.graph.GraphSerialisable;
 import uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.operation.impl.OperationImpl;
 import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
 import uk.gov.gchq.gaffer.operation.impl.get.GetAllElements;
 import uk.gov.gchq.gaffer.store.Context;

--- a/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreTest.java
+++ b/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreTest.java
@@ -256,11 +256,6 @@ public class FederatedStoreTest {
         }
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void shouldDoUnhandledOperation() throws Exception {
-        store.doUnhandledOperation(null, null);
-    }
-
     @Test
     public void shouldAlwaysReturnSupportedTraits() throws Exception {
         // Given


### PR DESCRIPTION
Removed unnecessary override of method
It is already implemented correctly in Super Class of FederatedStore.java i.e. Store.java