### PR TITLE
Gh 791 add named operation group label (part of tools Issue #791)

### DIFF
--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/AddNamedOperation.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/AddNamedOperation.java
@@ -58,7 +58,7 @@ public class AddNamedOperation implements Operation, Operations<Operation> {
     @Required
     private String operations;
     private String operationName;
-    private String label;
+    private List<String> labels;
     private String description;
     private List<String> readAccessRoles = new ArrayList<>();
     private List<String> writeAccessRoles = new ArrayList<>();
@@ -124,12 +124,12 @@ public class AddNamedOperation implements Operation, Operations<Operation> {
         this.operationName = operationName;
     }
 
-    public String getLabel() {
-        return label;
+    public List<String> getLabels() {
+        return labels;
     }
 
-    public void setLabel(final String label) {
-        this.label = label;
+    public void setLabels(final List<String> labels) {
+        this.labels = labels;
     }
 
     public List<String> getReadAccessRoles() {
@@ -169,7 +169,7 @@ public class AddNamedOperation implements Operation, Operations<Operation> {
         return new AddNamedOperation.Builder()
                 .operationChain(operations)
                 .name(operationName)
-                .label(label)
+                .labels(labels)
                 .description(description)
                 .readAccessRoles(readAccessRoles.toArray(new String[readAccessRoles.size()]))
                 .writeAccessRoles(writeAccessRoles.toArray(new String[writeAccessRoles.size()]))
@@ -270,8 +270,8 @@ public class AddNamedOperation implements Operation, Operations<Operation> {
             return _self();
         }
 
-        public Builder label(final String label) {
-            _getOp().setLabel(label);
+        public Builder labels(final List<String> labels) {
+            _getOp().setLabels(labels);
             return _self();
         }
 

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/AddNamedOperation.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/AddNamedOperation.java
@@ -18,6 +18,7 @@ package uk.gov.gchq.gaffer.named.operation;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -54,9 +55,11 @@ import static java.util.Objects.nonNull;
 @Since("1.0.0")
 @Summary("Adds a new named operation")
 public class AddNamedOperation implements Operation, Operations<Operation> {
+
     @Required
     private String operations;
     private String operationName;
+    private String label;
     private String description;
     private List<String> readAccessRoles = new ArrayList<>();
     private List<String> writeAccessRoles = new ArrayList<>();
@@ -64,6 +67,7 @@ public class AddNamedOperation implements Operation, Operations<Operation> {
     private Map<String, ParameterDetail> parameters;
     private Map<String, String> options;
     private Integer score;
+
 
     private static final String CHARSET_NAME = CommonConstants.UTF_8;
 
@@ -121,6 +125,14 @@ public class AddNamedOperation implements Operation, Operations<Operation> {
         this.operationName = operationName;
     }
 
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(final String label) {
+        this.label = label;
+    }
+
     public List<String> getReadAccessRoles() {
         return readAccessRoles;
     }
@@ -158,6 +170,7 @@ public class AddNamedOperation implements Operation, Operations<Operation> {
         return new AddNamedOperation.Builder()
                 .operationChain(operations)
                 .name(operationName)
+                .label(label)
                 .description(description)
                 .readAccessRoles(readAccessRoles.toArray(new String[readAccessRoles.size()]))
                 .writeAccessRoles(writeAccessRoles.toArray(new String[writeAccessRoles.size()]))
@@ -255,6 +268,11 @@ public class AddNamedOperation implements Operation, Operations<Operation> {
 
         public Builder name(final String name) {
             _getOp().setOperationName(name);
+            return _self();
+        }
+
+        public Builder label(final String label) {
+            _getOp().setLabel(label);
             return _self();
         }
 

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/AddNamedOperation.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/AddNamedOperation.java
@@ -18,7 +18,6 @@ package uk.gov.gchq.gaffer.named.operation;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/NamedOperationDetail.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/NamedOperationDetail.java
@@ -225,41 +225,42 @@ public class NamedOperationDetail implements Serializable {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
 
-        if (o == null || getClass() != o.getClass()) return false;
+        if (null == obj || getClass() != obj.getClass()) {
+            return false;
+        }
 
-        NamedOperationDetail that = (NamedOperationDetail) o;
+        final NamedOperationDetail op = (NamedOperationDetail) obj;
 
         return new EqualsBuilder()
-                .append(operationName, that.operationName)
-                .append(inputType, that.inputType)
-                .append(description, that.description)
-                .append(label, that.label)
-                .append(creatorId, that.creatorId)
-                .append(operations, that.operations)
-                .append(readAccessRoles, that.readAccessRoles)
-                .append(writeAccessRoles, that.writeAccessRoles)
-                .append(parameters, that.parameters)
-                .append(score, that.score)
+                .append(operationName, op.operationName)
+                .append(label, op.label)
+                .append(inputType, op.inputType)
+                .append(creatorId, op.creatorId)
+                .append(operations, op.operations)
+                .append(readAccessRoles, op.readAccessRoles)
+                .append(writeAccessRoles, op.writeAccessRoles)
+                .append(parameters, op.parameters)
+                .append(score, op.score)
                 .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37)
+        return new HashCodeBuilder(71, 3)
                 .append(operationName)
                 .append(inputType)
-                .append(description)
-                .append(label)
                 .append(creatorId)
                 .append(operations)
                 .append(readAccessRoles)
                 .append(writeAccessRoles)
                 .append(parameters)
                 .append(score)
-                .toHashCode();
+                .hashCode();
     }
 
     @Override

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/NamedOperationDetail.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/NamedOperationDetail.java
@@ -46,6 +46,7 @@ public class NamedOperationDetail implements Serializable {
     private static final long serialVersionUID = -8831783492657131469L;
     private static final String CHARSET_NAME = CommonConstants.UTF_8;
     private String operationName;
+    private String label;
     private String inputType;
     private String description;
     private String creatorId;
@@ -58,15 +59,15 @@ public class NamedOperationDetail implements Serializable {
     public NamedOperationDetail() {
     }
 
-    public NamedOperationDetail(final String operationName, final String description, final String userId,
+    public NamedOperationDetail(final String operationName, final String label, final String description, final String userId,
                                 final String operations, final List<String> readers,
                                 final List<String> writers, final Map<String, ParameterDetail> parameters,
                                 final Integer score) {
-        this(operationName, null, description, userId, operations, readers, writers, parameters, score);
+        this(operationName, label, null, description, userId, operations, readers, writers, parameters, score);
     }
 
-    public NamedOperationDetail(final String operationName, final String inputType, final String description, final String userId,
-                                final String operations, final List<String> readers,
+    public NamedOperationDetail(final String operationName, final String label, final String inputType, final String description,
+                                final String userId, final String operations, final List<String> readers,
                                 final List<String> writers, final Map<String, ParameterDetail> parameters,
                                 final Integer score) {
         if (null == operations) {
@@ -77,6 +78,7 @@ public class NamedOperationDetail implements Serializable {
         }
 
         this.operationName = operationName;
+        this.label = label;
         this.inputType = inputType;
         this.description = description;
         this.creatorId = userId;
@@ -90,6 +92,10 @@ public class NamedOperationDetail implements Serializable {
 
     public String getOperationName() {
         return operationName;
+    }
+
+    public String getLabel() {
+        return label;
     }
 
     public String getInputType() {
@@ -219,47 +225,48 @@ public class NamedOperationDetail implements Serializable {
     }
 
     @Override
-    public boolean equals(final Object obj) {
-        if (this == obj) {
-            return true;
-        }
+    public boolean equals(Object o) {
+        if (this == o) return true;
 
-        if (null == obj || getClass() != obj.getClass()) {
-            return false;
-        }
+        if (o == null || getClass() != o.getClass()) return false;
 
-        final NamedOperationDetail op = (NamedOperationDetail) obj;
+        NamedOperationDetail that = (NamedOperationDetail) o;
 
         return new EqualsBuilder()
-                .append(operationName, op.operationName)
-                .append(inputType, op.inputType)
-                .append(creatorId, op.creatorId)
-                .append(operations, op.operations)
-                .append(readAccessRoles, op.readAccessRoles)
-                .append(writeAccessRoles, op.writeAccessRoles)
-                .append(parameters, op.parameters)
-                .append(score, op.score)
+                .append(operationName, that.operationName)
+                .append(inputType, that.inputType)
+                .append(description, that.description)
+                .append(label, that.label)
+                .append(creatorId, that.creatorId)
+                .append(operations, that.operations)
+                .append(readAccessRoles, that.readAccessRoles)
+                .append(writeAccessRoles, that.writeAccessRoles)
+                .append(parameters, that.parameters)
+                .append(score, that.score)
                 .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(71, 3)
+        return new HashCodeBuilder(17, 37)
                 .append(operationName)
                 .append(inputType)
+                .append(description)
+                .append(label)
                 .append(creatorId)
                 .append(operations)
                 .append(readAccessRoles)
                 .append(writeAccessRoles)
                 .append(parameters)
                 .append(score)
-                .hashCode();
+                .toHashCode();
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .appendSuper(super.toString())
+                .append("label", label)
                 .append("inputType", inputType)
                 .append("creatorId", creatorId)
                 .append("operations", operations)
@@ -304,6 +311,7 @@ public class NamedOperationDetail implements Serializable {
 
     public static final class Builder {
         private String operationName;
+        private String label;
         private String inputType;
         private String description;
         private String creatorId;
@@ -320,6 +328,11 @@ public class NamedOperationDetail implements Serializable {
 
         public Builder operationName(final String operationName) {
             this.operationName = operationName;
+            return this;
+        }
+
+        public Builder label(final String label) {
+            this.label = label;
             return this;
         }
 
@@ -371,7 +384,7 @@ public class NamedOperationDetail implements Serializable {
         }
 
         public NamedOperationDetail build() {
-            return new NamedOperationDetail(operationName, inputType, description, creatorId, opChain, readers, writers, parameters, score);
+            return new NamedOperationDetail(operationName, label, inputType, description, creatorId, opChain, readers, writers, parameters, score);
         }
     }
 }

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/NamedOperationDetail.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/NamedOperationDetail.java
@@ -43,10 +43,11 @@ import java.util.Set;
  */
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class NamedOperationDetail implements Serializable {
+
     private static final long serialVersionUID = -8831783492657131469L;
     private static final String CHARSET_NAME = CommonConstants.UTF_8;
     private String operationName;
-    private String label;
+    private List<String> labels;
     private String inputType;
     private String description;
     private String creatorId;
@@ -59,14 +60,22 @@ public class NamedOperationDetail implements Serializable {
     public NamedOperationDetail() {
     }
 
-    public NamedOperationDetail(final String operationName, final String label, final String description, final String userId,
+
+    public NamedOperationDetail(final String operationName, final String description, final String userId,
                                 final String operations, final List<String> readers,
                                 final List<String> writers, final Map<String, ParameterDetail> parameters,
                                 final Integer score) {
-        this(operationName, label, null, description, userId, operations, readers, writers, parameters, score);
+        this(operationName, null, null, description, userId, operations, readers, writers, parameters, score);
     }
 
-    public NamedOperationDetail(final String operationName, final String label, final String inputType, final String description,
+    public NamedOperationDetail(final String operationName, final String inputType, final String description, final String userId,
+                                final String operations, final List<String> readers,
+                                final List<String> writers, final Map<String, ParameterDetail> parameters,
+                                final Integer score) {
+        this(operationName, null, inputType, description, userId, operations, readers, writers, parameters, score);
+    }
+
+    public NamedOperationDetail(final String operationName, final List<String> labels, final String inputType, final String description,
                                 final String userId, final String operations, final List<String> readers,
                                 final List<String> writers, final Map<String, ParameterDetail> parameters,
                                 final Integer score) {
@@ -78,7 +87,7 @@ public class NamedOperationDetail implements Serializable {
         }
 
         this.operationName = operationName;
-        this.label = label;
+        this.labels = labels;
         this.inputType = inputType;
         this.description = description;
         this.creatorId = userId;
@@ -94,8 +103,8 @@ public class NamedOperationDetail implements Serializable {
         return operationName;
     }
 
-    public String getLabel() {
-        return label;
+    public List<String> getLabels() {
+        return labels;
     }
 
     public String getInputType() {
@@ -238,7 +247,7 @@ public class NamedOperationDetail implements Serializable {
 
         return new EqualsBuilder()
                 .append(operationName, op.operationName)
-                .append(label, op.label)
+                .append(labels, op.labels)
                 .append(inputType, op.inputType)
                 .append(creatorId, op.creatorId)
                 .append(operations, op.operations)
@@ -267,7 +276,7 @@ public class NamedOperationDetail implements Serializable {
     public String toString() {
         return new ToStringBuilder(this)
                 .appendSuper(super.toString())
-                .append("label", label)
+                .append("labels", labels)
                 .append("inputType", inputType)
                 .append("creatorId", creatorId)
                 .append("operations", operations)
@@ -312,7 +321,7 @@ public class NamedOperationDetail implements Serializable {
 
     public static final class Builder {
         private String operationName;
-        private String label;
+        private List<String> labels;
         private String inputType;
         private String description;
         private String creatorId;
@@ -332,8 +341,8 @@ public class NamedOperationDetail implements Serializable {
             return this;
         }
 
-        public Builder label(final String label) {
-            this.label = label;
+        public Builder labels(final List<String> labels) {
+            this.labels = labels;
             return this;
         }
 
@@ -385,7 +394,7 @@ public class NamedOperationDetail implements Serializable {
         }
 
         public NamedOperationDetail build() {
-            return new NamedOperationDetail(operationName, label, inputType, description, creatorId, opChain, readers, writers, parameters, score);
+            return new NamedOperationDetail(operationName, labels, inputType, description, creatorId, opChain, readers, writers, parameters, score);
         }
     }
 }

--- a/core/operation/src/test/java/uk/gov/gchq/gaffer/named/operation/AddNamedOperationTest.java
+++ b/core/operation/src/test/java/uk/gov/gchq/gaffer/named/operation/AddNamedOperationTest.java
@@ -62,6 +62,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
                 .operationChain(OPERATION_CHAIN)
                 .description("Test Named Operation")
                 .name("Test")
+                .label("Test label")
                 .overwrite()
                 .readAccessRoles(USER)
                 .writeAccessRoles(USER)
@@ -78,7 +79,8 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
                 " \"class\" : \"uk.gov.gchq.gaffer.named.operation.AddNamedOperation\",%n" +
                 " \"operationName\": \"Test\",%n" +
                 " \"description\": \"Test Named Operation\",%n" +
-                " \"score\": 0,%n" +
+                " \"score\" : 0,%n" +
+                " \"label\": \"Test label\",%n" +
                 " \"operationChain\": {" +
                 " \"operations\": [{\"class\": \"uk.gov.gchq.gaffer.operation.impl.get.GetAdjacentIds\", \"input\": [{\"vertex\" : \"seed\", \"class\": \"uk.gov.gchq.gaffer.operation.data.EntitySeed\"}]}]},%n" +
                 " \"overwriteFlag\" : true,%n" +
@@ -99,6 +101,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
                 .operationChain(OPERATION_CHAIN)
                 .description("Test Named Operation")
                 .name("Test")
+                .label("Test label")
                 .overwrite()
                 .readAccessRoles(USER)
                 .writeAccessRoles(USER)
@@ -116,6 +119,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
                 " \"operationName\": \"Test\",%n" +
                 " \"description\": \"Test Named Operation\",%n" +
                 " \"score\": 0,%n" +
+                " \"label\": \"Test label\",%n" +
                 " \"operationChain\": {" +
                 " \"operations\": [{\"class\": \"uk.gov.gchq.gaffer.operation.impl.get.GetAdjacentIds\", \"input\": [{\"vertex\" : \"seed\", \"class\": \"uk.gov.gchq.gaffer.operation.data.EntitySeed\"}]}]},%n" +
                 " \"overwriteFlag\" : true,%n" +
@@ -132,6 +136,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
                 .operationChain(OPERATION_CHAIN)
                 .description("Test Named Operation")
                 .name("Test")
+                .label("Test label")
                 .overwrite()
                 .readAccessRoles(USER)
                 .writeAccessRoles(USER)
@@ -144,6 +149,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
         }
         assertEquals(opChain, addNamedOperation.getOperationChainAsString());
         assertEquals("Test", addNamedOperation.getOperationName());
+        assertEquals("Test label", addNamedOperation.getLabel());
         assertEquals("Test Named Operation", addNamedOperation.getDescription());
         assertEquals(Collections.singletonList(USER), addNamedOperation.getReadAccessRoles());
         assertEquals(Collections.singletonList(USER), addNamedOperation.getWriteAccessRoles());
@@ -160,6 +166,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
                 .operationChain(OPERATION_CHAIN)
                 .description("Test Named Operation")
                 .name("Test")
+                .label("Test label")
                 .overwrite(false)
                 .readAccessRoles(USER)
                 .writeAccessRoles(USER)
@@ -180,6 +187,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
         assertNotSame(addNamedOperation, clone);
         assertEquals(opChain, clone.getOperationChainAsString());
         assertEquals("Test", clone.getOperationName());
+        assertEquals("Test label", clone.getLabel());
         assertEquals("Test Named Operation", clone.getDescription());
         assertEquals(2, (int) clone.getScore());
         assertFalse(clone.isOverwriteFlag());
@@ -196,6 +204,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
                 .operationChain("{\"operations\":[{\"class\": \"uk.gov.gchq.gaffer.operation.impl.get.GetAdjacentIds\", \"input\": [{\"vertex\": \"${testParameter}\", \"class\": \"uk.gov.gchq.gaffer.operation.data.EntitySeed\"}]}]}")
                 .description("Test Named Operation")
                 .name("Test")
+                .label("Test label")
                 .overwrite(false)
                 .readAccessRoles(USER)
                 .writeAccessRoles(USER)
@@ -228,6 +237,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
                 .operationChain("{\"operations\":[{\"class\": \"uk.gov.gchq.gaffer.operation.impl.get.GetAdjacentIds\", \"input\": [{\"vertex\": \"${testParameter}\", \"class\": \"uk.gov.gchq.gaffer.operation.data.EntitySeed\"}]}]}")
                 .description("Test Named Operation")
                 .name("Test")
+                .label("Test label")
                 .overwrite(false)
                 .readAccessRoles(USER)
                 .writeAccessRoles(USER)

--- a/core/operation/src/test/java/uk/gov/gchq/gaffer/named/operation/AddNamedOperationTest.java
+++ b/core/operation/src/test/java/uk/gov/gchq/gaffer/named/operation/AddNamedOperationTest.java
@@ -62,7 +62,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
                 .operationChain(OPERATION_CHAIN)
                 .description("Test Named Operation")
                 .name("Test")
-                .label("Test label")
+                .labels(Arrays.asList("Test label"))
                 .overwrite()
                 .readAccessRoles(USER)
                 .writeAccessRoles(USER)
@@ -80,7 +80,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
                 " \"operationName\": \"Test\",%n" +
                 " \"description\": \"Test Named Operation\",%n" +
                 " \"score\" : 0,%n" +
-                " \"label\": \"Test label\",%n" +
+                " \"labels\": [ \"Test label\" ],%n" +
                 " \"operationChain\": {" +
                 " \"operations\": [{\"class\": \"uk.gov.gchq.gaffer.operation.impl.get.GetAdjacentIds\", \"input\": [{\"vertex\" : \"seed\", \"class\": \"uk.gov.gchq.gaffer.operation.data.EntitySeed\"}]}]},%n" +
                 " \"overwriteFlag\" : true,%n" +
@@ -101,7 +101,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
                 .operationChain(OPERATION_CHAIN)
                 .description("Test Named Operation")
                 .name("Test")
-                .label("Test label")
+                .labels(Arrays.asList("Test label"))
                 .overwrite()
                 .readAccessRoles(USER)
                 .writeAccessRoles(USER)
@@ -119,7 +119,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
                 " \"operationName\": \"Test\",%n" +
                 " \"description\": \"Test Named Operation\",%n" +
                 " \"score\": 0,%n" +
-                " \"label\": \"Test label\",%n" +
+                " \"labels\": [ \"Test label\" ],%n" +
                 " \"operationChain\": {" +
                 " \"operations\": [{\"class\": \"uk.gov.gchq.gaffer.operation.impl.get.GetAdjacentIds\", \"input\": [{\"vertex\" : \"seed\", \"class\": \"uk.gov.gchq.gaffer.operation.data.EntitySeed\"}]}]},%n" +
                 " \"overwriteFlag\" : true,%n" +
@@ -136,7 +136,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
                 .operationChain(OPERATION_CHAIN)
                 .description("Test Named Operation")
                 .name("Test")
-                .label("Test label")
+                .labels(Arrays.asList("Test label"))
                 .overwrite()
                 .readAccessRoles(USER)
                 .writeAccessRoles(USER)
@@ -149,7 +149,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
         }
         assertEquals(opChain, addNamedOperation.getOperationChainAsString());
         assertEquals("Test", addNamedOperation.getOperationName());
-        assertEquals("Test label", addNamedOperation.getLabel());
+        assertEquals(Arrays.asList("Test label"), addNamedOperation.getLabels());
         assertEquals("Test Named Operation", addNamedOperation.getDescription());
         assertEquals(Collections.singletonList(USER), addNamedOperation.getReadAccessRoles());
         assertEquals(Collections.singletonList(USER), addNamedOperation.getWriteAccessRoles());
@@ -166,7 +166,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
                 .operationChain(OPERATION_CHAIN)
                 .description("Test Named Operation")
                 .name("Test")
-                .label("Test label")
+                .labels(Arrays.asList("Test label"))
                 .overwrite(false)
                 .readAccessRoles(USER)
                 .writeAccessRoles(USER)
@@ -187,7 +187,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
         assertNotSame(addNamedOperation, clone);
         assertEquals(opChain, clone.getOperationChainAsString());
         assertEquals("Test", clone.getOperationName());
-        assertEquals("Test label", clone.getLabel());
+        assertEquals(Arrays.asList("Test label"), clone.getLabels());
         assertEquals("Test Named Operation", clone.getDescription());
         assertEquals(2, (int) clone.getScore());
         assertFalse(clone.isOverwriteFlag());
@@ -204,7 +204,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
                 .operationChain("{\"operations\":[{\"class\": \"uk.gov.gchq.gaffer.operation.impl.get.GetAdjacentIds\", \"input\": [{\"vertex\": \"${testParameter}\", \"class\": \"uk.gov.gchq.gaffer.operation.data.EntitySeed\"}]}]}")
                 .description("Test Named Operation")
                 .name("Test")
-                .label("Test label")
+                .labels(Arrays.asList("Test label"))
                 .overwrite(false)
                 .readAccessRoles(USER)
                 .writeAccessRoles(USER)
@@ -237,7 +237,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
                 .operationChain("{\"operations\":[{\"class\": \"uk.gov.gchq.gaffer.operation.impl.get.GetAdjacentIds\", \"input\": [{\"vertex\": \"${testParameter}\", \"class\": \"uk.gov.gchq.gaffer.operation.data.EntitySeed\"}]}]}")
                 .description("Test Named Operation")
                 .name("Test")
-                .label("Test label")
+                .labels(Arrays.asList("Test label"))
                 .overwrite(false)
                 .readAccessRoles(USER)
                 .writeAccessRoles(USER)

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/named/AddNamedOperationHandler.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/named/AddNamedOperationHandler.java
@@ -63,7 +63,7 @@ public class AddNamedOperationHandler implements OperationHandler<AddNamedOperat
             final NamedOperationDetail namedOperationDetail = new NamedOperationDetail.Builder()
                     .operationChain(operation.getOperationChainAsString())
                     .operationName(operation.getOperationName())
-                    .label(operation.getLabel())
+                    .labels(operation.getLabels())
                     .creatorId(context.getUser().getUserId())
                     .readers(operation.getReadAccessRoles())
                     .writers(operation.getWriteAccessRoles())

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/named/AddNamedOperationHandler.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/named/AddNamedOperationHandler.java
@@ -63,6 +63,7 @@ public class AddNamedOperationHandler implements OperationHandler<AddNamedOperat
             final NamedOperationDetail namedOperationDetail = new NamedOperationDetail.Builder()
                     .operationChain(operation.getOperationChainAsString())
                     .operationName(operation.getOperationName())
+                    .label(operation.getLabel())
                     .creatorId(context.getUser().getUserId())
                     .readers(operation.getReadAccessRoles())
                     .writers(operation.getWriteAccessRoles())

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/named/AddNamedOperationHandlerTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/named/AddNamedOperationHandlerTest.java
@@ -46,6 +46,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
@@ -212,24 +213,26 @@ public class AddNamedOperationHandlerTest {
     }
 
     @Test
-    public void shouldAddNamedOperationWithScoreCorrectly() throws OperationException, CacheOperationFailedException {
+    public void shouldAddNamedOperationFieldsToNamedOperationDetailCorrectly() throws OperationException, CacheOperationFailedException {
         OperationChain opChain = new OperationChain.Builder().first(new AddElements()).build();
         addNamedOperation.setOperationChain(opChain);
         addNamedOperation.setScore(2);
         addNamedOperation.setOperationName("testOp");
+        addNamedOperation.setLabel("test label");
 
         handler.doOperation(addNamedOperation, context, store);
 
         final NamedOperationDetail result = mockCache.getNamedOperation("testOp", new User(), EMPTY_ADMIN_AUTH);
 
         assert cacheContains("testOp");
-        assertEquals(addNamedOperation.getScore(), result.getScore());
+        assertTrue(result.getScore() == 2);
+        assertEquals("test label", result.getLabel());
     }
 
-    private boolean cacheContains(final String opName) {
+    private boolean cacheContains(final String operationName) {
         Iterable<NamedOperationDetail> ops = mockCache.getAllNamedOperations(context.getUser(), EMPTY_ADMIN_AUTH);
         for (final NamedOperationDetail op : ops) {
-            if (op.getOperationName().equals(opName)) {
+            if (op.getOperationName().equals(operationName)) {
                 return true;
             }
         }

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/named/AddNamedOperationHandlerTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/named/AddNamedOperationHandlerTest.java
@@ -42,6 +42,7 @@ import uk.gov.gchq.gaffer.store.operation.handler.named.cache.NamedOperationCach
 import uk.gov.gchq.gaffer.user.User;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -218,7 +219,7 @@ public class AddNamedOperationHandlerTest {
         addNamedOperation.setOperationChain(opChain);
         addNamedOperation.setScore(2);
         addNamedOperation.setOperationName("testOp");
-        addNamedOperation.setLabel("test label");
+        addNamedOperation.setLabels(Arrays.asList("test label"));
 
         handler.doOperation(addNamedOperation, context, store);
 
@@ -226,7 +227,7 @@ public class AddNamedOperationHandlerTest {
 
         assert cacheContains("testOp");
         assertTrue(result.getScore() == 2);
-        assertEquals("test label", result.getLabel());
+        assertEquals(Arrays.asList("test label"), result.getLabels());
     }
 
     private boolean cacheContains(final String operationName) {

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/named/GetAllNamedOperationsHandlerTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/named/GetAllNamedOperationsHandlerTest.java
@@ -33,6 +33,7 @@ import uk.gov.gchq.gaffer.store.operation.handler.named.cache.NamedOperationCach
 import uk.gov.gchq.gaffer.user.User;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -84,28 +85,28 @@ public class GetAllNamedOperationsHandlerTest {
     public void shouldReturnLabelWhenNamedOperationHasLabel() throws Exception {
         final AddNamedOperation addNamedOperationWithLabel = new AddNamedOperation.Builder()
                 .name("My Operation With Label")
-                .label("test label")
+                .labels(Arrays.asList("test label"))
                 .operationChain("{\"operations\":[{\"class\":\"uk.gov.gchq.gaffer.operation.impl.add.AddElements\",\"skipInvalidElements\":false,\"validate\":true}]}")
                 .build();
         addNamedOperationHandler.doOperation(addNamedOperationWithLabel, context, store);
 
         final CloseableIterable<NamedOperationDetail> allNamedOperations = getAllNamedOperationsHandler.doOperation(new GetAllNamedOperations(), context, store);
 
-        assertEquals("test label", allNamedOperations.iterator().next().getLabel());
+        assertEquals(Arrays.asList("test label"), allNamedOperations.iterator().next().getLabels());
     }
 
     @Test
     public void shouldReturnNullLabelWhenLabelIsNullFromAddNamedOperationRequest() throws Exception {
         final AddNamedOperation addNamedOperationWithNullLabel = new AddNamedOperation.Builder()
                 .name("My Operation With Label")
-                .label(null)
+                .labels(null)
                 .operationChain("{\"operations\":[{\"class\":\"uk.gov.gchq.gaffer.operation.impl.add.AddElements\",\"skipInvalidElements\":false,\"validate\":true}]}")
                 .build();
         addNamedOperationHandler.doOperation(addNamedOperationWithNullLabel, context, store);
 
         final CloseableIterable<NamedOperationDetail> allNamedOperations = getAllNamedOperationsHandler.doOperation(new GetAllNamedOperations(), context, store);
 
-        assertEquals(null, allNamedOperations.iterator().next().getLabel());
+        assertEquals(null, allNamedOperations.iterator().next().getLabels());
     }
 
     @Test

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/named/GetAllNamedOperationsHandlerTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/named/GetAllNamedOperationsHandlerTest.java
@@ -82,12 +82,12 @@ public class GetAllNamedOperationsHandlerTest {
 
     @Test
     public void shouldReturnLabelWhenNamedOperationHasLabel() throws Exception {
-        AddNamedOperation addNamedOperation = new AddNamedOperation.Builder()
+        final AddNamedOperation addNamedOperationWithLabel = new AddNamedOperation.Builder()
                 .name("My Operation With Label")
                 .label("test label")
                 .operationChain("{\"operations\":[{\"class\":\"uk.gov.gchq.gaffer.operation.impl.add.AddElements\",\"skipInvalidElements\":false,\"validate\":true}]}")
                 .build();
-        addNamedOperationHandler.doOperation(addNamedOperation, context, store);
+        addNamedOperationHandler.doOperation(addNamedOperationWithLabel, context, store);
 
         final CloseableIterable<NamedOperationDetail> allNamedOperations = getAllNamedOperationsHandler.doOperation(new GetAllNamedOperations(), context, store);
 
@@ -96,12 +96,12 @@ public class GetAllNamedOperationsHandlerTest {
 
     @Test
     public void shouldReturnNullLabelWhenLabelIsNullFromAddNamedOperationRequest() throws Exception {
-        AddNamedOperation addNamedOperation = new AddNamedOperation.Builder()
+        final AddNamedOperation addNamedOperationWithNullLabel = new AddNamedOperation.Builder()
                 .name("My Operation With Label")
                 .label(null)
                 .operationChain("{\"operations\":[{\"class\":\"uk.gov.gchq.gaffer.operation.impl.add.AddElements\",\"skipInvalidElements\":false,\"validate\":true}]}")
                 .build();
-        addNamedOperationHandler.doOperation(addNamedOperation, context, store);
+        addNamedOperationHandler.doOperation(addNamedOperationWithNullLabel, context, store);
 
         final CloseableIterable<NamedOperationDetail> allNamedOperations = getAllNamedOperationsHandler.doOperation(new GetAllNamedOperations(), context, store);
 

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/named/GetAllNamedOperationsHandlerTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/named/GetAllNamedOperationsHandlerTest.java
@@ -81,6 +81,34 @@ public class GetAllNamedOperationsHandlerTest {
     }
 
     @Test
+    public void shouldReturnLabelWhenNamedOperationHasLabel() throws Exception {
+        AddNamedOperation addNamedOperation = new AddNamedOperation.Builder()
+                .name("My Operation With Label")
+                .label("test label")
+                .operationChain("{\"operations\":[{\"class\":\"uk.gov.gchq.gaffer.operation.impl.add.AddElements\",\"skipInvalidElements\":false,\"validate\":true}]}")
+                .build();
+        addNamedOperationHandler.doOperation(addNamedOperation, context, store);
+
+        final CloseableIterable<NamedOperationDetail> allNamedOperations = getAllNamedOperationsHandler.doOperation(new GetAllNamedOperations(), context, store);
+
+        assertEquals("test label", allNamedOperations.iterator().next().getLabel());
+    }
+
+    @Test
+    public void shouldReturnNullLabelWhenLabelIsNullFromAddNamedOperationRequest() throws Exception {
+        AddNamedOperation addNamedOperation = new AddNamedOperation.Builder()
+                .name("My Operation With Label")
+                .label(null)
+                .operationChain("{\"operations\":[{\"class\":\"uk.gov.gchq.gaffer.operation.impl.add.AddElements\",\"skipInvalidElements\":false,\"validate\":true}]}")
+                .build();
+        addNamedOperationHandler.doOperation(addNamedOperation, context, store);
+
+        final CloseableIterable<NamedOperationDetail> allNamedOperations = getAllNamedOperationsHandler.doOperation(new GetAllNamedOperations(), context, store);
+
+        assertEquals(null, allNamedOperations.iterator().next().getLabel());
+    }
+
+    @Test
     public void shouldReturnNamedOperationWithInputType() throws Exception {
         // Given
         AddNamedOperation addNamedOperation = new AddNamedOperation.Builder()

--- a/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/GraphHooksIT.java
+++ b/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/GraphHooksIT.java
@@ -100,6 +100,7 @@ public class GraphHooksIT extends AbstractStoreIT {
                         .build())
                 .description("named operation GetAllElements test query")
                 .name("GetAllElements test")
+                .labels(Arrays.asList("label 1", "Label 2"))
                 .overwrite(true)
                 .build();
 

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/example/DefaultExamplesFactory.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/example/DefaultExamplesFactory.java
@@ -26,6 +26,7 @@ import uk.gov.gchq.gaffer.data.element.id.EntityId;
 import uk.gov.gchq.gaffer.data.elementdefinition.view.GlobalViewElementDefinition;
 import uk.gov.gchq.gaffer.data.elementdefinition.view.View;
 import uk.gov.gchq.gaffer.data.generator.MapGenerator;
+import uk.gov.gchq.gaffer.named.operation.AddNamedOperation;
 import uk.gov.gchq.gaffer.named.view.AddNamedView;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.OperationChain;
@@ -102,6 +103,7 @@ public class DefaultExamplesFactory implements ExamplesFactory {
         map.put(Min.class, min());
         map.put(ToMap.class, toMap());
         map.put(GetWalks.class, getWalks());
+        map.put(AddNamedOperation.class, addNamedOperation());
         map.put(AddNamedView.class, addNamedView());
         map.put(If.class, ifOperation());
         map.put(While.class, whileOperation());
@@ -477,6 +479,19 @@ public class DefaultExamplesFactory implements ExamplesFactory {
                                 .build())
                         .build())
                 .resultsLimit(10000)
+                .build();
+    }
+
+    @Override
+    public AddNamedOperation addNamedOperation() {
+        return new AddNamedOperation.Builder()
+                .name("My Named Operation")
+                .label("My Group Name Label")
+                .description("A description of my named operation")
+                .score(2)
+                .operationChain(new OperationChain.Builder().first(new GetAllElements()).build())
+                .overwrite(true)
+                .options(new HashMap<>())
                 .build();
     }
 

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/example/DefaultExamplesFactory.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/example/DefaultExamplesFactory.java
@@ -486,8 +486,8 @@ public class DefaultExamplesFactory implements ExamplesFactory {
     public AddNamedOperation addNamedOperation() {
         return new AddNamedOperation.Builder()
                 .name("My Named Operation")
-                .label("My Group Name Label")
-                .description("A description of my named operation")
+                .labels(Arrays.asList("Optional list of group labels"))
+                .description("Optional description of my named operation")
                 .score(2)
                 .operationChain(new OperationChain.Builder().first(new GetAllElements()).build())
                 .overwrite(true)

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/example/ExamplesFactory.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/example/ExamplesFactory.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.rest.service.v2.example;
 
+import uk.gov.gchq.gaffer.named.operation.AddNamedOperation;
 import uk.gov.gchq.gaffer.named.view.AddNamedView;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.impl.GetWalks;
@@ -124,6 +125,13 @@ public interface ExamplesFactory {
      * @return the example class for GetWalks
      */
     GetWalks getWalks();
+
+    /**
+     * Generates an example for the {@link AddNamedOperation} operation.
+     *
+     * @return the example of a customisable AddNamedOperation
+     */
+    AddNamedOperation addNamedOperation();
 
     /**
      * Generates an example for the {@link AddNamedView} operation.

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/impl/OperationServiceIT.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/impl/OperationServiceIT.java
@@ -23,6 +23,9 @@ import uk.gov.gchq.gaffer.commonutil.TestGroups;
 import uk.gov.gchq.gaffer.data.GroupCounts;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.Entity;
+import uk.gov.gchq.gaffer.named.operation.AddNamedOperation;
+import uk.gov.gchq.gaffer.named.operation.GetAllNamedOperations;
+import uk.gov.gchq.gaffer.named.operation.NamedOperationDetail;
 import uk.gov.gchq.gaffer.operation.OperationChain;
 import uk.gov.gchq.gaffer.operation.impl.CountGroups;
 import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
@@ -34,6 +37,7 @@ import javax.ws.rs.core.Response;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -41,6 +45,35 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 public abstract class OperationServiceIT extends AbstractRestApiIT {
+
+    @Test
+    public void shouldReturnNamedOpDetailWithLabelWhenLabelIsAddedToNamedOp() throws Exception {
+        // Given
+        final AddNamedOperation namedOperation = new AddNamedOperation.Builder()
+                .name("My Operation With Label")
+                .label("test label")
+                .operationChain("{\"operations\":[{\"class\":\"uk.gov.gchq.gaffer.operation.impl.add.AddElements\",\"skipInvalidElements\":false,\"validate\":true}]}")
+                .build();
+        client.executeOperation(namedOperation);
+
+        // When
+        final Response response = client.executeOperation(new GetAllNamedOperations());
+        final List<NamedOperationDetail> namedOperationDetails = response.readEntity(new GenericType<List<NamedOperationDetail>>() {
+        });
+
+        // Then
+        final NamedOperationDetail expected = new NamedOperationDetail.Builder()
+                .operationName("My Operation With Label")
+                .label("test label")
+                .operationChain("{\"operations\":[{\"class\":\"uk.gov.gchq.gaffer.operation.impl.add.AddElements\",\"skipInvalidElements\":false,\"validate\":true}]}")
+                .inputType("uk.gov.gchq.gaffer.data.element.Element[]")
+                .creatorId("UNKNOWN")
+                .readers(Arrays.asList())
+                .writers(Arrays.asList())
+                .build();
+        assertEquals(expected, namedOperationDetails.iterator().next());
+    }
+
     @Test
     public void shouldReturnAllElements() throws IOException {
         // Given

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/impl/OperationServiceIT.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/impl/OperationServiceIT.java
@@ -51,7 +51,7 @@ public abstract class OperationServiceIT extends AbstractRestApiIT {
         // Given
         final AddNamedOperation namedOperation = new AddNamedOperation.Builder()
                 .name("My Operation With Label")
-                .label("test label")
+                .labels(Arrays.asList("test label"))
                 .operationChain("{\"operations\":[{\"class\":\"uk.gov.gchq.gaffer.operation.impl.add.AddElements\",\"skipInvalidElements\":false,\"validate\":true}]}")
                 .build();
         client.executeOperation(namedOperation);
@@ -64,7 +64,7 @@ public abstract class OperationServiceIT extends AbstractRestApiIT {
         // Then
         final NamedOperationDetail expected = new NamedOperationDetail.Builder()
                 .operationName("My Operation With Label")
-                .label("test label")
+                .labels(Arrays.asList("test label"))
                 .operationChain("{\"operations\":[{\"class\":\"uk.gov.gchq.gaffer.operation.impl.add.AddElements\",\"skipInvalidElements\":false,\"validate\":true}]}")
                 .inputType("uk.gov.gchq.gaffer.data.element.Element[]")
                 .creatorId("UNKNOWN")

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/OperationServiceV2IT.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/OperationServiceV2IT.java
@@ -422,7 +422,7 @@ public class OperationServiceV2IT extends OperationServiceIT {
         public User createUser() {
             final String headerAuthVal = httpHeaders.getHeaderString(HttpHeaders.AUTHORIZATION);
             return new User.Builder()
-                    .userId("unknown")
+                    .userId("UNKNOWN")
                     .opAuth(headerAuthVal)
                     .build();
         }


### PR DESCRIPTION
Hi - here is the back end change for Issue #791 (in gaffer-tools) - it's ready to go in to develop anytime by itself.

This backend feature in this PR is just enabling NamedOperationDetail to include a label and it is safe to merge anytime - as I'm still working on the gaffer-tools UI to send the request down.

It is compatible with the current request that gaffer-tools and Swagger sends (i.e. it sends AddNamedOperation request with "label" missing from body - the backend will read this as null).

Let me know what you think, thanks