### PR TITLE
bugfix for gh-2239:  Merging views with global elements

### DIFF
--- a/core/data/src/main/java/uk/gov/gchq/gaffer/data/elementdefinition/view/View.java
+++ b/core/data/src/main/java/uk/gov/gchq/gaffer/data/elementdefinition/view/View.java
@@ -203,17 +203,17 @@ public class View extends ElementDefinitions<ViewElementDefinition, ViewElementD
      * The global element definitions will then be set to null
      */
     public void expandGlobalDefinitions() {
-        if (null != globalEntities && !globalEntities.isEmpty()) {
+        if (null != globalEntities && !globalEntities.isEmpty() && !getEntityGroups().isEmpty()) {
             setEntities(expandGlobalDefinitions(getEntities(), getEntityGroups(), globalEntities, false));
             globalEntities = null;
         }
 
-        if (null != globalEdges && !globalEdges.isEmpty()) {
+        if (null != globalEdges && !globalEdges.isEmpty() && !getEdgeGroups().isEmpty()) {
             setEdges(expandGlobalDefinitions(getEdges(), getEdgeGroups(), globalEdges, false));
             globalEdges = null;
         }
 
-        if (null != globalElements && !globalElements.isEmpty()) {
+        if (null != globalElements && !globalElements.isEmpty() && (!getEdgeGroups().isEmpty() || !getEntityGroups().isEmpty())) {
             setEntities(expandGlobalDefinitions(getEntities(), getEntityGroups(), globalElements, true));
             setEdges(expandGlobalDefinitions(getEdges(), getEdgeGroups(), globalElements, true));
             globalElements = null;

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/Graph.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/Graph.java
@@ -72,19 +72,20 @@ import static org.apache.commons.collections.CollectionUtils.isEmpty;
 /**
  * <p>
  * The Graph separates the user from the {@link Store}. It holds an instance of
- * the {@link Store} and acts as a proxy for the store, delegating
- * {@link Operation}s to the store.
+ * the {@link Store} and
+ * acts as a proxy for the store, delegating {@link Operation}s to the store.
  * </p>
  * <p>
  * The Graph provides users with a single point of entry for executing
- * operations on a store. This allows the underlying store to be swapped and the
- * same operations can still be applied.
+ * operations on a store.
+ * This allows the underlying store to be swapped and the same operations can
+ * still be applied.
  * </p>
  * <p>
  * Graphs also provides a view of the data with a instance of {@link View}. The
- * view filters out unwanted information and can transform
- * {@link uk.gov.gchq.gaffer.data.element.Properties} into transient properties
- * such as averages.
+ * view filters out unwanted information
+ * and can transform {@link uk.gov.gchq.gaffer.data.element.Properties} into
+ * transient properties such as averages.
  * </p>
  * <p>
  * When executing operations on a graph, an operation view would override the
@@ -104,11 +105,12 @@ public final class Graph {
     private GraphConfig config;
 
     /**
-     * Constructs a {@code Graph} with the given
-     * {@link uk.gov.gchq.gaffer.store.Store} and
+     * Constructs a {@code Graph} with the given {@link uk.gov.gchq.gaffer.store.Store}
+     * and
      * {@link uk.gov.gchq.gaffer.data.elementdefinition.view.View}.
      *
-     * @param config a {@link GraphConfig} used to store the configuration for a
+     * @param config a {@link GraphConfig} used to store the configuration for
+     *               a
      *               Graph.
      * @param store  a {@link Store} used to store the elements and handle
      *               operations.
@@ -119,8 +121,8 @@ public final class Graph {
     }
 
     /**
-     * Performs the given operation on the store. If the operation does not have a
-     * view then the graph view is used.
+     * Performs the given operation on the store.
+     * If the operation does not have a view then the graph view is used.
      *
      * @param operation the operation to be executed.
      * @param user      the user executing the operation.
@@ -131,9 +133,9 @@ public final class Graph {
     }
 
     /**
-     * Performs the given operation on the store. If the operation does not have a
-     * view then the graph view is used. The context will be cloned and a new jobId
-     * will be created.
+     * Performs the given operation on the store.
+     * If the operation does not have a view then the graph view is used.
+     * The context will be cloned and a new jobId will be created.
      *
      * @param operation the operation to be executed.
      * @param context   the user context for the execution of the operation
@@ -144,8 +146,8 @@ public final class Graph {
     }
 
     /**
-     * Performs the given output operation on the store. If the operation does not
-     * have a view then the graph view is used.
+     * Performs the given output operation on the store.
+     * If the operation does not have a view then the graph view is used.
      *
      * @param operation the output operation to be executed.
      * @param user      the user executing the operation.
@@ -158,9 +160,9 @@ public final class Graph {
     }
 
     /**
-     * Performs the given output operation on the store. If the operation does not
-     * have a view then the graph view is used. The context will be cloned and a new
-     * jobId will be created.
+     * Performs the given output operation on the store.
+     * If the operation does not have a view then the graph view is used.
+     * The context will be cloned and a new jobId will be created.
      *
      * @param operation the output operation to be executed.
      * @param context   the user context for the execution of the operation.
@@ -173,8 +175,7 @@ public final class Graph {
     }
 
     /**
-     * Exeutes a {@link GraphRequest} on the graph and returns the
-     * {@link GraphResult}.
+     * Executes a {@link GraphRequest} on the graph and returns the {@link GraphResult}.
      *
      * @param request the request to execute
      * @param <O>     the result type
@@ -186,8 +187,8 @@ public final class Graph {
     }
 
     /**
-     * Performs the given operation job on the store. If the operation does not have
-     * a view then the graph view is used.
+     * Performs the given operation job on the store.
+     * If the operation does not have a view then the graph view is used.
      *
      * @param operation the operation to be executed.
      * @param user      the user executing the job.
@@ -199,9 +200,9 @@ public final class Graph {
     }
 
     /**
-     * Performs the given operation job on the store. If the operation does not have
-     * a view then the graph view is used. The context will be cloned and a new
-     * jobId will be created.
+     * Performs the given operation job on the store.
+     * If the operation does not have a view then the graph view is used.
+     * The context will be cloned and a new jobId will be created.
      *
      * @param operation the operation to be executed.
      * @param context   the user context for the execution of the operation
@@ -214,9 +215,9 @@ public final class Graph {
 
     /**
      * Executes the given {@link GraphRequest} on the graph as an asynchronous job
-     * and returns a {@link GraphResult} containing the {@link JobDetail}s. If the
-     * operation does not have a view then the graph view is used. The context will
-     * be cloned and a new jobId will be created.
+     * and returns a {@link GraphResult} containing the {@link JobDetail}s.
+     * If the operation does not have a view then the graph view is used.
+     * The context will be cloned and a new jobId will be created.
      *
      * @param request the request to execute
      * @return {@link GraphResult} containing the job details
@@ -227,12 +228,12 @@ public final class Graph {
     }
 
     /**
-     * Performs the given Job on the store. This should be used for Scheduled Jobs,
-     * although if no repeat is set it will act as a normal Job.
+     * Performs the given Job on the store.
+     * This should be used for Scheduled Jobs,
+     * although if no repeat is set it
+     * will act as a normal Job.
      *
-     * @param job  the {@link Job} to execute, which contains the
-     *             {@link OperationChain} and the
-     *             {@link uk.gov.gchq.gaffer.jobtracker.Repeat}
+     * @param job  the {@link Job} to execute, which contains the {@link OperationChain} and the {@link uk.gov.gchq.gaffer.jobtracker.Repeat}
      * @param user the user running the Job.
      * @return the job detail.
      * @throws OperationException thrown if the job fails to run.
@@ -242,12 +243,12 @@ public final class Graph {
     }
 
     /**
-     * Performs the given Job on the store. This should be used for Scheduled Jobs,
-     * although if no repeat is set it will act as a normal Job.
+     * Performs the given Job on the store.
+     * This should be used for Scheduled Jobs,
+     * although if no repeat is set it
+     * will act as a normal Job.
      *
-     * @param job     the {@link Job} to execute, which contains the
-     *                {@link OperationChain} and the
-     *                {@link uk.gov.gchq.gaffer.jobtracker.Repeat}
+     * @param job     the {@link Job} to execute, which contains the {@link OperationChain} and the {@link uk.gov.gchq.gaffer.jobtracker.Repeat}
      * @param context the user context for the execution of the operation
      * @return the job detail
      * @throws OperationException thrown if the job fails to run.
@@ -284,8 +285,7 @@ public final class Graph {
                 try {
                     result = graphHook.onFailure(result, clonedOpChain, clonedContext, e);
                 } catch (final Exception graphHookE) {
-                    LOGGER.warn("Error in graphHook " + graphHook.getClass().getSimpleName() + ": "
-                            + graphHookE.getMessage(), graphHookE);
+                    LOGGER.warn("Error in graphHook " + graphHook.getClass().getSimpleName() + ": " + graphHookE.getMessage(), graphHookE);
                 }
             }
             CloseableUtil.close(clonedOpChain);
@@ -295,8 +295,7 @@ public final class Graph {
         return result;
     }
 
-    private <O> GraphResult<O> _execute(final StoreExecuter<O> storeExecuter, final GraphRequest<?> request)
-            throws OperationException {
+    private <O> GraphResult<O> _execute(final StoreExecuter<O> storeExecuter, final GraphRequest<?> request) throws OperationException {
         if (null == request) {
             throw new IllegalArgumentException("A request is required");
         }
@@ -343,8 +342,7 @@ public final class Graph {
                 try {
                     result = graphHook.onFailure(result, clonedOpChain, clonedContext, e);
                 } catch (final Exception graphHookE) {
-                    LOGGER.warn("Error in graphHook " + graphHook.getClass().getSimpleName() + ": "
-                            + graphHookE.getMessage(), graphHookE);
+                    LOGGER.warn("Error in graphHook " + graphHook.getClass().getSimpleName() + ": " + graphHookE.getMessage(), graphHookE);
                 }
             }
             CloseableUtil.close(clonedOpChain);
@@ -354,7 +352,8 @@ public final class Graph {
         return new GraphResult<>(result, clonedContext);
     }
 
-    void updateOperationChainView(final Operations<?> operations) {
+    private void updateOperationChainView(final Operations<?> operations) {
+
         for (final Operation operation : operations.getOperations()) {
             if (operation instanceof Operations) {
                 updateOperationChainView((Operations) operation);
@@ -362,24 +361,28 @@ public final class Graph {
                 View opView = ((OperationView) operation).getView();
                 if (null == opView) {
                     opView = config.getView();
-                } else if (!(opView instanceof NamedView) && !opView.hasGroups() && !opView.isAllEdges()
-                        && !opView.isAllEntities()) {
+                } else if (!(opView instanceof NamedView) && !opView.hasGroups() && !opView.isAllEdges() && !opView.isAllEntities()) {
 
-                    // If we have either global elements or nothing at all then merge with both
-                    // Entities and Edges
-                    if (!isEmpty(opView.getGlobalElements())
-                            || (isEmpty(opView.getGlobalEdges()) && isEmpty(opView.getGlobalEntities()))) {
+                    // If we have either global elements or nothing at all then
+                    // merge with both Entities and Edges
+                    if (!isEmpty(opView.getGlobalElements()) || (isEmpty(opView.getGlobalEdges()) && isEmpty(opView.getGlobalEntities()))) {
                         opView = new View.Builder().merge(config.getView()).merge(opView).build();
-                    } else { // We have either global edges or entities in opView, but not both
+                    } else { // We have either global edges or entities in
+                             // opView, but not both
                         final View originalView = opView;
-                        final View partialConfigView = new View.Builder().merge(config.getView())
+                        final View partialConfigView = new View.Builder()
+                                .merge(config.getView())
                                 .removeEdges((x -> isEmpty(originalView.getGlobalEdges())))
-                                .removeEntities((x -> isEmpty(originalView.getGlobalEntities()))).build();
-                        opView = new View.Builder().merge(partialConfigView).merge(opView).build();
+                                .removeEntities((x -> isEmpty(originalView.getGlobalEntities())))
+                                .build();
+                        opView = new View.Builder().merge(partialConfigView)
+                                .merge(opView)
+                                .build();
 
                     }
                 } else if (opView.isAllEdges() || opView.isAllEntities()) {
-                    View.Builder opViewBuilder = new View.Builder().merge(opView);
+                    View.Builder opViewBuilder = new View.Builder()
+                            .merge(opView);
                     if (opView.isAllEdges()) {
                         opViewBuilder.edges(getSchema().getEdgeGroups());
                     }
@@ -411,8 +414,8 @@ public final class Graph {
 
     /**
      * @param operation the class of the operation to check
-     * @return a collection of all the compatible {@link Operation}s that could be
-     *         added to an operation chain after the provided operation.
+     * @return a collection of all the compatible {@link Operation}s that could
+     *         be added to an operation chain after the provided operation.
      */
     public Set<Class<? extends Operation>> getNextOperations(final Class<? extends Operation> operation) {
         return store.getNextOperations(operation);
@@ -453,7 +456,8 @@ public final class Graph {
      * Returns all the {@link StoreTrait}s for the contained {@link Store}
      * implementation
      *
-     * @return a {@link Set} of all of the {@link StoreTrait}s that the store has.
+     * @return a {@link Set} of all of the {@link StoreTrait}s that the store
+     *         has.
      */
     public Set<StoreTrait> getStoreTraits() {
         return store.getTraits();
@@ -498,12 +502,17 @@ public final class Graph {
      * <p>
      * Builder for {@link Graph}.
      * </p>
-     * We recommend instantiating a Graph from a graphConfig.json file, a schema
-     * directory and a store.properties file. For example:
+     * We recommend instantiating a Graph from a graphConfig.json file, a
+     * schema
+     * directory and a store.properties file.
+     * For example:
      *
      * <pre>
-     * new Graph.Builder().config(Paths.get("graphConfig.json")).addSchemas(Paths.get("schema"))
-     *         .storeProperties(Paths.get("store.properties")).build();
+     * new Graph.Builder()
+     *         .config(Paths.get("graphConfig.json"))
+     *         .addSchemas(Paths.get("schema"))
+     *         .storeProperties(Paths.get("store.properties"))
+     *         .build();
      * </pre>
      */
     public static class Builder {
@@ -642,7 +651,9 @@ public final class Graph {
             this.properties = properties;
             if (null != properties) {
                 ReflectionUtil.addReflectionPackages(properties.getReflectionPackages());
-                JSONSerialiser.update(properties.getJsonSerialiserClass(), properties.getJsonSerialiserModules(),
+                JSONSerialiser.update(
+                        properties.getJsonSerialiserClass(),
+                        properties.getJsonSerialiserModules(),
                         properties.getStrictJson());
             }
             return this;
@@ -799,7 +810,10 @@ public final class Graph {
         public Builder addSchema(final Schema schemaModule) {
             if (null != schemaModule) {
                 if (null != schema) {
-                    schema = new Schema.Builder().merge(schema).merge(schemaModule).build();
+                    schema = new Schema.Builder()
+                            .merge(schema)
+                            .merge(schemaModule)
+                            .build();
                 } else {
                     schema = schemaModule;
                 }
@@ -883,8 +897,7 @@ public final class Graph {
             }
             final GraphHook[] hooks;
             try {
-                hooks = JSONSerialiser.deserialise(FileUtils.readFileToByteArray(hooksPath.toFile()),
-                        GraphHook[].class);
+                hooks = JSONSerialiser.deserialise(FileUtils.readFileToByteArray(hooksPath.toFile()), GraphHook[].class);
             } catch (final IOException e) {
                 throw new IllegalArgumentException("Unable to load graph hooks file: " + hooksPath, e);
             }
@@ -1014,7 +1027,9 @@ public final class Graph {
                             if (null == mergedParentSchema) {
                                 mergedParentSchema = parentSchema;
                             } else {
-                                mergedParentSchema = new Schema.Builder().merge(mergedParentSchema).merge(parentSchema)
+                                mergedParentSchema = new Schema.Builder()
+                                        .merge(mergedParentSchema)
+                                        .merge(parentSchema)
                                         .build();
                             }
                         }
@@ -1026,19 +1041,22 @@ public final class Graph {
                 if (null == schema) {
                     schema = mergedParentSchema;
                 } else {
-                    schema = new Schema.Builder().merge(mergedParentSchema).merge(schema).build();
+                    schema = new Schema.Builder()
+                            .merge(mergedParentSchema)
+                            .merge(schema)
+                            .build();
                 }
             }
 
             if (!schemaBytesList.isEmpty()) {
                 if (null == properties) {
-                    throw new IllegalArgumentException(
-                            "To load a schema from json, the store properties must be provided.");
+                    throw new IllegalArgumentException("To load a schema from json, the store properties must be provided.");
                 }
 
                 final Class<? extends Schema> schemaClass = properties.getSchemaClass();
                 final Schema newSchema = new Schema.Builder()
-                        .json(schemaClass, schemaBytesList.toArray(new byte[schemaBytesList.size()][])).build();
+                        .json(schemaClass, schemaBytesList.toArray(new byte[schemaBytesList.size()][]))
+                        .build();
                 addSchema(newSchema);
             }
         }
@@ -1063,7 +1081,8 @@ public final class Graph {
             if (null == store) {
                 store = Store.createStore(config.getGraphId(), cloneSchema(schema), properties);
             } else if ((null != config.getGraphId() && !config.getGraphId().equals(store.getGraphId()))
-                    || (null != schema) || (null != properties && !properties.equals(store.getProperties()))) {
+                    || (null != schema)
+                    || (null != properties && !properties.equals(store.getProperties()))) {
                 if (null == config.getGraphId()) {
                     config.setGraphId(store.getGraphId());
                 }
@@ -1078,8 +1097,7 @@ public final class Graph {
                 try {
                     store.initialise(config.getGraphId(), cloneSchema(schema), properties);
                 } catch (final StoreException e) {
-                    throw new IllegalArgumentException(
-                            "Unable to initialise the store with the given graphId, schema and properties", e);
+                    throw new IllegalArgumentException("Unable to initialise the store with the given graphId, schema and properties", e);
                 }
             }
 
@@ -1092,8 +1110,10 @@ public final class Graph {
 
         private void updateView(final GraphConfig config) {
             if (null == config.getView()) {
-                config.setView(new View.Builder().entities(store.getSchema().getEntityGroups())
-                        .edges(store.getSchema().getEdgeGroups()).build());
+                config.setView(new View.Builder()
+                        .entities(store.getSchema().getEntityGroups())
+                        .edges(store.getSchema().getEdgeGroups())
+                        .build());
             }
         }
 

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/Graph.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/Graph.java
@@ -16,7 +16,6 @@
 
 package uk.gov.gchq.gaffer.graph;
 
-import com.google.common.base.Predicates;
 import com.google.common.collect.Lists;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -70,24 +69,22 @@ import java.util.stream.Collectors;
 
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
 
-
 /**
  * <p>
  * The Graph separates the user from the {@link Store}. It holds an instance of
- * the {@link Store} and
- * acts as a proxy for the store, delegating {@link Operation}s to the store.
+ * the {@link Store} and acts as a proxy for the store, delegating
+ * {@link Operation}s to the store.
  * </p>
  * <p>
  * The Graph provides users with a single point of entry for executing
- * operations on a store.
- * This allows the underlying store to be swapped and the same operations can
- * still be applied.
+ * operations on a store. This allows the underlying store to be swapped and the
+ * same operations can still be applied.
  * </p>
  * <p>
  * Graphs also provides a view of the data with a instance of {@link View}. The
- * view filters out unwanted information
- * and can transform {@link uk.gov.gchq.gaffer.data.element.Properties} into
- * transient properties such as averages.
+ * view filters out unwanted information and can transform
+ * {@link uk.gov.gchq.gaffer.data.element.Properties} into transient properties
+ * such as averages.
  * </p>
  * <p>
  * When executing operations on a graph, an operation view would override the
@@ -107,12 +104,11 @@ public final class Graph {
     private GraphConfig config;
 
     /**
-     * Constructs a {@code Graph} with the given {@link uk.gov.gchq.gaffer.store.Store}
-     * and
+     * Constructs a {@code Graph} with the given
+     * {@link uk.gov.gchq.gaffer.store.Store} and
      * {@link uk.gov.gchq.gaffer.data.elementdefinition.view.View}.
      *
-     * @param config a {@link GraphConfig} used to store the configuration for
-     *               a
+     * @param config a {@link GraphConfig} used to store the configuration for a
      *               Graph.
      * @param store  a {@link Store} used to store the elements and handle
      *               operations.
@@ -123,8 +119,8 @@ public final class Graph {
     }
 
     /**
-     * Performs the given operation on the store.
-     * If the operation does not have a view then the graph view is used.
+     * Performs the given operation on the store. If the operation does not have a
+     * view then the graph view is used.
      *
      * @param operation the operation to be executed.
      * @param user      the user executing the operation.
@@ -135,9 +131,9 @@ public final class Graph {
     }
 
     /**
-     * Performs the given operation on the store.
-     * If the operation does not have a view then the graph view is used.
-     * The context will be cloned and a new jobId will be created.
+     * Performs the given operation on the store. If the operation does not have a
+     * view then the graph view is used. The context will be cloned and a new jobId
+     * will be created.
      *
      * @param operation the operation to be executed.
      * @param context   the user context for the execution of the operation
@@ -148,8 +144,8 @@ public final class Graph {
     }
 
     /**
-     * Performs the given output operation on the store.
-     * If the operation does not have a view then the graph view is used.
+     * Performs the given output operation on the store. If the operation does not
+     * have a view then the graph view is used.
      *
      * @param operation the output operation to be executed.
      * @param user      the user executing the operation.
@@ -162,9 +158,9 @@ public final class Graph {
     }
 
     /**
-     * Performs the given output operation on the store.
-     * If the operation does not have a view then the graph view is used.
-     * The context will be cloned and a new jobId will be created.
+     * Performs the given output operation on the store. If the operation does not
+     * have a view then the graph view is used. The context will be cloned and a new
+     * jobId will be created.
      *
      * @param operation the output operation to be executed.
      * @param context   the user context for the execution of the operation.
@@ -177,7 +173,8 @@ public final class Graph {
     }
 
     /**
-     * Exeutes a {@link GraphRequest} on the graph and returns the {@link GraphResult}.
+     * Exeutes a {@link GraphRequest} on the graph and returns the
+     * {@link GraphResult}.
      *
      * @param request the request to execute
      * @param <O>     the result type
@@ -189,8 +186,8 @@ public final class Graph {
     }
 
     /**
-     * Performs the given operation job on the store.
-     * If the operation does not have a view then the graph view is used.
+     * Performs the given operation job on the store. If the operation does not have
+     * a view then the graph view is used.
      *
      * @param operation the operation to be executed.
      * @param user      the user executing the job.
@@ -202,9 +199,9 @@ public final class Graph {
     }
 
     /**
-     * Performs the given operation job on the store.
-     * If the operation does not have a view then the graph view is used.
-     * The context will be cloned and a new jobId will be created.
+     * Performs the given operation job on the store. If the operation does not have
+     * a view then the graph view is used. The context will be cloned and a new
+     * jobId will be created.
      *
      * @param operation the operation to be executed.
      * @param context   the user context for the execution of the operation
@@ -217,9 +214,9 @@ public final class Graph {
 
     /**
      * Executes the given {@link GraphRequest} on the graph as an asynchronous job
-     * and returns a {@link GraphResult} containing the {@link JobDetail}s.
-     * If the operation does not have a view then the graph view is used.
-     * The context will be cloned and a new jobId will be created.
+     * and returns a {@link GraphResult} containing the {@link JobDetail}s. If the
+     * operation does not have a view then the graph view is used. The context will
+     * be cloned and a new jobId will be created.
      *
      * @param request the request to execute
      * @return {@link GraphResult} containing the job details
@@ -230,12 +227,12 @@ public final class Graph {
     }
 
     /**
-     * Performs the given Job on the store.
-     * This should be used for Scheduled Jobs,
-     * although if no repeat is set it
-     * will act as a normal Job.
+     * Performs the given Job on the store. This should be used for Scheduled Jobs,
+     * although if no repeat is set it will act as a normal Job.
      *
-     * @param job  the {@link Job} to execute, which contains the {@link OperationChain} and the {@link uk.gov.gchq.gaffer.jobtracker.Repeat}
+     * @param job  the {@link Job} to execute, which contains the
+     *             {@link OperationChain} and the
+     *             {@link uk.gov.gchq.gaffer.jobtracker.Repeat}
      * @param user the user running the Job.
      * @return the job detail.
      * @throws OperationException thrown if the job fails to run.
@@ -245,12 +242,12 @@ public final class Graph {
     }
 
     /**
-     * Performs the given Job on the store.
-     * This should be used for Scheduled Jobs,
-     * although if no repeat is set it
-     * will act as a normal Job.
+     * Performs the given Job on the store. This should be used for Scheduled Jobs,
+     * although if no repeat is set it will act as a normal Job.
      *
-     * @param job     the {@link Job} to execute, which contains the {@link OperationChain} and the {@link uk.gov.gchq.gaffer.jobtracker.Repeat}
+     * @param job     the {@link Job} to execute, which contains the
+     *                {@link OperationChain} and the
+     *                {@link uk.gov.gchq.gaffer.jobtracker.Repeat}
      * @param context the user context for the execution of the operation
      * @return the job detail
      * @throws OperationException thrown if the job fails to run.
@@ -287,7 +284,8 @@ public final class Graph {
                 try {
                     result = graphHook.onFailure(result, clonedOpChain, clonedContext, e);
                 } catch (final Exception graphHookE) {
-                    LOGGER.warn("Error in graphHook " + graphHook.getClass().getSimpleName() + ": " + graphHookE.getMessage(), graphHookE);
+                    LOGGER.warn("Error in graphHook " + graphHook.getClass().getSimpleName() + ": "
+                            + graphHookE.getMessage(), graphHookE);
                 }
             }
             CloseableUtil.close(clonedOpChain);
@@ -297,7 +295,8 @@ public final class Graph {
         return result;
     }
 
-    private <O> GraphResult<O> _execute(final StoreExecuter<O> storeExecuter, final GraphRequest<?> request) throws OperationException {
+    private <O> GraphResult<O> _execute(final StoreExecuter<O> storeExecuter, final GraphRequest<?> request)
+            throws OperationException {
         if (null == request) {
             throw new IllegalArgumentException("A request is required");
         }
@@ -344,7 +343,8 @@ public final class Graph {
                 try {
                     result = graphHook.onFailure(result, clonedOpChain, clonedContext, e);
                 } catch (final Exception graphHookE) {
-                    LOGGER.warn("Error in graphHook " + graphHook.getClass().getSimpleName() + ": " + graphHookE.getMessage(), graphHookE);
+                    LOGGER.warn("Error in graphHook " + graphHook.getClass().getSimpleName() + ": "
+                            + graphHookE.getMessage(), graphHookE);
                 }
             }
             CloseableUtil.close(clonedOpChain);
@@ -362,31 +362,24 @@ public final class Graph {
                 View opView = ((OperationView) operation).getView();
                 if (null == opView) {
                     opView = config.getView();
-                } else if (!(opView instanceof NamedView) && !opView.hasGroups() && !opView.isAllEdges() && !opView.isAllEntities()) {
-                	
-                	// If we have either global elements or nothing at all then merge with both Entities and Edges
-                	if (!isEmpty(opView.getGlobalElements()) || (isEmpty(opView.getGlobalEdges()) && isEmpty(opView.getGlobalEntities()))) {                		
-	                    opView = new View.Builder()
-	                            .merge(config.getView())
-	                            .merge(opView)
-	                            .build();
-                	}
-                	else { // We have either global edges or entities in opView, but not both
-                		final View originalView = opView;
-                		final View partialConfigView = new View.Builder()
-                				.merge(config.getView())
-                				.removeEdges((x->isEmpty(originalView.getGlobalEdges())))
-                				.removeEntities((x->isEmpty(originalView.getGlobalEntities())))
-                				.build();
-                		opView = new View.Builder()
-                				.merge(partialConfigView)
-                				.merge(opView)
-                				.build();
-                		
-                	}
+                } else if (!(opView instanceof NamedView) && !opView.hasGroups() && !opView.isAllEdges()
+                        && !opView.isAllEntities()) {
+
+                    // If we have either global elements or nothing at all then merge with both
+                    // Entities and Edges
+                    if (!isEmpty(opView.getGlobalElements())
+                            || (isEmpty(opView.getGlobalEdges()) && isEmpty(opView.getGlobalEntities()))) {
+                        opView = new View.Builder().merge(config.getView()).merge(opView).build();
+                    } else { // We have either global edges or entities in opView, but not both
+                        final View originalView = opView;
+                        final View partialConfigView = new View.Builder().merge(config.getView())
+                                .removeEdges((x -> isEmpty(originalView.getGlobalEdges())))
+                                .removeEntities((x -> isEmpty(originalView.getGlobalEntities()))).build();
+                        opView = new View.Builder().merge(partialConfigView).merge(opView).build();
+
+                    }
                 } else if (opView.isAllEdges() || opView.isAllEntities()) {
-                    View.Builder opViewBuilder = new View.Builder()
-                            .merge(opView);
+                    View.Builder opViewBuilder = new View.Builder().merge(opView);
                     if (opView.isAllEdges()) {
                         opViewBuilder.edges(getSchema().getEdgeGroups());
                     }
@@ -418,8 +411,8 @@ public final class Graph {
 
     /**
      * @param operation the class of the operation to check
-     * @return a collection of all the compatible {@link Operation}s that could
-     * be added to an operation chain after the provided operation.
+     * @return a collection of all the compatible {@link Operation}s that could be
+     *         added to an operation chain after the provided operation.
      */
     public Set<Class<? extends Operation>> getNextOperations(final Class<? extends Operation> operation) {
         return store.getNextOperations(operation);
@@ -460,8 +453,7 @@ public final class Graph {
      * Returns all the {@link StoreTrait}s for the contained {@link Store}
      * implementation
      *
-     * @return a {@link Set} of all of the {@link StoreTrait}s that the store
-     * has.
+     * @return a {@link Set} of all of the {@link StoreTrait}s that the store has.
      */
     public Set<StoreTrait> getStoreTraits() {
         return store.getTraits();
@@ -506,16 +498,12 @@ public final class Graph {
      * <p>
      * Builder for {@link Graph}.
      * </p>
-     * We recommend instantiating a Graph from a graphConfig.json file, a
-     * schema
-     * directory and a store.properties file.
-     * For example:
+     * We recommend instantiating a Graph from a graphConfig.json file, a schema
+     * directory and a store.properties file. For example:
+     *
      * <pre>
-     * new Graph.Builder()
-     *     .config(Paths.get("graphConfig.json"))
-     *     .addSchemas(Paths.get("schema"))
-     *     .storeProperties(Paths.get("store.properties"))
-     *     .build();
+     * new Graph.Builder().config(Paths.get("graphConfig.json")).addSchemas(Paths.get("schema"))
+     *         .storeProperties(Paths.get("store.properties")).build();
      * </pre>
      */
     public static class Builder {
@@ -654,11 +642,8 @@ public final class Graph {
             this.properties = properties;
             if (null != properties) {
                 ReflectionUtil.addReflectionPackages(properties.getReflectionPackages());
-                JSONSerialiser.update(
-                        properties.getJsonSerialiserClass(),
-                        properties.getJsonSerialiserModules(),
-                        properties.getStrictJson()
-                );
+                JSONSerialiser.update(properties.getJsonSerialiserClass(), properties.getJsonSerialiserModules(),
+                        properties.getStrictJson());
             }
             return this;
         }
@@ -814,10 +799,7 @@ public final class Graph {
         public Builder addSchema(final Schema schemaModule) {
             if (null != schemaModule) {
                 if (null != schema) {
-                    schema = new Schema.Builder()
-                            .merge(schema)
-                            .merge(schemaModule)
-                            .build();
+                    schema = new Schema.Builder().merge(schema).merge(schemaModule).build();
                 } else {
                     schema = schemaModule;
                 }
@@ -901,7 +883,8 @@ public final class Graph {
             }
             final GraphHook[] hooks;
             try {
-                hooks = JSONSerialiser.deserialise(FileUtils.readFileToByteArray(hooksPath.toFile()), GraphHook[].class);
+                hooks = JSONSerialiser.deserialise(FileUtils.readFileToByteArray(hooksPath.toFile()),
+                        GraphHook[].class);
             } catch (final IOException e) {
                 throw new IllegalArgumentException("Unable to load graph hooks file: " + hooksPath, e);
             }
@@ -965,7 +948,7 @@ public final class Graph {
             updateSchema(config);
 
             if (null != config.getLibrary() && config.getLibrary().exists(config.getGraphId())) {
-                //Set Props & Schema if null.
+                // Set Props & Schema if null.
                 final Pair<Schema, StoreProperties> pair = config.getLibrary().get(config.getGraphId());
                 properties = (null == properties) ? pair.getSecond() : properties;
                 schema = (null == schema) ? pair.getFirst() : schema;
@@ -988,7 +971,6 @@ public final class Graph {
             }
 
             updateGraphHooks(config);
-
 
             if (addToLibrary) {
                 config.getLibrary().add(config.getGraphId(), schema, store.getProperties());
@@ -1032,9 +1014,7 @@ public final class Graph {
                             if (null == mergedParentSchema) {
                                 mergedParentSchema = parentSchema;
                             } else {
-                                mergedParentSchema = new Schema.Builder()
-                                        .merge(mergedParentSchema)
-                                        .merge(parentSchema)
+                                mergedParentSchema = new Schema.Builder().merge(mergedParentSchema).merge(parentSchema)
                                         .build();
                             }
                         }
@@ -1046,22 +1026,19 @@ public final class Graph {
                 if (null == schema) {
                     schema = mergedParentSchema;
                 } else {
-                    schema = new Schema.Builder()
-                            .merge(mergedParentSchema)
-                            .merge(schema)
-                            .build();
+                    schema = new Schema.Builder().merge(mergedParentSchema).merge(schema).build();
                 }
             }
 
             if (!schemaBytesList.isEmpty()) {
                 if (null == properties) {
-                    throw new IllegalArgumentException("To load a schema from json, the store properties must be provided.");
+                    throw new IllegalArgumentException(
+                            "To load a schema from json, the store properties must be provided.");
                 }
 
                 final Class<? extends Schema> schemaClass = properties.getSchemaClass();
                 final Schema newSchema = new Schema.Builder()
-                        .json(schemaClass, schemaBytesList.toArray(new byte[schemaBytesList.size()][]))
-                        .build();
+                        .json(schemaClass, schemaBytesList.toArray(new byte[schemaBytesList.size()][])).build();
                 addSchema(newSchema);
             }
         }
@@ -1086,8 +1063,7 @@ public final class Graph {
             if (null == store) {
                 store = Store.createStore(config.getGraphId(), cloneSchema(schema), properties);
             } else if ((null != config.getGraphId() && !config.getGraphId().equals(store.getGraphId()))
-                    || (null != schema)
-                    || (null != properties && !properties.equals(store.getProperties()))) {
+                    || (null != schema) || (null != properties && !properties.equals(store.getProperties()))) {
                 if (null == config.getGraphId()) {
                     config.setGraphId(store.getGraphId());
                 }
@@ -1102,7 +1078,8 @@ public final class Graph {
                 try {
                     store.initialise(config.getGraphId(), cloneSchema(schema), properties);
                 } catch (final StoreException e) {
-                    throw new IllegalArgumentException("Unable to initialise the store with the given graphId, schema and properties", e);
+                    throw new IllegalArgumentException(
+                            "Unable to initialise the store with the given graphId, schema and properties", e);
                 }
             }
 
@@ -1115,10 +1092,8 @@ public final class Graph {
 
         private void updateView(final GraphConfig config) {
             if (null == config.getView()) {
-                config.setView(new View.Builder()
-                        .entities(store.getSchema().getEntityGroups())
-                        .edges(store.getSchema().getEdgeGroups())
-                        .build());
+                config.setView(new View.Builder().entities(store.getSchema().getEntityGroups())
+                        .edges(store.getSchema().getEdgeGroups()).build());
             }
         }
 

--- a/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphTest.java
+++ b/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphTest.java
@@ -167,41 +167,72 @@ public class GraphTest {
         storeProperties.setStoreClass(TestStoreImpl.class.getName());
 
         final Schema schemaModule1 = new Schema.Builder()
-                .type(TestTypes.PROP_STRING, new TypeDefinition.Builder().clazz(String.class).build())
-                .type("vertex", new TypeDefinition.Builder().clazz(String.class).build())
-                .edge(TestGroups.EDGE,
-                        new SchemaEdgeDefinition.Builder().property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
-                                .aggregate(false).source("vertex").destination("vertex").directed(DIRECTED_EITHER)
-                                .build())
+                .type(TestTypes.PROP_STRING, new TypeDefinition.Builder()
+                        .clazz(String.class)
+                        .build())
+                .type("vertex", new TypeDefinition.Builder()
+                        .clazz(String.class)
+                        .build())
+                .edge(TestGroups.EDGE, new SchemaEdgeDefinition.Builder()
+                        .property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
+                        .aggregate(false)
+                        .source("vertex")
+                        .destination("vertex")
+                        .directed(DIRECTED_EITHER)
+                        .build())
                 .build();
 
         final Schema schemaModule2 = new Schema.Builder()
-                .type(TestTypes.PROP_INTEGER, new TypeDefinition.Builder().clazz(Integer.class).build())
-                .type("vertex2", new TypeDefinition.Builder().clazz(String.class).build())
-                .edge(TestGroups.EDGE_2,
-                        new SchemaEdgeDefinition.Builder().property(TestPropertyNames.PROP_2, TestTypes.PROP_INTEGER)
-                                .aggregate(false).source("vertex2").destination("vertex2").directed(DIRECTED_EITHER)
-                                .build())
+                .type(TestTypes.PROP_INTEGER, new TypeDefinition.Builder()
+                        .clazz(Integer.class)
+                        .build())
+                .type("vertex2", new TypeDefinition.Builder()
+                        .clazz(String.class)
+                        .build())
+                .edge(TestGroups.EDGE_2, new SchemaEdgeDefinition.Builder()
+                        .property(TestPropertyNames.PROP_2, TestTypes.PROP_INTEGER)
+                        .aggregate(false)
+                        .source("vertex2")
+                        .destination("vertex2")
+                        .directed(DIRECTED_EITHER)
+                        .build())
                 .build();
 
         final Schema schemaModule3 = new Schema.Builder()
-                .entity(TestGroups.ENTITY,
-                        new SchemaEntityDefinition.Builder().property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
-                                .aggregate(false).vertex("vertex3").build())
-                .type("vertex3", new TypeDefinition.Builder().clazz(String.class).build()).build();
+                .entity(TestGroups.ENTITY, new SchemaEntityDefinition.Builder()
+                        .property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
+                        .aggregate(false)
+                        .vertex("vertex3")
+                        .build())
+                .type("vertex3", new TypeDefinition.Builder()
+                        .clazz(String.class)
+                        .build())
+                .build();
 
         final Schema schemaModule4 = new Schema.Builder()
-                .entity(TestGroups.ENTITY_2,
-                        new SchemaEntityDefinition.Builder().property(TestPropertyNames.PROP_2, TestTypes.PROP_INTEGER)
-                                .aggregate(false).vertex("vertex4").build())
-                .type("vertex4", new TypeDefinition.Builder().clazz(String.class).build())
-                .type(DIRECTED_EITHER, Boolean.class).build();
+                .entity(TestGroups.ENTITY_2, new SchemaEntityDefinition.Builder()
+                        .property(TestPropertyNames.PROP_2, TestTypes.PROP_INTEGER)
+                        .aggregate(false)
+                        .vertex("vertex4")
+                        .build())
+                .type("vertex4", new TypeDefinition.Builder()
+                        .clazz(String.class)
+                        .build())
+                .type(DIRECTED_EITHER, Boolean.class)
+                .build();
 
         // When
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().description("testDescription").graphId(GRAPH_ID).build())
-                .storeProperties(storeProperties).addSchema(schemaModule1).addSchema(schemaModule2)
-                .addSchema(schemaModule3).addSchema(schemaModule4).build();
+                .config(new GraphConfig.Builder()
+                        .description("testDescription")
+                        .graphId(GRAPH_ID)
+                        .build())
+                .storeProperties(storeProperties)
+                .addSchema(schemaModule1)
+                .addSchema(schemaModule2)
+                .addSchema(schemaModule3)
+                .addSchema(schemaModule4)
+                .build();
 
         // Then
         final Schema schema = graph.getSchema();
@@ -213,7 +244,8 @@ public class GraphTest {
     public void shouldConstructGraphFromSchemaFolderPath() throws IOException {
         // Given
         final Schema expectedSchema = new Schema.Builder()
-                .json(StreamUtil.elementsSchema(getClass()), StreamUtil.typesSchema(getClass())).build();
+                .json(StreamUtil.elementsSchema(getClass()), StreamUtil.typesSchema(getClass()))
+                .build();
 
         Graph graph = null;
         File schemaDir = null;
@@ -221,8 +253,12 @@ public class GraphTest {
             schemaDir = createSchemaDirectory();
 
             // When
-            graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                    .storeProperties(StreamUtil.storeProps(getClass())).addSchema(Paths.get(schemaDir.getPath()))
+            graph = new Graph.Builder()
+                    .config(new GraphConfig.Builder()
+                            .graphId(GRAPH_ID)
+                            .build())
+                    .storeProperties(StreamUtil.storeProps(getClass()))
+                    .addSchema(Paths.get(schemaDir.getPath()))
                     .build();
         } finally {
             if (null != schemaDir) {
@@ -241,7 +277,8 @@ public class GraphTest {
         final URI schemaInputUri = getResourceUri(StreamUtil.ELEMENTS_SCHEMA);
         final URI storeInputUri = getResourceUri(StreamUtil.STORE_PROPERTIES);
         final Schema expectedSchema = new Schema.Builder()
-                .json(StreamUtil.elementsSchema(getClass()), StreamUtil.typesSchema(getClass())).build();
+                .json(StreamUtil.elementsSchema(getClass()), StreamUtil.typesSchema(getClass()))
+                .build();
         Graph graph = null;
         File schemaDir = null;
 
@@ -249,8 +286,13 @@ public class GraphTest {
             schemaDir = createSchemaDirectory();
 
             // When
-            graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                    .storeProperties(storeInputUri).addSchemas(typeInputUri, schemaInputUri).build();
+            graph = new Graph.Builder()
+                    .config(new GraphConfig.Builder()
+                            .graphId(GRAPH_ID)
+                            .build())
+                    .storeProperties(storeInputUri)
+                    .addSchemas(typeInputUri, schemaInputUri)
+                    .build();
         } finally {
             if (schemaDir != null) {
                 FileUtils.deleteDirectory(schemaDir);
@@ -278,8 +320,13 @@ public class GraphTest {
         given(store.getSchema()).willReturn(schema);
         given(store.getProperties()).willReturn(new StoreProperties());
 
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(new Schema.Builder().build())
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .addSchema(new Schema.Builder().build())
                 .build();
 
         // When
@@ -297,8 +344,13 @@ public class GraphTest {
         given(store.getSchema()).willReturn(schema);
         given(store.getProperties()).willReturn(new StoreProperties());
 
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(new Schema.Builder().build())
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .addSchema(new Schema.Builder().build())
                 .build();
 
         // When
@@ -316,8 +368,13 @@ public class GraphTest {
         given(store.getSchema()).willReturn(schema);
         given(store.getProperties()).willReturn(new StoreProperties());
 
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(new Schema.Builder().build())
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .addSchema(new Schema.Builder().build())
                 .build();
 
         // When
@@ -328,8 +385,7 @@ public class GraphTest {
     }
 
     @Test
-    public void shouldCloseAllOperationInputsWhenExceptionIsThrownWhenExecuted()
-            throws OperationException, IOException {
+    public void shouldCloseAllOperationInputsWhenExceptionIsThrownWhenExecuted() throws OperationException, IOException {
         // Given
         final Exception exception = mock(RuntimeException.class);
         final Store store = mock(Store.class);
@@ -339,11 +395,13 @@ public class GraphTest {
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(new FunctionAuthoriser()) // skips json
-                                                                                                      // serialisation
-                                                                                                      // in default hook
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(new FunctionAuthoriser()) // skips json serialisation in default hook
                         .build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(new Schema.Builder().build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .addSchema(new Schema.Builder().build())
                 .build();
 
         // When / Then
@@ -357,8 +415,7 @@ public class GraphTest {
     }
 
     @Test
-    public void shouldCloseAllOperationInputsWhenExceptionIsThrownWhenJobExecuted()
-            throws OperationException, IOException {
+    public void shouldCloseAllOperationInputsWhenExceptionIsThrownWhenJobExecuted() throws OperationException, IOException {
         // Given
         final Exception exception = mock(RuntimeException.class);
         final Store store = mock(Store.class);
@@ -368,11 +425,13 @@ public class GraphTest {
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(new FunctionAuthoriser()) // skips json
-                                                                                                      // serialisation
-                                                                                                      // in default hook
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(new FunctionAuthoriser()) // skips json serialisation in default hook
                         .build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(new Schema.Builder().build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .addSchema(new Schema.Builder().build())
                 .build();
 
         // When / Then
@@ -395,8 +454,14 @@ public class GraphTest {
         final GraphHook hook1 = mock(GraphHook.class);
         final GraphHook hook2 = mock(GraphHook.class);
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(new Schema.Builder().build())
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(hook1)
+                        .addHook(hook2)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .addSchema(new Schema.Builder().build())
                 .build();
 
         // When
@@ -420,8 +485,14 @@ public class GraphTest {
         final GraphHook hook1 = mock(GraphHook.class);
         final GraphHook hook2 = mock(GraphHook.class);
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(new Schema.Builder().build())
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(hook1)
+                        .addHook(hook2)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .addSchema(new Schema.Builder().build())
                 .build();
 
         // When
@@ -452,8 +523,15 @@ public class GraphTest {
         given(hook2.postExecute(result2, clonedOpChain, clonedContext)).willReturn(result3);
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(schema).build();
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(hook1)
+                        .addHook(hook2)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .addSchema(schema)
+                .build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         final ArgumentCaptor<Context> contextCaptor1 = ArgumentCaptor.forClass(Context.class);
@@ -489,8 +567,15 @@ public class GraphTest {
         given(hook2.postExecute(result2, clonedOpChain, clonedContext)).willReturn(result3);
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(schema).build();
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(hook1)
+                        .addHook(hook2)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .addSchema(schema)
+                .build();
 
         given(store.execute(clonedOpChain, clonedContext)).willReturn(result1);
 
@@ -521,8 +606,15 @@ public class GraphTest {
         given(hook2.postExecute(result2, clonedOpChain, clonedContext)).willReturn(result3);
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(schema).build();
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(hook1)
+                        .addHook(hook2)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .addSchema(schema)
+                .build();
 
         given(store.executeJob(clonedOpChain, clonedContext)).willReturn(result1);
 
@@ -548,13 +640,19 @@ public class GraphTest {
         given(store.getProperties()).willReturn(new StoreProperties());
         final RuntimeException e = new RuntimeException("Hook2 failed in postExecute");
         doThrow(e).when(hook1).preExecute(clonedOpChain, clonedContext);
-        given(hook1.onFailure(null, clonedOpChain, clonedContext, e))
-                .willThrow(new RuntimeException("Hook1 failed in onFailure"));
+        given(hook1.onFailure(null, clonedOpChain, clonedContext, e)).willThrow(new RuntimeException("Hook1 failed in onFailure"));
         given(hook2.onFailure(null, clonedOpChain, clonedContext, e)).willReturn(null);
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(schema).build();
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(hook1)
+                        .addHook(hook2)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .addSchema(schema)
+                .build();
 
         // When / Then
         try {
@@ -586,13 +684,19 @@ public class GraphTest {
         given(hook1.postExecute(result1, clonedOpChain, clonedContext)).willReturn(result2);
         final RuntimeException e = new RuntimeException("Hook2 failed in postExecute");
         given(hook2.postExecute(result2, clonedOpChain, clonedContext)).willThrow(e);
-        given(hook1.onFailure(result2, clonedOpChain, clonedContext, e))
-                .willThrow(new RuntimeException("Hook1 failed in onFailure"));
+        given(hook1.onFailure(result2, clonedOpChain, clonedContext, e)).willThrow(new RuntimeException("Hook1 failed in onFailure"));
         given(hook2.onFailure(result2, clonedOpChain, clonedContext, e)).willReturn(result3);
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(schema).build();
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(hook1)
+                        .addHook(hook2)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .addSchema(schema)
+                .build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         given(store.execute(captor.capture(), eq(clonedContext))).willReturn(result1);
@@ -625,13 +729,19 @@ public class GraphTest {
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final RuntimeException e = new RuntimeException("Store failed to execute operation chain");
-        given(hook1.onFailure(null, clonedOpChain, clonedContext, e))
-                .willThrow(new RuntimeException("Hook1 failed in onFailure"));
+        given(hook1.onFailure(null, clonedOpChain, clonedContext, e)).willThrow(new RuntimeException("Hook1 failed in onFailure"));
         given(hook2.onFailure(null, clonedOpChain, clonedContext, e)).willReturn(null);
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(schema).build();
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(hook1)
+                        .addHook(hook2)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .addSchema(schema)
+                .build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         given(store.execute(captor.capture(), eq(clonedContext))).willThrow(e);
@@ -664,13 +774,19 @@ public class GraphTest {
         given(store.getProperties()).willReturn(new StoreProperties());
         final RuntimeException e = new RuntimeException("Hook2 failed in postExecute");
         doThrow(e).when(hook1).preExecute(clonedOpChain, clonedContext);
-        given(hook1.onFailure(null, clonedOpChain, clonedContext, e))
-                .willThrow(new RuntimeException("Hook1 failed in onFailure"));
+        given(hook1.onFailure(null, clonedOpChain, clonedContext, e)).willThrow(new RuntimeException("Hook1 failed in onFailure"));
         given(hook2.onFailure(null, clonedOpChain, clonedContext, e)).willReturn(null);
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(schema).build();
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(hook1)
+                        .addHook(hook2)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .addSchema(schema)
+                .build();
 
         // When / Then
         try {
@@ -703,13 +819,19 @@ public class GraphTest {
         given(hook1.postExecute(result1, clonedOpChain, clonedContext)).willReturn(result2);
         final RuntimeException e = new RuntimeException("Hook2 failed in postExecute");
         given(hook2.postExecute(result2, clonedOpChain, clonedContext)).willThrow(e);
-        given(hook1.onFailure(result2, clonedOpChain, clonedContext, e))
-                .willThrow(new RuntimeException("Hook1 failed in onFailure"));
+        given(hook1.onFailure(result2, clonedOpChain, clonedContext, e)).willThrow(new RuntimeException("Hook1 failed in onFailure"));
         given(hook2.onFailure(result2, clonedOpChain, clonedContext, e)).willReturn(result3);
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(schema).build();
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(hook1)
+                        .addHook(hook2)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .addSchema(schema)
+                .build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         given(store.executeJob(captor.capture(), eq(clonedContext))).willReturn(result1);
@@ -748,13 +870,19 @@ public class GraphTest {
 
         given(store.getSchema()).willReturn(schema);
         given(store.getProperties()).willReturn(new StoreProperties());
-        given(hook1.onFailure(null, clonedOpChain, clonedContext, e))
-                .willThrow(new RuntimeException("Hook1 failed in onFailure"));
+        given(hook1.onFailure(null, clonedOpChain, clonedContext, e)).willThrow(new RuntimeException("Hook1 failed in onFailure"));
         given(hook2.onFailure(null, clonedOpChain, clonedContext, e)).willReturn(null);
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(schema).build();
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(hook1)
+                        .addHook(hook2)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .addSchema(schema)
+                .build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         given(store.executeJob(captor.capture(), eq(clonedContext))).willThrow(e);
@@ -799,7 +927,10 @@ public class GraphTest {
         given(store.getSchema()).willReturn(schema);
 
         // When
-        final View resultView = new Graph.Builder().store(store).build().getView();
+        final View resultView = new Graph.Builder()
+                .store(store)
+                .build()
+                .getView();
 
         // Then
         assertNotSame(schema, resultView);
@@ -825,12 +956,16 @@ public class GraphTest {
         given(store.getSchema()).willReturn(new Schema());
         given(store.getProperties()).willReturn(new StoreProperties());
         final View view = mock(View.class);
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).view(view).build())
-                .store(store).build();
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .view(view)
+                        .build())
+                .store(store)
+                .build();
 
         // When
-        final Set<StoreTrait> storeTraits = new HashSet<>(
-                Arrays.asList(StoreTrait.INGEST_AGGREGATION, StoreTrait.TRANSFORMATION));
+        final Set<StoreTrait> storeTraits = new HashSet<>(Arrays.asList(StoreTrait.INGEST_AGGREGATION, StoreTrait.TRANSFORMATION));
         given(store.getTraits()).willReturn(storeTraits);
         final Collection<StoreTrait> returnedTraits = graph.getStoreTraits();
 
@@ -844,28 +979,46 @@ public class GraphTest {
         // Given
         final Store store = mock(Store.class);
         final Schema schema = new Schema.Builder()
-                .entity(TestGroups.ENTITY, new SchemaEntityDefinition.Builder().vertex("string").build())
-                .type("string", String.class).build();
+                .entity(TestGroups.ENTITY, new SchemaEntityDefinition.Builder()
+                        .vertex("string")
+                        .build())
+                .type("string", String.class)
+                .build();
         given(store.getSchema()).willReturn(schema);
         given(store.getOriginalSchema()).willReturn(schema);
         given(store.getProperties()).willReturn(new StoreProperties());
         final View view = mock(View.class);
-        new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).view(view).build())
-                .addSchema(new Schema()).store(store).build();
+        new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .view(view)
+                        .build())
+                .addSchema(new Schema())
+                .store(store)
+                .build();
 
         // When
         verify(store).setOriginalSchema(schema);
     }
 
     @Test
-    public void shouldSetGraphViewOnOperationAndDelegateDoOperationToStore() throws OperationException {
+    public void shouldSetGraphViewOnOperationAndDelegateDoOperationToStore()
+            throws OperationException {
         // Given
         final Store store = mock(Store.class);
         given(store.getSchema()).willReturn(new Schema());
         given(store.getProperties()).willReturn(new StoreProperties());
-        final View view = new View.Builder().entity(TestGroups.ENTITY).edge(TestGroups.EDGE).build();
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).view(view).build())
-                .store(store).build();
+        final View view = new View.Builder()
+                .entity(TestGroups.ENTITY)
+                .edge(TestGroups.EDGE)
+                .build();
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .view(view)
+                        .build())
+                .store(store)
+                .build();
         final Integer expectedResult = 5;
         final GetElements operation = new GetElements();
 
@@ -892,8 +1045,13 @@ public class GraphTest {
         given(store.getProperties()).willReturn(new StoreProperties());
         final View opView = mock(View.class);
         final View view = mock(View.class);
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).view(view).build())
-                .store(store).build();
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .view(view)
+                        .build())
+                .store(store)
+                .build();
         final Integer expectedResult = 5;
         given(operation.getView()).willReturn(opView);
 
@@ -919,8 +1077,13 @@ public class GraphTest {
         given(store.getSchema()).willReturn(new Schema());
         given(store.getProperties()).willReturn(new StoreProperties());
         final View view = mock(View.class);
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).view(view).build())
-                .store(store).build();
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .view(view)
+                        .build())
+                .store(store)
+                .build();
         final int expectedResult = 5;
         final Operation operation = mock(Operation.class);
 
@@ -941,12 +1104,16 @@ public class GraphTest {
     @Test
     public void shouldThrowExceptionIfStoreClassPropertyIsNotSet() throws OperationException {
         try {
-            new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build()).addSchema(new Schema())
-                    .storeProperties(new StoreProperties()).build();
+            new Graph.Builder()
+                    .config(new GraphConfig.Builder()
+                            .graphId(GRAPH_ID)
+                            .build())
+                    .addSchema(new Schema())
+                    .storeProperties(new StoreProperties())
+                    .build();
             fail("exception expected");
         } catch (final IllegalArgumentException e) {
-            assertEquals("The Store class name was not found in the store properties for key: "
-                    + StoreProperties.STORE_CLASS + ", GraphId: " + GRAPH_ID, e.getMessage());
+            assertEquals("The Store class name was not found in the store properties for key: " + StoreProperties.STORE_CLASS + ", GraphId: " + GRAPH_ID, e.getMessage());
         }
     }
 
@@ -955,22 +1122,34 @@ public class GraphTest {
         final StoreProperties storeProperties = new StoreProperties();
         storeProperties.setStoreClass(TestStoreImpl.class.getName());
         try {
-            new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                    .addSchema(new Schema.Builder()
-                            .type("int", new TypeDefinition.Builder().clazz(Integer.class).aggregateFunction(new Sum())
-                                    // invalid serialiser
-                                    .serialiser(new RawDoubleSerialiser()).build())
-                            .type("string",
-                                    new TypeDefinition.Builder().clazz(String.class)
-                                            .aggregateFunction(new StringConcat()).build())
-                            .type("boolean", Boolean.class)
-                            .edge("EDGE",
-                                    new SchemaEdgeDefinition.Builder().source("string").destination("string")
-                                            .directed("boolean").build())
-                            .entity("ENTITY",
-                                    new SchemaEntityDefinition.Builder().vertex("string").property("p2", "int").build())
+            new Graph.Builder()
+                    .config(new GraphConfig.Builder()
+                            .graphId(GRAPH_ID)
                             .build())
-                    .storeProperties(storeProperties).build();
+                    .addSchema(new Schema.Builder()
+                            .type("int", new TypeDefinition.Builder()
+                                    .clazz(Integer.class)
+                                    .aggregateFunction(new Sum())
+                                    // invalid serialiser
+                                    .serialiser(new RawDoubleSerialiser())
+                                    .build())
+                            .type("string", new TypeDefinition.Builder()
+                                    .clazz(String.class)
+                                    .aggregateFunction(new StringConcat())
+                                    .build())
+                            .type("boolean", Boolean.class)
+                            .edge("EDGE", new SchemaEdgeDefinition.Builder()
+                                    .source("string")
+                                    .destination("string")
+                                    .directed("boolean")
+                                    .build())
+                            .entity("ENTITY", new SchemaEntityDefinition.Builder()
+                                    .vertex("string")
+                                    .property("p2", "int")
+                                    .build())
+                            .build())
+                    .storeProperties(storeProperties)
+                    .build();
             fail("exception expected");
         } catch (final SchemaException e) {
             assertNotNull(e.getMessage());
@@ -983,7 +1162,11 @@ public class GraphTest {
         final Store store = mock(Store.class);
         given(store.getSchema()).willReturn(new Schema());
         given(store.getProperties()).willReturn(new StoreProperties());
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build()).store(store)
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .build())
+                .store(store)
                 .build();
 
         final Set<Class<? extends Operation>> expectedNextOperations = mock(Set.class);
@@ -1002,7 +1185,11 @@ public class GraphTest {
         final Store store = mock(Store.class);
         given(store.getSchema()).willReturn(new Schema());
         given(store.getProperties()).willReturn(new StoreProperties());
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build()).store(store)
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .build())
+                .store(store)
                 .build();
 
         given(store.isSupported(GetElements.class)).willReturn(true);
@@ -1019,7 +1206,11 @@ public class GraphTest {
         final Store store = mock(Store.class);
         given(store.getSchema()).willReturn(new Schema());
         given(store.getProperties()).willReturn(new StoreProperties());
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build()).store(store)
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .build())
+                .store(store)
                 .build();
 
         final Set<Class<? extends Operation>> expectedSupportedOperations = mock(Set.class);
@@ -1041,10 +1232,16 @@ public class GraphTest {
 
         // When / Then
         try {
-            new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                    .addSchema(new Schema.Builder().edge("group", new SchemaEdgeDefinition())
-                            .entity("group", new SchemaEntityDefinition()).build())
-                    .storeProperties(storeProperties).build();
+            new Graph.Builder()
+                    .config(new GraphConfig.Builder()
+                            .graphId(GRAPH_ID)
+                            .build())
+                    .addSchema(new Schema.Builder()
+                            .edge("group", new SchemaEdgeDefinition())
+                            .entity("group", new SchemaEntityDefinition())
+                            .build())
+                    .storeProperties(storeProperties)
+                    .build();
         } catch (final SchemaException e) {
             assertTrue(e.getMessage().contains("Schema is not valid"));
         }
@@ -1058,8 +1255,12 @@ public class GraphTest {
 
         // When / Then
         try {
-            new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                    .storeProperties(storeProperties).build();
+            new Graph.Builder()
+                    .config(new GraphConfig.Builder()
+                            .graphId(GRAPH_ID)
+                            .build())
+                    .storeProperties(storeProperties)
+                    .build();
         } catch (final SchemaException e) {
             assertTrue(e.getMessage().contains("Schema is missing"));
         }
@@ -1072,8 +1273,7 @@ public class GraphTest {
     }
 
     private void writeToFile(final String schemaFile, final File dir) throws IOException {
-        Files.copy(new File(getClass().getResource("/schema/" + schemaFile).getPath()),
-                new File(dir + "/" + schemaFile));
+        Files.copy(new File(getClass().getResource("/schema/" + schemaFile).getPath()), new File(dir + "/" + schemaFile));
     }
 
     @Test
@@ -1082,7 +1282,11 @@ public class GraphTest {
         given(properties.getJobExecutorThreadCount()).willReturn(1);
 
         try {
-            new Graph.Builder().config(new GraphConfig.Builder().graphId("invalid-id").build()).build();
+            new Graph.Builder()
+                    .config(new GraphConfig.Builder()
+                            .graphId("invalid-id")
+                            .build())
+                    .build();
             fail("Exception expected");
         } catch (final IllegalArgumentException e) {
             assertNotNull(e.getMessage());
@@ -1096,45 +1300,80 @@ public class GraphTest {
         storeProperties.setStoreClass(TestStoreImpl.class.getName());
 
         final Schema schemaModule1 = new Schema.Builder()
-                .type(TestTypes.PROP_STRING, new TypeDefinition.Builder().clazz(String.class).build())
-                .type("vertex", new TypeDefinition.Builder().clazz(String.class).build())
-                .edge(TestGroups.EDGE,
-                        new SchemaEdgeDefinition.Builder().property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
-                                .aggregate(false).source("vertex").destination("vertex").directed(DIRECTED_EITHER)
-                                .build())
+                .type(TestTypes.PROP_STRING, new TypeDefinition.Builder()
+                        .clazz(String.class)
+                        .build())
+                .type("vertex", new TypeDefinition.Builder()
+                        .clazz(String.class)
+                        .build())
+                .edge(TestGroups.EDGE, new SchemaEdgeDefinition.Builder()
+                        .property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
+                        .aggregate(false)
+                        .source("vertex")
+                        .destination("vertex")
+                        .directed(DIRECTED_EITHER)
+                        .build())
                 .build();
 
         final Schema schemaModule2 = new Schema.Builder()
-                .type(TestTypes.PROP_INTEGER, new TypeDefinition.Builder().clazz(Integer.class).build())
-                .type("vertex2", new TypeDefinition.Builder().clazz(String.class).build())
-                .edge(TestGroups.EDGE_2,
-                        new SchemaEdgeDefinition.Builder().property(TestPropertyNames.PROP_2, TestTypes.PROP_INTEGER)
-                                .aggregate(false).source("vertex2").destination("vertex2").directed(DIRECTED_EITHER)
-                                .build())
+                .type(TestTypes.PROP_INTEGER, new TypeDefinition.Builder()
+                        .clazz(Integer.class)
+                        .build())
+                .type("vertex2", new TypeDefinition.Builder()
+                        .clazz(String.class)
+                        .build())
+                .edge(TestGroups.EDGE_2, new SchemaEdgeDefinition.Builder()
+                        .property(TestPropertyNames.PROP_2, TestTypes.PROP_INTEGER)
+                        .aggregate(false)
+                        .source("vertex2")
+                        .destination("vertex2")
+                        .directed(DIRECTED_EITHER)
+                        .build())
                 .build();
 
         final Schema schemaModule3 = new Schema.Builder()
-                .entity(TestGroups.ENTITY,
-                        new SchemaEntityDefinition.Builder().property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
-                                .aggregate(false).vertex("vertex3").build())
-                .type("vertex3", new TypeDefinition.Builder().clazz(String.class).build()).build();
+                .entity(TestGroups.ENTITY, new SchemaEntityDefinition.Builder()
+                        .property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
+                        .aggregate(false)
+                        .vertex("vertex3")
+                        .build())
+                .type("vertex3", new TypeDefinition.Builder()
+                        .clazz(String.class)
+                        .build())
+                .build();
 
         final Schema schemaModule4 = new Schema.Builder()
-                .entity(TestGroups.ENTITY_2,
-                        new SchemaEntityDefinition.Builder().property(TestPropertyNames.PROP_2, TestTypes.PROP_INTEGER)
-                                .aggregate(false).vertex("vertex4").build())
-                .type("vertex4", new TypeDefinition.Builder().clazz(String.class).build())
-                .type(DIRECTED_EITHER, Boolean.class).build();
+                .entity(TestGroups.ENTITY_2, new SchemaEntityDefinition.Builder()
+                        .property(TestPropertyNames.PROP_2, TestTypes.PROP_INTEGER)
+                        .aggregate(false)
+                        .vertex("vertex4")
+                        .build())
+                .type("vertex4", new TypeDefinition.Builder()
+                        .clazz(String.class)
+                        .build())
+                .type(DIRECTED_EITHER, Boolean.class)
+                .build();
 
         // When
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).library(new HashMapGraphLibrary()).build())
-                .addSchema(schemaModule1).addSchema(schemaModule2).addSchema(schemaModule3).addSchema(schemaModule4)
-                .storeProperties(storeProperties).build();
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .library(new HashMapGraphLibrary())
+                        .build())
+                .addSchema(schemaModule1)
+                .addSchema(schemaModule2)
+                .addSchema(schemaModule3)
+                .addSchema(schemaModule4)
+                .storeProperties(storeProperties)
+                .build();
 
         final Graph graph2 = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).library(new HashMapGraphLibrary()).build())
-                .storeProperties(storeProperties).build();
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .library(new HashMapGraphLibrary())
+                        .build())
+                .storeProperties(storeProperties)
+                .build();
 
         // Then
         JsonAssert.assertEquals(graph.getSchema().toJson(false), graph2.getSchema().toJson(false));
@@ -1150,12 +1389,16 @@ public class GraphTest {
 
         // When
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId("graphId").addHooks(graphHook1, graphHook2).build())
-                .storeProperties(storeProperties).addSchemas(StreamUtil.schemas(getClass())).build();
+                .config(new GraphConfig.Builder()
+                        .graphId("graphId")
+                        .addHooks(graphHook1, graphHook2)
+                        .build())
+                .storeProperties(storeProperties)
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .build();
 
         // Then
-        assertEquals(Arrays.asList(NamedViewResolver.class, graphHook1.getClass(), graphHook2.getClass(),
-                FunctionAuthoriser.class), graph.getGraphHooks());
+        assertEquals(Arrays.asList(NamedViewResolver.class, graphHook1.getClass(), graphHook2.getClass(), FunctionAuthoriser.class), graph.getGraphHooks());
     }
 
     @Test
@@ -1170,13 +1413,17 @@ public class GraphTest {
         final Log4jLogger graphHook3 = mock(Log4jLogger.class);
 
         // When
-        final Graph graph = new Graph.Builder().graphId("graphId").storeProperties(storeProperties)
-                .addSchemas(StreamUtil.schemas(getClass())).addHook(graphHook1).addHook(graphHook2).addHook(graphHook3)
+        final Graph graph = new Graph.Builder()
+                .graphId("graphId")
+                .storeProperties(storeProperties)
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .addHook(graphHook1)
+                .addHook(graphHook2)
+                .addHook(graphHook3)
                 .build();
 
         // Then
-        assertEquals(Arrays.asList(NamedViewResolver.class, graphHook1.getClass(), graphHook2.getClass(),
-                graphHook3.getClass(), FunctionAuthoriser.class), graph.getGraphHooks());
+        assertEquals(Arrays.asList(NamedViewResolver.class, graphHook1.getClass(), graphHook2.getClass(), graphHook3.getClass(), FunctionAuthoriser.class), graph.getGraphHooks());
     }
 
     @Test
@@ -1191,12 +1438,17 @@ public class GraphTest {
 
         // When
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId("graphId").addHook(graphHook1).addHook(graphHook2).build())
-                .storeProperties(storeProperties).addSchemas(StreamUtil.schemas(getClass())).build();
+                .config(new GraphConfig.Builder()
+                        .graphId("graphId")
+                        .addHook(graphHook1)
+                        .addHook(graphHook2)
+                        .build())
+                .storeProperties(storeProperties)
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .build();
 
         // Then
-        assertEquals(Arrays.asList(NamedOperationResolver.class, NamedViewResolver.class, graphHook1.getClass(),
-                graphHook2.getClass(), FunctionAuthoriser.class), graph.getGraphHooks());
+        assertEquals(Arrays.asList(NamedOperationResolver.class, NamedViewResolver.class, graphHook1.getClass(), graphHook2.getClass(), FunctionAuthoriser.class), graph.getGraphHooks());
     }
 
     @Test
@@ -1210,12 +1462,18 @@ public class GraphTest {
 
         // When
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId("graphId").addHooks(Paths.get(graphHooks.getPath())).build())
-                .storeProperties(storeProperties).addSchemas(StreamUtil.schemas(getClass())).build();
+                .config(new GraphConfig.Builder()
+                        .graphId("graphId")
+                        .addHooks(Paths.get(graphHooks.getPath()))
+                        .build())
+                .storeProperties(storeProperties)
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .build();
 
         // Then
-        assertEquals(Arrays.asList(NamedViewResolver.class, OperationChainLimiter.class, AddOperationsToChain.class,
-                OperationAuthoriser.class, FunctionAuthoriser.class), graph.getGraphHooks());
+        assertEquals(
+                Arrays.asList(NamedViewResolver.class, OperationChainLimiter.class, AddOperationsToChain.class, OperationAuthoriser.class, FunctionAuthoriser.class),
+                graph.getGraphHooks());
     }
 
     @Test
@@ -1225,21 +1483,24 @@ public class GraphTest {
         storeProperties.setStoreClass(TestStoreImpl.class.getName());
 
         final File graphHook1File = tempDir.resolve("opChainLimiter.json").toFile();
-        FileUtils.writeLines(graphHook1File,
-                IOUtils.readLines(StreamUtil.openStream(getClass(), "opChainLimiter.json")));
+        FileUtils.writeLines(graphHook1File, IOUtils.readLines(StreamUtil.openStream(getClass(), "opChainLimiter.json")));
 
         final File graphHook2File = tempDir.resolve("opAuthoriser.json").toFile();
         FileUtils.writeLines(graphHook2File, IOUtils.readLines(StreamUtil.openStream(getClass(), "opAuthoriser.json")));
 
         // When
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId("graphId").addHook(Paths.get(graphHook1File.getPath()))
-                        .addHook(Paths.get(graphHook2File.getPath())).build())
-                .storeProperties(storeProperties).addSchemas(StreamUtil.schemas(getClass())).build();
+                .config(new GraphConfig.Builder()
+                        .graphId("graphId")
+                        .addHook(Paths.get(graphHook1File.getPath()))
+                        .addHook(Paths.get(graphHook2File.getPath()))
+                        .build())
+                .storeProperties(storeProperties)
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .build();
 
         // Then
-        assertEquals(Arrays.asList(NamedViewResolver.class, OperationChainLimiter.class, OperationAuthoriser.class,
-                FunctionAuthoriser.class), graph.getGraphHooks());
+        assertEquals(Arrays.asList(NamedViewResolver.class, OperationChainLimiter.class, OperationAuthoriser.class, FunctionAuthoriser.class), graph.getGraphHooks());
     }
 
     @Test
@@ -1249,17 +1510,21 @@ public class GraphTest {
         storeProperties.setStoreClass(TestStoreImpl.class.getName());
 
         // When
-        final Graph graph = new Graph.Builder().config(StreamUtil.graphConfig(getClass()))
-                .storeProperties(storeProperties).addSchemas(StreamUtil.schemas(getClass())).build();
+        final Graph graph = new Graph.Builder()
+                .config(StreamUtil.graphConfig(getClass()))
+                .storeProperties(storeProperties)
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .build();
 
         // Then
         assertEquals("graphId1", graph.getGraphId());
-        assertEquals(
-                new View.Builder().globalElements(new GlobalViewElementDefinition.Builder().groupBy().build()).build(),
-                graph.getView());
+        assertEquals(new View.Builder()
+                .globalElements(new GlobalViewElementDefinition.Builder()
+                        .groupBy()
+                        .build())
+                .build(), graph.getView());
         assertEquals(HashMapGraphLibrary.class, graph.getGraphLibrary().getClass());
-        assertEquals(Arrays.asList(NamedViewResolver.class, OperationChainLimiter.class, AddOperationsToChain.class,
-                FunctionAuthoriser.class), graph.getGraphHooks());
+        assertEquals(Arrays.asList(NamedViewResolver.class, OperationChainLimiter.class, AddOperationsToChain.class, FunctionAuthoriser.class), graph.getGraphHooks());
     }
 
     @Test
@@ -1282,19 +1547,30 @@ public class GraphTest {
         final GraphHook hook3 = mock(GraphHook.class);
 
         // When
-        final GraphConfig config = new GraphConfig.Builder().graphId(graphId2).library(library2).addHook(hook2)
-                .view(view2).build();
+        final GraphConfig config = new GraphConfig.Builder()
+                .graphId(graphId2)
+                .library(library2)
+                .addHook(hook2)
+                .view(view2)
+                .build();
 
-        final Graph graph = new Graph.Builder().graphId(graphId1).library(library1).view(view1)
-                .storeProperties(storeProperties).addSchemas(StreamUtil.schemas(getClass())).addHook(hook1)
-                .config(config).addHook(hook3).build();
+        final Graph graph = new Graph.Builder()
+                .graphId(graphId1)
+                .library(library1)
+                .view(view1)
+                .storeProperties(storeProperties)
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .addHook(hook1)
+                .config(config)
+                .addHook(hook3)
+                .build();
 
         // Then
         assertEquals(graphId2, graph.getGraphId());
         assertEquals(view2, graph.getView());
         assertEquals(library2, graph.getGraphLibrary());
-        assertEquals(Arrays.asList(NamedViewResolver.class, hook1.getClass(), hook2.getClass(), hook3.getClass(),
-                FunctionAuthoriser.class), graph.getGraphHooks());
+        assertEquals(Arrays.asList(NamedViewResolver.class, hook1.getClass(), hook2.getClass(), hook3.getClass(), FunctionAuthoriser.class),
+                graph.getGraphHooks());
     }
 
     @Test
@@ -1317,19 +1593,30 @@ public class GraphTest {
         final GraphHook hook3 = mock(GraphHook.class);
 
         // When
-        final GraphConfig config = new GraphConfig.Builder().graphId(graphId2).library(library2).addHook(hook2)
-                .view(view2).build();
+        final GraphConfig config = new GraphConfig.Builder()
+                .graphId(graphId2)
+                .library(library2)
+                .addHook(hook2)
+                .view(view2)
+                .build();
 
-        final Graph graph = new Graph.Builder().config(config).graphId(graphId1).library(library1).view(view1)
-                .storeProperties(storeProperties).addSchemas(StreamUtil.schemas(getClass())).addHook(hook1)
-                .addHook(hook3).build();
+        final Graph graph = new Graph.Builder()
+                .config(config)
+                .graphId(graphId1)
+                .library(library1)
+                .view(view1)
+                .storeProperties(storeProperties)
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .addHook(hook1)
+                .addHook(hook3)
+                .build();
 
         // Then
         assertEquals(graphId1, graph.getGraphId());
         assertEquals(view1, graph.getView());
         assertEquals(library1, graph.getGraphLibrary());
-        assertEquals(Arrays.asList(NamedViewResolver.class, hook2.getClass(), hook1.getClass(), hook3.getClass(),
-                FunctionAuthoriser.class), graph.getGraphHooks());
+        assertEquals(Arrays.asList(NamedViewResolver.class, hook2.getClass(), hook1.getClass(), hook3.getClass(), FunctionAuthoriser.class),
+                graph.getGraphHooks());
     }
 
     @Test
@@ -1343,10 +1630,16 @@ public class GraphTest {
         final View view = new View.Builder().entity(TestGroups.ENTITY).build();
 
         // When
-        final GraphConfig config = new GraphConfig.Builder().graphId(graphId).view(view).build();
+        final GraphConfig config = new GraphConfig.Builder()
+                .graphId(graphId)
+                .view(view)
+                .build();
 
-        final Graph graph = new Graph.Builder().config(config).storeProperties(storeProperties)
-                .addSchemas(StreamUtil.schemas(getClass())).build();
+        final Graph graph = new Graph.Builder()
+                .config(config)
+                .storeProperties(storeProperties)
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .build();
 
         // Then
         assertEquals(graphId, graph.getGraphId());
@@ -1374,11 +1667,19 @@ public class GraphTest {
         library.addProperties(STORE_PROPERTIES_ID_1, libraryStoreProperties);
 
         // When
-        final GraphConfig config = new GraphConfig.Builder().graphId(graphId1).library(library).build();
+        final GraphConfig config = new GraphConfig.Builder()
+                .graphId(graphId1)
+                .library(library)
+                .build();
 
-        final Graph graph1 = new Graph.Builder().config(config).addToLibrary(true)
-                .parentStorePropertiesId("storePropertiesId1").storeProperties(graphStoreProperties)
-                .addParentSchemaIds(SCHEMA_ID_1).addSchemas(graphSchema).build();
+        final Graph graph1 = new Graph.Builder()
+                .config(config)
+                .addToLibrary(true)
+                .parentStorePropertiesId("storePropertiesId1")
+                .storeProperties(graphStoreProperties)
+                .addParentSchemaIds(SCHEMA_ID_1)
+                .addSchemas(graphSchema)
+                .build();
 
         // Then
         assertEquals(graphId1, graph1.getGraphId());
@@ -1386,8 +1687,7 @@ public class GraphTest {
         final Pair<String, String> ids = library.getIds(graphId1);
         // Check that the schemaIds are different between the parent and supplied schema
         assertEquals(graphId1, ids.getFirst());
-        // Check that the storePropsIds are different between the parent and supplied
-        // storeProps
+        // Check that the storePropsIds are different between the parent and supplied storeProps
         assertEquals(graphId1, ids.getSecond());
     }
 
@@ -1407,20 +1707,26 @@ public class GraphTest {
         library.addProperties(storePropertiesId1, storeProperties);
 
         // When
-        final GraphConfig config = new GraphConfig.Builder().graphId(graphId1).library(library).build();
+        final GraphConfig config = new GraphConfig.Builder()
+                .graphId(graphId1)
+                .library(library)
+                .build();
 
-        final Graph graph1 = new Graph.Builder().config(config).addToLibrary(true)
-                .parentStorePropertiesId(storePropertiesId1).storeProperties(storeProperties)
-                .addParentSchemaIds(SCHEMA_ID_1).addSchemas(schema).build();
+        final Graph graph1 = new Graph.Builder()
+                .config(config)
+                .addToLibrary(true)
+                .parentStorePropertiesId(storePropertiesId1)
+                .storeProperties(storeProperties)
+                .addParentSchemaIds(SCHEMA_ID_1)
+                .addSchemas(schema)
+                .build();
 
         // Then
         assertEquals(graphId1, graph1.getGraphId());
         JsonAssert.assertEquals(library.getSchema(SCHEMA_ID_1).toJson(false), schema.toJson(false));
-        // Check that the schemaId = schemaId1 as both the parent and supplied schema
-        // have same id's
+        // Check that the schemaId = schemaId1 as both the parent and supplied schema have same id's
         assertTrue(library.getIds(graphId1).getFirst().equals(graphId1));
-        // Check that the storePropsId = storePropertiesId1 as both parent and supplied
-        // storeProps have same id's
+        // Check that the storePropsId = storePropertiesId1 as both parent and supplied storeProps have same id's
         assertTrue(library.getIds(graphId1).getSecond().equals(graphId1));
     }
 
@@ -1444,19 +1750,26 @@ public class GraphTest {
         library.addProperties(STORE_PROPERTIES_ID_1, libraryStoreProperties);
 
         // When
-        final GraphConfig config = new GraphConfig.Builder().graphId(graphId1).library(library).build();
+        final GraphConfig config = new GraphConfig.Builder()
+                .graphId(graphId1)
+                .library(library)
+                .build();
 
-        final Graph graph1 = new Graph.Builder().config(config).addToLibrary(true)
-                .parentStorePropertiesId("storePropertiesId1").storeProperties(graphStoreProperties)
-                .addParentSchemaIds(SCHEMA_ID_1).addSchemas(graphSchema).build();
+        final Graph graph1 = new Graph.Builder()
+                .config(config)
+                .addToLibrary(true)
+                .parentStorePropertiesId("storePropertiesId1")
+                .storeProperties(graphStoreProperties)
+                .addParentSchemaIds(SCHEMA_ID_1)
+                .addSchemas(graphSchema)
+                .build();
 
         // Then
         assertEquals(graphId1, graph1.getGraphId());
         JsonAssert.assertEquals(library.getSchema(SCHEMA_ID_1).toJson(false), librarySchema.toJson(false));
         // Check that the schemaId = schemaId1 as both the supplied schema id is null
         assertTrue(library.getIds(graphId1).getFirst().equals(graphId1));
-        // Check that the storePropsId = storePropertiesId1 as the supplied storeProps
-        // id is null
+        // Check that the storePropsId = storePropertiesId1 as the supplied storeProps id is null
         assertTrue(library.getIds(graphId1).getSecond().equals(graphId1));
     }
 
@@ -1464,22 +1777,35 @@ public class GraphTest {
     public void shouldCorrectlySetViewForNestedOperationChain() throws OperationException {
         // Given
         final Store store = new TestStore();
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .build())
                 .storeProperties(new StoreProperties())
                 .addSchema(new Schema.Builder()
-                        .edge(TestGroups.EDGE,
-                                new SchemaEdgeDefinition.Builder()
-                                        .property(TestPropertyNames.PROP_1, TestTypes.PROP_INTEGER).aggregate(false)
-                                        .source("vertex2").destination("vertex2").directed(DIRECTED_EITHER).build())
-                        .type(TestTypes.PROP_INTEGER, new TypeDefinition.Builder().clazz(Integer.class).build())
-                        .type("vertex2", new TypeDefinition.Builder().clazz(String.class).build())
-                        .type(DIRECTED_EITHER, Boolean.class).build())
+                        .edge(TestGroups.EDGE, new SchemaEdgeDefinition.Builder()
+                                .property(TestPropertyNames.PROP_1, TestTypes.PROP_INTEGER)
+                                .aggregate(false)
+                                .source("vertex2")
+                                .destination("vertex2")
+                                .directed(DIRECTED_EITHER)
+                                .build())
+                        .type(TestTypes.PROP_INTEGER, new TypeDefinition.Builder()
+                                .clazz(Integer.class)
+                                .build())
+                        .type("vertex2", new TypeDefinition.Builder()
+                                .clazz(String.class)
+                                .build())
+                        .type(DIRECTED_EITHER, Boolean.class)
+                        .build())
                 .store(store).build();
         final User user = new User();
         final Context context = new Context(user);
 
         final OperationChain<Iterable<? extends Element>> nestedChain = new OperationChain<>(
-                Arrays.asList(new GetAllElements(), new Limit<>(3, true)));
+                Arrays.asList(
+                        new GetAllElements(),
+                        new Limit<>(3, true)));
         final OperationChain<Iterable<? extends Element>> outerChain = new OperationChain<>(nestedChain);
 
         graph.execute(outerChain, context);
@@ -1494,8 +1820,13 @@ public class GraphTest {
         final Context context = null;
         final OperationChain opChain = mock(OperationChain.class);
 
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).addSchemas(StreamUtil.schemas(getClass())).build();
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .build();
 
         // When / Then
         try {
@@ -1512,8 +1843,13 @@ public class GraphTest {
         final Context context = null;
         final OperationChain opChain = mock(OperationChain.class);
 
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).addSchemas(StreamUtil.schemas(getClass())).build();
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .build();
 
         // When / Then
         try {
@@ -1530,8 +1866,13 @@ public class GraphTest {
         final User user = null;
         final OperationChain opChain = mock(OperationChain.class);
 
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).addSchemas(StreamUtil.schemas(getClass())).build();
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .build();
 
         // When / Then
         try {
@@ -1548,8 +1889,13 @@ public class GraphTest {
         final User user = null;
         final OperationChain opChain = mock(OperationChain.class);
 
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).addSchemas(StreamUtil.schemas(getClass())).build();
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .build();
 
         // When / Then
         try {
@@ -1566,8 +1912,13 @@ public class GraphTest {
         final Context context = null;
         final OperationChain opChain = mock(OperationChain.class);
 
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).addSchemas(StreamUtil.schemas(getClass())).build();
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .build();
 
         final Job job = new Job(null, opChain);
 
@@ -1585,8 +1936,13 @@ public class GraphTest {
         // Given
         final Context context = new Context();
 
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).addSchemas(StreamUtil.schemas(getClass())).build();
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .build();
 
         final Job job = new Job(new Repeat(), new OperationChain<>());
 
@@ -1604,8 +1960,13 @@ public class GraphTest {
         // Given
         final Context context = new Context();
 
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).addSchemas(StreamUtil.schemas(getClass())).build();
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .build();
 
         final Job job = null;
 
@@ -1624,8 +1985,13 @@ public class GraphTest {
         final User user = null;
         final OperationChain opChain = mock(OperationChain.class);
 
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).addSchemas(StreamUtil.schemas(getClass())).build();
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .build();
 
         final Job job = new Job(null, opChain);
 
@@ -1642,10 +2008,15 @@ public class GraphTest {
     public void shouldManipulateViewRemovingBlacklistedEdgeUsingUpdateViewHook() throws OperationException {
         // Given
         operation = new GetElements.Builder()
-                .view(new View.Builder().edge(TestGroups.EDGE_5).edge(TestGroups.EDGE).build()).build();
+                .view(new View.Builder()
+                        .edge(TestGroups.EDGE_5)
+                        .edge(TestGroups.EDGE)
+                        .build())
+                .build();
 
         final UpdateViewHook updateViewHook = new UpdateViewHook.Builder()
-                .blackListElementGroups(Collections.singleton(TestGroups.EDGE)).build();
+                .blackListElementGroups(Collections.singleton(TestGroups.EDGE))
+                .build();
 
         given(opChain.getOperations()).willReturn(Lists.newArrayList(operation));
         given(opChain.shallowClone()).willReturn(clonedOpChain);
@@ -1658,8 +2029,13 @@ public class GraphTest {
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(updateViewHook).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).build();
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(updateViewHook)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         final ArgumentCaptor<Context> contextCaptor1 = ArgumentCaptor.forClass(Context.class);
@@ -1679,10 +2055,15 @@ public class GraphTest {
     public void shouldManipulateViewRemovingBlacklistedEdgeLeavingEmptyViewUsingUpdateViewHook()
             throws OperationException {
         // Given
-        operation = new GetElements.Builder().view(new View.Builder().edge(TestGroups.EDGE).build()).build();
+        operation = new GetElements.Builder()
+                .view(new View.Builder()
+                        .edge(TestGroups.EDGE)
+                        .build())
+                .build();
 
         final UpdateViewHook updateViewHook = new UpdateViewHook.Builder()
-                .blackListElementGroups(Collections.singleton(TestGroups.EDGE)).build();
+                .blackListElementGroups(Collections.singleton(TestGroups.EDGE))
+                .build();
 
         given(opChain.getOperations()).willReturn(Lists.newArrayList(operation));
         given(opChain.shallowClone()).willReturn(clonedOpChain);
@@ -1695,8 +2076,13 @@ public class GraphTest {
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(updateViewHook).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).build();
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(updateViewHook)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         final ArgumentCaptor<Context> contextCaptor1 = ArgumentCaptor.forClass(Context.class);
@@ -1716,14 +2102,20 @@ public class GraphTest {
     public void shouldRerunMultipleUpdateViewHooksToRemoveAllBlacklistedElements() throws OperationException {
         // Given
         operation = new GetElements.Builder()
-                .view(new View.Builder().edge(TestGroups.EDGE).edge(TestGroups.EDGE_2).build()).build();
+                .view(new View.Builder()
+                        .edge(TestGroups.EDGE)
+                        .edge(TestGroups.EDGE_2)
+                        .build())
+                .build();
 
         final UpdateViewHook first = new UpdateViewHook.Builder()
-                .blackListElementGroups(Collections.singleton(TestGroups.EDGE)).withOpAuth(Sets.newHashSet("opAuth1"))
+                .blackListElementGroups(Collections.singleton(TestGroups.EDGE))
+                .withOpAuth(Sets.newHashSet("opAuth1"))
                 .build();
 
         final UpdateViewHook second = new UpdateViewHook.Builder()
-                .blackListElementGroups(Collections.singleton(TestGroups.EDGE_2)).withOpAuth(Sets.newHashSet("opAuth2"))
+                .blackListElementGroups(Collections.singleton(TestGroups.EDGE_2))
+                .withOpAuth(Sets.newHashSet("opAuth2"))
                 .build();
 
         given(opChain.getOperations()).willReturn(Lists.newArrayList(operation));
@@ -1733,20 +2125,31 @@ public class GraphTest {
 
         final Store store = mock(Store.class);
 
-        given(store.getSchema()).willReturn(new Schema.Builder().edge(TestGroups.EDGE, new SchemaEdgeDefinition())
-                .edge(TestGroups.EDGE_2, new SchemaEdgeDefinition()).build());
+        given(store.getSchema()).willReturn(new Schema.Builder()
+                .edge(TestGroups.EDGE, new SchemaEdgeDefinition())
+                .edge(TestGroups.EDGE_2, new SchemaEdgeDefinition())
+                .build());
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(first).addHook(second).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).build();
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(first)
+                        .addHook(second)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         final ArgumentCaptor<Context> contextCaptor1 = ArgumentCaptor.forClass(Context.class);
 
         given(store.execute(captor.capture(), contextCaptor1.capture())).willReturn(new ArrayList<>());
 
-        User user = new User.Builder().userId("user").opAuths("opAuth1", "opAuth2").build();
+        User user = new User.Builder()
+                .userId("user")
+                .opAuths("opAuth1", "opAuth2")
+                .build();
         // When / Then
         graph.execute(opChain, user);
 
@@ -1760,10 +2163,12 @@ public class GraphTest {
     public void shouldFillSchemaViewAndManipulateViewRemovingBlacklistedEdgeUsingUpdateViewHook()
             throws OperationException {
         // Given
-        operation = new GetElements.Builder().build();
+        operation = new GetElements.Builder()
+                .build();
 
         final UpdateViewHook updateViewHook = new UpdateViewHook.Builder()
-                .blackListElementGroups(Collections.singleton(TestGroups.EDGE)).build();
+                .blackListElementGroups(Collections.singleton(TestGroups.EDGE))
+                .build();
 
         given(opChain.getOperations()).willReturn(Lists.newArrayList(operation));
         given(opChain.shallowClone()).willReturn(clonedOpChain);
@@ -1772,13 +2177,20 @@ public class GraphTest {
 
         final Store store = mock(Store.class);
 
-        given(store.getSchema()).willReturn(new Schema.Builder().edge(TestGroups.EDGE, new SchemaEdgeDefinition())
-                .edge(TestGroups.EDGE_5, new SchemaEdgeDefinition()).build());
+        given(store.getSchema()).willReturn(new Schema.Builder()
+                .edge(TestGroups.EDGE, new SchemaEdgeDefinition())
+                .edge(TestGroups.EDGE_5, new SchemaEdgeDefinition())
+                .build());
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(updateViewHook).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).build();
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(updateViewHook)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         final ArgumentCaptor<Context> contextCaptor1 = ArgumentCaptor.forClass(Context.class);
@@ -1795,13 +2207,14 @@ public class GraphTest {
     }
 
     @Test
-    public void shouldFillSchemaViewAndManipulateViewRemovingBlacklistedEdgeLeavingEmptyViewUsingUpdateViewHook()
-            throws OperationException {
+    public void shouldFillSchemaViewAndManipulateViewRemovingBlacklistedEdgeLeavingEmptyViewUsingUpdateViewHook() throws OperationException {
         // Given
-        operation = new GetElements.Builder().build();
+        operation = new GetElements.Builder()
+                .build();
 
         final UpdateViewHook updateViewHook = new UpdateViewHook.Builder()
-                .blackListElementGroups(Collections.singleton(TestGroups.EDGE)).build();
+                .blackListElementGroups(Collections.singleton(TestGroups.EDGE))
+                .build();
 
         given(opChain.getOperations()).willReturn(Lists.newArrayList(operation));
         given(opChain.shallowClone()).willReturn(clonedOpChain);
@@ -1815,8 +2228,13 @@ public class GraphTest {
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(updateViewHook).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).build();
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(updateViewHook)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         final ArgumentCaptor<Context> contextCaptor1 = ArgumentCaptor.forClass(Context.class);
@@ -1833,13 +2251,15 @@ public class GraphTest {
     }
 
     @Test
-    public void shouldCorrectlyAddExtraGroupsFromSchemaViewWithUpdateViewHookWhenNotInBlacklist()
-            throws OperationException {
+    public void shouldCorrectlyAddExtraGroupsFromSchemaViewWithUpdateViewHookWhenNotInBlacklist() throws OperationException {
         // Given
-        operation = new GetElements.Builder().build();
+        operation = new GetElements.Builder()
+                .build();
 
-        final UpdateViewHook updateViewHook = new UpdateViewHook.Builder().addExtraGroups(true)
-                .blackListElementGroups(Collections.singleton(TestGroups.EDGE)).build();
+        final UpdateViewHook updateViewHook = new UpdateViewHook.Builder()
+                .addExtraGroups(true)
+                .blackListElementGroups(Collections.singleton(TestGroups.EDGE))
+                .build();
 
         given(opChain.getOperations()).willReturn(Lists.newArrayList(operation));
         given(opChain.shallowClone()).willReturn(clonedOpChain);
@@ -1848,14 +2268,21 @@ public class GraphTest {
 
         final Store store = mock(Store.class);
 
-        given(store.getSchema()).willReturn(new Schema.Builder().edge(TestGroups.EDGE_4, new SchemaEdgeDefinition())
-                .edge(TestGroups.EDGE_5, new SchemaEdgeDefinition()).edge(TestGroups.EDGE, new SchemaEdgeDefinition())
+        given(store.getSchema()).willReturn(new Schema.Builder()
+                .edge(TestGroups.EDGE_4, new SchemaEdgeDefinition())
+                .edge(TestGroups.EDGE_5, new SchemaEdgeDefinition())
+                .edge(TestGroups.EDGE, new SchemaEdgeDefinition())
                 .build());
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(updateViewHook).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).build();
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(updateViewHook)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         final ArgumentCaptor<Context> contextCaptor1 = ArgumentCaptor.forClass(Context.class);
@@ -1867,18 +2294,20 @@ public class GraphTest {
 
         final List<Operation> ops = captor.getValue().getOperations();
 
-        JsonAssert.assertEquals(
-                new View.Builder().edge(TestGroups.EDGE_5).edge(TestGroups.EDGE_4).build().toCompactJson(),
-                ((GetElements) ops.get(0)).getView().toCompactJson());
+        JsonAssert.assertEquals(new View.Builder().edge(TestGroups.EDGE_5).edge(TestGroups.EDGE_4).build().toCompactJson(), ((GetElements) ops.get(0)).getView().toCompactJson());
     }
 
     @Test
     public void shouldNotAddExtraGroupsFromSchemaViewWithUpdateViewHookWhenInBlacklist() throws OperationException {
         // Given
-        operation = new GetElements.Builder().build();
+        operation = new GetElements.Builder()
+                .build();
 
-        final UpdateViewHook updateViewHook = new UpdateViewHook.Builder().addExtraGroups(true)
-                .blackListElementGroups(Sets.newHashSet(TestGroups.EDGE_4, TestGroups.EDGE)).build();
+        final UpdateViewHook updateViewHook = new UpdateViewHook.Builder()
+                .addExtraGroups(true)
+                .blackListElementGroups(Sets.newHashSet(TestGroups.EDGE_4,
+                        TestGroups.EDGE))
+                .build();
 
         given(opChain.getOperations()).willReturn(Lists.newArrayList(operation));
         given(opChain.shallowClone()).willReturn(clonedOpChain);
@@ -1887,14 +2316,21 @@ public class GraphTest {
 
         final Store store = mock(Store.class);
 
-        given(store.getSchema()).willReturn(new Schema.Builder().edge(TestGroups.EDGE_4, new SchemaEdgeDefinition())
-                .edge(TestGroups.EDGE_5, new SchemaEdgeDefinition()).edge(TestGroups.EDGE, new SchemaEdgeDefinition())
+        given(store.getSchema()).willReturn(new Schema.Builder()
+                .edge(TestGroups.EDGE_4, new SchemaEdgeDefinition())
+                .edge(TestGroups.EDGE_5, new SchemaEdgeDefinition())
+                .edge(TestGroups.EDGE, new SchemaEdgeDefinition())
                 .build());
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(updateViewHook).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).build();
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .addHook(updateViewHook)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         final ArgumentCaptor<Context> contextCaptor1 = ArgumentCaptor.forClass(Context.class);
@@ -1917,13 +2353,20 @@ public class GraphTest {
 
         final Store store = mock(Store.class);
 
-        given(store.getSchema()).willReturn(new Schema.Builder().entity(TestGroups.ENTITY, new SchemaEntityDefinition())
-                .edge(TestGroups.EDGE, new SchemaEdgeDefinition()).edge(TestGroups.EDGE_2, new SchemaEdgeDefinition())
+        given(store.getSchema()).willReturn(new Schema.Builder()
+                .entity(TestGroups.ENTITY, new SchemaEntityDefinition())
+                .edge(TestGroups.EDGE, new SchemaEdgeDefinition())
+                .edge(TestGroups.EDGE_2, new SchemaEdgeDefinition())
                 .build());
         given(store.getProperties()).willReturn(new StoreProperties());
 
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).build();
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .build();
 
         final ArgumentCaptor<Job> jobCaptor = ArgumentCaptor.forClass(Job.class);
         final ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
@@ -1934,12 +2377,11 @@ public class GraphTest {
         graph.executeJob(job, context);
 
         // then
-        final GetAllElements operation = (GetAllElements) ((OperationChain) jobCaptor.getValue().getOperation())
-                .getOperations().get(0);
+        final GetAllElements operation = (GetAllElements) ((OperationChain) jobCaptor.getValue().getOperation()).getOperations().get(0);
 
         assertEquals(new View.Builder().entity(TestGroups.ENTITY, new ViewElementDefinition())
-                .edge(TestGroups.EDGE, new ViewElementDefinition()).edge(TestGroups.EDGE_2, new ViewElementDefinition())
-                .build(), operation.getView());
+                .edge(TestGroups.EDGE, new ViewElementDefinition())
+                .edge(TestGroups.EDGE_2, new ViewElementDefinition()).build(), operation.getView());
     }
 
     @Test
@@ -1950,16 +2392,19 @@ public class GraphTest {
         TestStore.mockStore = mock(Store.class);
         given(TestStore.mockStore.isSupported(NamedOperation.class)).willReturn(true);
         // When
-        final GraphConfig config = new GraphConfig.Builder().graphId("test").build();
+        final GraphConfig config = new GraphConfig.Builder()
+                .graphId("test")
+                .build();
 
-        final Graph graph = new Graph.Builder().addSchemas(StreamUtil.schemas(getClass()))
-                .storeProperties(storeProperties).config(config).build();
+        final Graph graph = new Graph.Builder()
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .storeProperties(storeProperties)
+                .config(config)
+                .build();
 
         // Then
-        assertEquals(Arrays.asList(NamedOperationResolver.class, NamedViewResolver.class, FunctionAuthoriser.class),
-                graph.getGraphHooks());
-        assertEquals(CreateObject.class,
-                ((FunctionAuthoriser) graph.getConfig().getHooks().get(2)).getUnauthorisedFunctions().get(0));
+        assertEquals(Arrays.asList(NamedOperationResolver.class, NamedViewResolver.class, FunctionAuthoriser.class), graph.getGraphHooks());
+        assertEquals(CreateObject.class, ((FunctionAuthoriser) graph.getConfig().getHooks().get(2)).getUnauthorisedFunctions().get(0));
     }
 
     @Test
@@ -1970,90 +2415,142 @@ public class GraphTest {
         TestStore.mockStore = mock(Store.class);
         given(TestStore.mockStore.isSupported(NamedOperation.class)).willReturn(true);
         // When
-        final GraphConfig config = new GraphConfig.Builder().graphId("test")
-                .addHook(new FunctionAuthoriser(Lists.newArrayList(Identity.class))).build();
+        final GraphConfig config = new GraphConfig.Builder()
+                .graphId("test")
+                .addHook(new FunctionAuthoriser(Lists.newArrayList(Identity.class)))
+                .build();
 
-        final Graph graph = new Graph.Builder().addSchemas(StreamUtil.schemas(getClass()))
-                .storeProperties(storeProperties).config(config).build();
+        final Graph graph = new Graph.Builder()
+                .addSchemas(StreamUtil.schemas(getClass()))
+                .storeProperties(storeProperties)
+                .config(config)
+                .build();
 
         // Then
-        assertEquals(Arrays.asList(NamedOperationResolver.class, NamedViewResolver.class, FunctionAuthoriser.class),
-                graph.getGraphHooks());
-        assertEquals(Identity.class,
-                ((FunctionAuthoriser) graph.getConfig().getHooks().get(2)).getUnauthorisedFunctions().get(0));
+        assertEquals(Arrays.asList(NamedOperationResolver.class, NamedViewResolver.class, FunctionAuthoriser.class), graph.getGraphHooks());
+        assertEquals(Identity.class, ((FunctionAuthoriser) graph.getConfig().getHooks().get(2)).getUnauthorisedFunctions().get(0));
     }
 
     @Test
-    public void shouldExpandGlobalEdges() {
+    public void shouldExpandGlobalEdges() throws OperationException {
 
         final Schema twoEdgesNoEntities = new Schema.Builder()
-                .type(TestTypes.PROP_STRING, new TypeDefinition.Builder().clazz(String.class).build())
-                .type("vertex", new TypeDefinition.Builder().clazz(String.class).build())
+                .type(TestTypes.PROP_STRING, new TypeDefinition.Builder()
+                        .clazz(String.class)
+                        .build())
+                .type("vertex", new TypeDefinition.Builder()
+                        .clazz(String.class)
+                        .build())
                 .edge("firstEdge",
-                        new SchemaEdgeDefinition.Builder().property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
-                                .aggregate(false).source("vertex").destination("vertex").directed(DIRECTED_EITHER)
+                        new SchemaEdgeDefinition.Builder()
+                                .property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
+                                .aggregate(false)
+                                .source("vertex")
+                                .destination("vertex").directed(DIRECTED_EITHER)
                                 .build())
                 .edge("secondEdge",
-                        new SchemaEdgeDefinition.Builder().property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
-                                .aggregate(false).source("vertex").destination("vertex").directed(DIRECTED_EITHER)
+                        new SchemaEdgeDefinition.Builder()
+                                .property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
+                                .aggregate(false)
+                                .source("vertex")
+                                .destination("vertex")
+                                .directed(DIRECTED_EITHER)
                                 .build())
                 .build();
 
         final Store store = mock(Store.class);
+        final ArgumentCaptor<OperationChain> capturedOperation = ArgumentCaptor.forClass(OperationChain.class);
+        final ArgumentCaptor<Context> capturedContext = ArgumentCaptor.forClass(Context.class);
+
         given(store.getSchema()).willReturn(twoEdgesNoEntities);
         given(store.getProperties()).willReturn(mock(StoreProperties.class));
 
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(twoEdgesNoEntities).build();
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .addSchema(twoEdgesNoEntities)
+                .build();
 
         final ElementFilter filter = mock(ElementFilter.class);
 
         final GlobalViewElementDefinition globalEdgeAggregate = new GlobalViewElementDefinition.Builder()
-                .postAggregationFilter(filter).build();
-        final View view = new View.Builder().globalEdges(globalEdgeAggregate).build();
+                .postAggregationFilter(filter)
+                .build();
+        final View view = new View.Builder()
+                .globalEdges(globalEdgeAggregate)
+                .build();
 
-        operation = new GetElements.Builder().view(view).build();
-        opChain = new OperationChain.Builder().first(operation).build();
+        operation = new GetElements.Builder()
+                .view(view)
+                .build();
+        opChain = new OperationChain.Builder()
+                .first(operation)
+                .build();
 
-        graph.updateOperationChainView(opChain);
+        graph.execute(opChain, context);
+        Mockito.verify(store, Mockito.times(1)).execute(capturedOperation.capture(), capturedContext.capture());
 
-        assertEquals(1, opChain.getOperations().size());
-        assertEquals(GetElements.class, opChain.getOperations().get(0).getClass());
-        final View mergedView = ((GetElements) opChain.getOperations().get(0)).getView();
+        assertEquals(1, capturedOperation.getAllValues().size());
+        final OperationChain transformedOpChain = capturedOperation.getAllValues().get(0);
+
+        assertEquals(1, transformedOpChain.getOperations().size());
+        assertEquals(GetElements.class, transformedOpChain.getOperations().get(0).getClass());
+        final View mergedView = ((GetElements) transformedOpChain.getOperations().get(0)).getView();
         assertTrue(mergedView.getGlobalEdges() == null || mergedView.getGlobalEdges().size() == 0);
         assertEquals(2, mergedView.getEdges().size());
         for (final Map.Entry<String, ViewElementDefinition> e : mergedView.getEdges().entrySet()) {
             assertNotNull(e.getValue().getPostAggregationFilter());
         }
 
-    };
+    }
 
     @Test
-    public void shouldNotExpandGlobalEdgesWhereNotPresentInSchema() {
+    public void shouldNotExpandGlobalEdgesWhereNotPresentInSchema() throws OperationException {
         final Schema federatedStoreSchema = new Schema.Builder().build();
 
         final Store store = mock(Store.class);
         given(store.getSchema()).willReturn(federatedStoreSchema);
         given(store.getProperties()).willReturn(mock(StoreProperties.class));
+        final ArgumentCaptor<OperationChain> capturedOperation = ArgumentCaptor.forClass(OperationChain.class);
+        final ArgumentCaptor<Context> capturedContext = ArgumentCaptor.forClass(Context.class);
 
-        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
-                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(federatedStoreSchema)
+        final Graph graph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(GRAPH_ID)
+                        .build())
+                .storeProperties(StreamUtil.storeProps(getClass()))
+                .store(store)
+                .addSchema(federatedStoreSchema)
                 .build();
 
         final ElementFilter filter = mock(ElementFilter.class);
 
         final GlobalViewElementDefinition globalEdgeAggregate = new GlobalViewElementDefinition.Builder()
-                .postAggregationFilter(filter).build();
-        final View view = new View.Builder().globalEdges(globalEdgeAggregate).build();
+                .postAggregationFilter(filter)
+                .build();
+        final View view = new View.Builder()
+                .globalEdges(globalEdgeAggregate)
+                .build();
 
-        operation = new GetElements.Builder().view(view).build();
-        opChain = new OperationChain.Builder().first(operation).build();
+        operation = new GetElements.Builder()
+                .view(view)
+                .build();
+        opChain = new OperationChain.Builder()
+                .first(operation)
+                .build();
 
-        graph.updateOperationChainView(opChain);
+        graph.execute(opChain, context);
+        Mockito.verify(store, Mockito.times(1)).execute(capturedOperation.capture(), capturedContext.capture());
 
-        assertEquals(1, opChain.getOperations().size());
-        assertEquals(GetElements.class, opChain.getOperations().get(0).getClass());
-        final View mergedView = ((GetElements) opChain.getOperations().get(0)).getView();
+        assertEquals(1, capturedOperation.getAllValues().size());
+        final OperationChain transformedOpChain = capturedOperation.getAllValues().get(0);
+
+        assertEquals(1, transformedOpChain.getOperations().size());
+        assertEquals(GetElements.class, transformedOpChain.getOperations().get(0).getClass());
+        final View mergedView = ((GetElements) transformedOpChain.getOperations().get(0)).getView();
         assertEquals(0, mergedView.getEdges().size());
         assertEquals(1, mergedView.getGlobalEdges().size());
         assertNotNull(mergedView.getGlobalEdges().get(0).getPostAggregationFilter());
@@ -2112,8 +2609,7 @@ public class GraphTest {
         }
 
         @Override
-        public <T> T onFailure(final T result, final OperationChain<?> opChain, final Context context,
-                final Exception e) {
+        public <T> T onFailure(final T result, final OperationChain<?> opChain, final Context context, final Exception e) {
             return result;
         }
     }

--- a/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphTest.java
+++ b/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphTest.java
@@ -21,7 +21,6 @@ import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.exception.CloneFailedException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -59,7 +58,6 @@ import uk.gov.gchq.gaffer.named.operation.NamedOperation;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.OperationChain;
 import uk.gov.gchq.gaffer.operation.OperationException;
-import uk.gov.gchq.gaffer.operation.Operations;
 import uk.gov.gchq.gaffer.operation.graph.OperationView;
 import uk.gov.gchq.gaffer.operation.impl.Limit;
 import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
@@ -101,9 +99,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -171,73 +167,41 @@ public class GraphTest {
         storeProperties.setStoreClass(TestStoreImpl.class.getName());
 
         final Schema schemaModule1 = new Schema.Builder()
-                .type(TestTypes.PROP_STRING, new TypeDefinition.Builder()
-                        .clazz(String.class)
-                        .build())
-                .type("vertex", new TypeDefinition.Builder()
-                        .clazz(String.class)
-                        .build())
-                .edge(TestGroups.EDGE, new SchemaEdgeDefinition.Builder()
-                        .property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
-                        .aggregate(false)
-                        .source("vertex")
-                        .destination("vertex")
-                        .directed(DIRECTED_EITHER)
-                        .build())
+                .type(TestTypes.PROP_STRING, new TypeDefinition.Builder().clazz(String.class).build())
+                .type("vertex", new TypeDefinition.Builder().clazz(String.class).build())
+                .edge(TestGroups.EDGE,
+                        new SchemaEdgeDefinition.Builder().property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
+                                .aggregate(false).source("vertex").destination("vertex").directed(DIRECTED_EITHER)
+                                .build())
                 .build();
 
         final Schema schemaModule2 = new Schema.Builder()
-                .type(TestTypes.PROP_INTEGER, new TypeDefinition.Builder()
-                        .clazz(Integer.class)
-                        .build())
-                .type("vertex2", new TypeDefinition.Builder()
-                        .clazz(String.class)
-                        .build())
-                .edge(TestGroups.EDGE_2, new SchemaEdgeDefinition.Builder()
-                        .property(TestPropertyNames.PROP_2, TestTypes.PROP_INTEGER)
-                        .aggregate(false)
-                        .source("vertex2")
-                        .destination("vertex2")
-                        .directed(DIRECTED_EITHER)
-                        .build())
+                .type(TestTypes.PROP_INTEGER, new TypeDefinition.Builder().clazz(Integer.class).build())
+                .type("vertex2", new TypeDefinition.Builder().clazz(String.class).build())
+                .edge(TestGroups.EDGE_2,
+                        new SchemaEdgeDefinition.Builder().property(TestPropertyNames.PROP_2, TestTypes.PROP_INTEGER)
+                                .aggregate(false).source("vertex2").destination("vertex2").directed(DIRECTED_EITHER)
+                                .build())
                 .build();
 
         final Schema schemaModule3 = new Schema.Builder()
-                .entity(TestGroups.ENTITY, new SchemaEntityDefinition.Builder()
-                        .property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
-                        .aggregate(false)
-                        .vertex("vertex3")
-                        .build())
-                .type("vertex3", new TypeDefinition.Builder()
-                        .clazz(String.class)
-                        .build())
-                .build();
+                .entity(TestGroups.ENTITY,
+                        new SchemaEntityDefinition.Builder().property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
+                                .aggregate(false).vertex("vertex3").build())
+                .type("vertex3", new TypeDefinition.Builder().clazz(String.class).build()).build();
 
         final Schema schemaModule4 = new Schema.Builder()
-                .entity(TestGroups.ENTITY_2, new SchemaEntityDefinition.Builder()
-                        .property(TestPropertyNames.PROP_2, TestTypes.PROP_INTEGER)
-                        .aggregate(false)
-                        .vertex("vertex4")
-                        .build())
-                .type("vertex4", new TypeDefinition.Builder()
-                        .clazz(String.class)
-                        .build())
-                .type(DIRECTED_EITHER, Boolean.class)
-                .build();
-
+                .entity(TestGroups.ENTITY_2,
+                        new SchemaEntityDefinition.Builder().property(TestPropertyNames.PROP_2, TestTypes.PROP_INTEGER)
+                                .aggregate(false).vertex("vertex4").build())
+                .type("vertex4", new TypeDefinition.Builder().clazz(String.class).build())
+                .type(DIRECTED_EITHER, Boolean.class).build();
 
         // When
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .description("testDescription")
-                        .graphId(GRAPH_ID)
-                        .build())
-                .storeProperties(storeProperties)
-                .addSchema(schemaModule1)
-                .addSchema(schemaModule2)
-                .addSchema(schemaModule3)
-                .addSchema(schemaModule4)
-                .build();
+                .config(new GraphConfig.Builder().description("testDescription").graphId(GRAPH_ID).build())
+                .storeProperties(storeProperties).addSchema(schemaModule1).addSchema(schemaModule2)
+                .addSchema(schemaModule3).addSchema(schemaModule4).build();
 
         // Then
         final Schema schema = graph.getSchema();
@@ -249,8 +213,7 @@ public class GraphTest {
     public void shouldConstructGraphFromSchemaFolderPath() throws IOException {
         // Given
         final Schema expectedSchema = new Schema.Builder()
-                .json(StreamUtil.elementsSchema(getClass()), StreamUtil.typesSchema(getClass()))
-                .build();
+                .json(StreamUtil.elementsSchema(getClass()), StreamUtil.typesSchema(getClass())).build();
 
         Graph graph = null;
         File schemaDir = null;
@@ -258,12 +221,8 @@ public class GraphTest {
             schemaDir = createSchemaDirectory();
 
             // When
-            graph = new Graph.Builder()
-                    .config(new GraphConfig.Builder()
-                            .graphId(GRAPH_ID)
-                            .build())
-                    .storeProperties(StreamUtil.storeProps(getClass()))
-                    .addSchema(Paths.get(schemaDir.getPath()))
+            graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+                    .storeProperties(StreamUtil.storeProps(getClass())).addSchema(Paths.get(schemaDir.getPath()))
                     .build();
         } finally {
             if (null != schemaDir) {
@@ -282,8 +241,7 @@ public class GraphTest {
         final URI schemaInputUri = getResourceUri(StreamUtil.ELEMENTS_SCHEMA);
         final URI storeInputUri = getResourceUri(StreamUtil.STORE_PROPERTIES);
         final Schema expectedSchema = new Schema.Builder()
-                .json(StreamUtil.elementsSchema(getClass()), StreamUtil.typesSchema(getClass()))
-                .build();
+                .json(StreamUtil.elementsSchema(getClass()), StreamUtil.typesSchema(getClass())).build();
         Graph graph = null;
         File schemaDir = null;
 
@@ -291,13 +249,8 @@ public class GraphTest {
             schemaDir = createSchemaDirectory();
 
             // When
-            graph = new Graph.Builder()
-                    .config(new GraphConfig.Builder()
-                            .graphId(GRAPH_ID)
-                            .build())
-                    .storeProperties(storeInputUri)
-                    .addSchemas(typeInputUri, schemaInputUri)
-                    .build();
+            graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+                    .storeProperties(storeInputUri).addSchemas(typeInputUri, schemaInputUri).build();
         } finally {
             if (schemaDir != null) {
                 FileUtils.deleteDirectory(schemaDir);
@@ -325,13 +278,8 @@ public class GraphTest {
         given(store.getSchema()).willReturn(schema);
         given(store.getProperties()).willReturn(new StoreProperties());
 
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .addSchema(new Schema.Builder().build())
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(new Schema.Builder().build())
                 .build();
 
         // When
@@ -349,13 +297,8 @@ public class GraphTest {
         given(store.getSchema()).willReturn(schema);
         given(store.getProperties()).willReturn(new StoreProperties());
 
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .addSchema(new Schema.Builder().build())
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(new Schema.Builder().build())
                 .build();
 
         // When
@@ -373,13 +316,8 @@ public class GraphTest {
         given(store.getSchema()).willReturn(schema);
         given(store.getProperties()).willReturn(new StoreProperties());
 
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .addSchema(new Schema.Builder().build())
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(new Schema.Builder().build())
                 .build();
 
         // When
@@ -390,7 +328,8 @@ public class GraphTest {
     }
 
     @Test
-    public void shouldCloseAllOperationInputsWhenExceptionIsThrownWhenExecuted() throws OperationException, IOException {
+    public void shouldCloseAllOperationInputsWhenExceptionIsThrownWhenExecuted()
+            throws OperationException, IOException {
         // Given
         final Exception exception = mock(RuntimeException.class);
         final Store store = mock(Store.class);
@@ -400,13 +339,11 @@ public class GraphTest {
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(new FunctionAuthoriser()) // skips json serialisation in default hook
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(new FunctionAuthoriser()) // skips json
+                                                                                                      // serialisation
+                                                                                                      // in default hook
                         .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .addSchema(new Schema.Builder().build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(new Schema.Builder().build())
                 .build();
 
         // When / Then
@@ -420,7 +357,8 @@ public class GraphTest {
     }
 
     @Test
-    public void shouldCloseAllOperationInputsWhenExceptionIsThrownWhenJobExecuted() throws OperationException, IOException {
+    public void shouldCloseAllOperationInputsWhenExceptionIsThrownWhenJobExecuted()
+            throws OperationException, IOException {
         // Given
         final Exception exception = mock(RuntimeException.class);
         final Store store = mock(Store.class);
@@ -430,13 +368,11 @@ public class GraphTest {
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(new FunctionAuthoriser()) // skips json serialisation in default hook
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(new FunctionAuthoriser()) // skips json
+                                                                                                      // serialisation
+                                                                                                      // in default hook
                         .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .addSchema(new Schema.Builder().build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(new Schema.Builder().build())
                 .build();
 
         // When / Then
@@ -459,14 +395,8 @@ public class GraphTest {
         final GraphHook hook1 = mock(GraphHook.class);
         final GraphHook hook2 = mock(GraphHook.class);
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(hook1)
-                        .addHook(hook2)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .addSchema(new Schema.Builder().build())
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(new Schema.Builder().build())
                 .build();
 
         // When
@@ -490,14 +420,8 @@ public class GraphTest {
         final GraphHook hook1 = mock(GraphHook.class);
         final GraphHook hook2 = mock(GraphHook.class);
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(hook1)
-                        .addHook(hook2)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .addSchema(new Schema.Builder().build())
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(new Schema.Builder().build())
                 .build();
 
         // When
@@ -528,15 +452,8 @@ public class GraphTest {
         given(hook2.postExecute(result2, clonedOpChain, clonedContext)).willReturn(result3);
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(hook1)
-                        .addHook(hook2)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .addSchema(schema)
-                .build();
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(schema).build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         final ArgumentCaptor<Context> contextCaptor1 = ArgumentCaptor.forClass(Context.class);
@@ -572,15 +489,8 @@ public class GraphTest {
         given(hook2.postExecute(result2, clonedOpChain, clonedContext)).willReturn(result3);
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(hook1)
-                        .addHook(hook2)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .addSchema(schema)
-                .build();
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(schema).build();
 
         given(store.execute(clonedOpChain, clonedContext)).willReturn(result1);
 
@@ -611,15 +521,8 @@ public class GraphTest {
         given(hook2.postExecute(result2, clonedOpChain, clonedContext)).willReturn(result3);
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(hook1)
-                        .addHook(hook2)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .addSchema(schema)
-                .build();
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(schema).build();
 
         given(store.executeJob(clonedOpChain, clonedContext)).willReturn(result1);
 
@@ -645,19 +548,13 @@ public class GraphTest {
         given(store.getProperties()).willReturn(new StoreProperties());
         final RuntimeException e = new RuntimeException("Hook2 failed in postExecute");
         doThrow(e).when(hook1).preExecute(clonedOpChain, clonedContext);
-        given(hook1.onFailure(null, clonedOpChain, clonedContext, e)).willThrow(new RuntimeException("Hook1 failed in onFailure"));
+        given(hook1.onFailure(null, clonedOpChain, clonedContext, e))
+                .willThrow(new RuntimeException("Hook1 failed in onFailure"));
         given(hook2.onFailure(null, clonedOpChain, clonedContext, e)).willReturn(null);
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(hook1)
-                        .addHook(hook2)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .addSchema(schema)
-                .build();
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(schema).build();
 
         // When / Then
         try {
@@ -689,19 +586,13 @@ public class GraphTest {
         given(hook1.postExecute(result1, clonedOpChain, clonedContext)).willReturn(result2);
         final RuntimeException e = new RuntimeException("Hook2 failed in postExecute");
         given(hook2.postExecute(result2, clonedOpChain, clonedContext)).willThrow(e);
-        given(hook1.onFailure(result2, clonedOpChain, clonedContext, e)).willThrow(new RuntimeException("Hook1 failed in onFailure"));
+        given(hook1.onFailure(result2, clonedOpChain, clonedContext, e))
+                .willThrow(new RuntimeException("Hook1 failed in onFailure"));
         given(hook2.onFailure(result2, clonedOpChain, clonedContext, e)).willReturn(result3);
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(hook1)
-                        .addHook(hook2)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .addSchema(schema)
-                .build();
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(schema).build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         given(store.execute(captor.capture(), eq(clonedContext))).willReturn(result1);
@@ -734,19 +625,13 @@ public class GraphTest {
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final RuntimeException e = new RuntimeException("Store failed to execute operation chain");
-        given(hook1.onFailure(null, clonedOpChain, clonedContext, e)).willThrow(new RuntimeException("Hook1 failed in onFailure"));
+        given(hook1.onFailure(null, clonedOpChain, clonedContext, e))
+                .willThrow(new RuntimeException("Hook1 failed in onFailure"));
         given(hook2.onFailure(null, clonedOpChain, clonedContext, e)).willReturn(null);
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(hook1)
-                        .addHook(hook2)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .addSchema(schema)
-                .build();
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(schema).build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         given(store.execute(captor.capture(), eq(clonedContext))).willThrow(e);
@@ -779,19 +664,13 @@ public class GraphTest {
         given(store.getProperties()).willReturn(new StoreProperties());
         final RuntimeException e = new RuntimeException("Hook2 failed in postExecute");
         doThrow(e).when(hook1).preExecute(clonedOpChain, clonedContext);
-        given(hook1.onFailure(null, clonedOpChain, clonedContext, e)).willThrow(new RuntimeException("Hook1 failed in onFailure"));
+        given(hook1.onFailure(null, clonedOpChain, clonedContext, e))
+                .willThrow(new RuntimeException("Hook1 failed in onFailure"));
         given(hook2.onFailure(null, clonedOpChain, clonedContext, e)).willReturn(null);
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(hook1)
-                        .addHook(hook2)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .addSchema(schema)
-                .build();
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(schema).build();
 
         // When / Then
         try {
@@ -824,19 +703,13 @@ public class GraphTest {
         given(hook1.postExecute(result1, clonedOpChain, clonedContext)).willReturn(result2);
         final RuntimeException e = new RuntimeException("Hook2 failed in postExecute");
         given(hook2.postExecute(result2, clonedOpChain, clonedContext)).willThrow(e);
-        given(hook1.onFailure(result2, clonedOpChain, clonedContext, e)).willThrow(new RuntimeException("Hook1 failed in onFailure"));
+        given(hook1.onFailure(result2, clonedOpChain, clonedContext, e))
+                .willThrow(new RuntimeException("Hook1 failed in onFailure"));
         given(hook2.onFailure(result2, clonedOpChain, clonedContext, e)).willReturn(result3);
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(hook1)
-                        .addHook(hook2)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .addSchema(schema)
-                .build();
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(schema).build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         given(store.executeJob(captor.capture(), eq(clonedContext))).willReturn(result1);
@@ -875,19 +748,13 @@ public class GraphTest {
 
         given(store.getSchema()).willReturn(schema);
         given(store.getProperties()).willReturn(new StoreProperties());
-        given(hook1.onFailure(null, clonedOpChain, clonedContext, e)).willThrow(new RuntimeException("Hook1 failed in onFailure"));
+        given(hook1.onFailure(null, clonedOpChain, clonedContext, e))
+                .willThrow(new RuntimeException("Hook1 failed in onFailure"));
         given(hook2.onFailure(null, clonedOpChain, clonedContext, e)).willReturn(null);
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(hook1)
-                        .addHook(hook2)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .addSchema(schema)
-                .build();
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(hook1).addHook(hook2).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(schema).build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         given(store.executeJob(captor.capture(), eq(clonedContext))).willThrow(e);
@@ -932,10 +799,7 @@ public class GraphTest {
         given(store.getSchema()).willReturn(schema);
 
         // When
-        final View resultView = new Graph.Builder()
-                .store(store)
-                .build()
-                .getView();
+        final View resultView = new Graph.Builder().store(store).build().getView();
 
         // Then
         assertNotSame(schema, resultView);
@@ -961,17 +825,12 @@ public class GraphTest {
         given(store.getSchema()).willReturn(new Schema());
         given(store.getProperties()).willReturn(new StoreProperties());
         final View view = mock(View.class);
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .view(view)
-                        .build())
-                .store(store)
-                .build();
-
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).view(view).build())
+                .store(store).build();
 
         // When
-        final Set<StoreTrait> storeTraits = new HashSet<>(Arrays.asList(StoreTrait.INGEST_AGGREGATION, StoreTrait.TRANSFORMATION));
+        final Set<StoreTrait> storeTraits = new HashSet<>(
+                Arrays.asList(StoreTrait.INGEST_AGGREGATION, StoreTrait.TRANSFORMATION));
         given(store.getTraits()).willReturn(storeTraits);
         final Collection<StoreTrait> returnedTraits = graph.getStoreTraits();
 
@@ -985,46 +844,28 @@ public class GraphTest {
         // Given
         final Store store = mock(Store.class);
         final Schema schema = new Schema.Builder()
-                .entity(TestGroups.ENTITY, new SchemaEntityDefinition.Builder()
-                        .vertex("string")
-                        .build())
-                .type("string", String.class)
-                .build();
+                .entity(TestGroups.ENTITY, new SchemaEntityDefinition.Builder().vertex("string").build())
+                .type("string", String.class).build();
         given(store.getSchema()).willReturn(schema);
         given(store.getOriginalSchema()).willReturn(schema);
         given(store.getProperties()).willReturn(new StoreProperties());
         final View view = mock(View.class);
-        new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .view(view)
-                        .build())
-                .addSchema(new Schema())
-                .store(store)
-                .build();
+        new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).view(view).build())
+                .addSchema(new Schema()).store(store).build();
 
         // When
         verify(store).setOriginalSchema(schema);
     }
 
     @Test
-    public void shouldSetGraphViewOnOperationAndDelegateDoOperationToStore()
-            throws OperationException {
+    public void shouldSetGraphViewOnOperationAndDelegateDoOperationToStore() throws OperationException {
         // Given
         final Store store = mock(Store.class);
         given(store.getSchema()).willReturn(new Schema());
         given(store.getProperties()).willReturn(new StoreProperties());
-        final View view = new View.Builder()
-                .entity(TestGroups.ENTITY)
-                .edge(TestGroups.EDGE)
-                .build();
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .view(view)
-                        .build())
-                .store(store)
-                .build();
+        final View view = new View.Builder().entity(TestGroups.ENTITY).edge(TestGroups.EDGE).build();
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).view(view).build())
+                .store(store).build();
         final Integer expectedResult = 5;
         final GetElements operation = new GetElements();
 
@@ -1051,13 +892,8 @@ public class GraphTest {
         given(store.getProperties()).willReturn(new StoreProperties());
         final View opView = mock(View.class);
         final View view = mock(View.class);
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .view(view)
-                        .build())
-                .store(store)
-                .build();
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).view(view).build())
+                .store(store).build();
         final Integer expectedResult = 5;
         given(operation.getView()).willReturn(opView);
 
@@ -1083,13 +919,8 @@ public class GraphTest {
         given(store.getSchema()).willReturn(new Schema());
         given(store.getProperties()).willReturn(new StoreProperties());
         final View view = mock(View.class);
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .view(view)
-                        .build())
-                .store(store)
-                .build();
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).view(view).build())
+                .store(store).build();
         final int expectedResult = 5;
         final Operation operation = mock(Operation.class);
 
@@ -1110,16 +941,12 @@ public class GraphTest {
     @Test
     public void shouldThrowExceptionIfStoreClassPropertyIsNotSet() throws OperationException {
         try {
-            new Graph.Builder()
-                    .config(new GraphConfig.Builder()
-                            .graphId(GRAPH_ID)
-                            .build())
-                    .addSchema(new Schema())
-                    .storeProperties(new StoreProperties())
-                    .build();
+            new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build()).addSchema(new Schema())
+                    .storeProperties(new StoreProperties()).build();
             fail("exception expected");
         } catch (final IllegalArgumentException e) {
-            assertEquals("The Store class name was not found in the store properties for key: " + StoreProperties.STORE_CLASS + ", GraphId: " + GRAPH_ID, e.getMessage());
+            assertEquals("The Store class name was not found in the store properties for key: "
+                    + StoreProperties.STORE_CLASS + ", GraphId: " + GRAPH_ID, e.getMessage());
         }
     }
 
@@ -1128,34 +955,22 @@ public class GraphTest {
         final StoreProperties storeProperties = new StoreProperties();
         storeProperties.setStoreClass(TestStoreImpl.class.getName());
         try {
-            new Graph.Builder()
-                    .config(new GraphConfig.Builder()
-                            .graphId(GRAPH_ID)
-                            .build())
+            new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
                     .addSchema(new Schema.Builder()
-                            .type("int", new TypeDefinition.Builder()
-                                    .clazz(Integer.class)
-                                    .aggregateFunction(new Sum())
+                            .type("int", new TypeDefinition.Builder().clazz(Integer.class).aggregateFunction(new Sum())
                                     // invalid serialiser
-                                    .serialiser(new RawDoubleSerialiser())
-                                    .build())
-                            .type("string", new TypeDefinition.Builder()
-                                    .clazz(String.class)
-                                    .aggregateFunction(new StringConcat())
-                                    .build())
+                                    .serialiser(new RawDoubleSerialiser()).build())
+                            .type("string",
+                                    new TypeDefinition.Builder().clazz(String.class)
+                                            .aggregateFunction(new StringConcat()).build())
                             .type("boolean", Boolean.class)
-                            .edge("EDGE", new SchemaEdgeDefinition.Builder()
-                                    .source("string")
-                                    .destination("string")
-                                    .directed("boolean")
-                                    .build())
-                            .entity("ENTITY", new SchemaEntityDefinition.Builder()
-                                    .vertex("string")
-                                    .property("p2", "int")
-                                    .build())
+                            .edge("EDGE",
+                                    new SchemaEdgeDefinition.Builder().source("string").destination("string")
+                                            .directed("boolean").build())
+                            .entity("ENTITY",
+                                    new SchemaEntityDefinition.Builder().vertex("string").property("p2", "int").build())
                             .build())
-                    .storeProperties(storeProperties)
-                    .build();
+                    .storeProperties(storeProperties).build();
             fail("exception expected");
         } catch (final SchemaException e) {
             assertNotNull(e.getMessage());
@@ -1168,11 +983,7 @@ public class GraphTest {
         final Store store = mock(Store.class);
         given(store.getSchema()).willReturn(new Schema());
         given(store.getProperties()).willReturn(new StoreProperties());
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .build())
-                .store(store)
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build()).store(store)
                 .build();
 
         final Set<Class<? extends Operation>> expectedNextOperations = mock(Set.class);
@@ -1191,11 +1002,7 @@ public class GraphTest {
         final Store store = mock(Store.class);
         given(store.getSchema()).willReturn(new Schema());
         given(store.getProperties()).willReturn(new StoreProperties());
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .build())
-                .store(store)
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build()).store(store)
                 .build();
 
         given(store.isSupported(GetElements.class)).willReturn(true);
@@ -1212,11 +1019,7 @@ public class GraphTest {
         final Store store = mock(Store.class);
         given(store.getSchema()).willReturn(new Schema());
         given(store.getProperties()).willReturn(new StoreProperties());
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .build())
-                .store(store)
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build()).store(store)
                 .build();
 
         final Set<Class<? extends Operation>> expectedSupportedOperations = mock(Set.class);
@@ -1236,18 +1039,12 @@ public class GraphTest {
         final StoreProperties storeProperties = new StoreProperties();
         storeProperties.setStoreClass(TestStoreImpl.class.getName());
 
-        //When / Then
+        // When / Then
         try {
-            new Graph.Builder()
-                    .config(new GraphConfig.Builder()
-                            .graphId(GRAPH_ID)
-                            .build())
-                    .addSchema(new Schema.Builder()
-                            .edge("group", new SchemaEdgeDefinition())
-                            .entity("group", new SchemaEntityDefinition())
-                            .build())
-                    .storeProperties(storeProperties)
-                    .build();
+            new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+                    .addSchema(new Schema.Builder().edge("group", new SchemaEdgeDefinition())
+                            .entity("group", new SchemaEntityDefinition()).build())
+                    .storeProperties(storeProperties).build();
         } catch (final SchemaException e) {
             assertTrue(e.getMessage().contains("Schema is not valid"));
         }
@@ -1259,14 +1056,10 @@ public class GraphTest {
         final StoreProperties storeProperties = new StoreProperties();
         storeProperties.setStoreClass(TestStoreImpl.class.getName());
 
-        //When / Then
+        // When / Then
         try {
-            new Graph.Builder()
-                    .config(new GraphConfig.Builder()
-                            .graphId(GRAPH_ID)
-                            .build())
-                    .storeProperties(storeProperties)
-                    .build();
+            new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+                    .storeProperties(storeProperties).build();
         } catch (final SchemaException e) {
             assertTrue(e.getMessage().contains("Schema is missing"));
         }
@@ -1279,7 +1072,8 @@ public class GraphTest {
     }
 
     private void writeToFile(final String schemaFile, final File dir) throws IOException {
-        Files.copy(new File(getClass().getResource("/schema/" + schemaFile).getPath()), new File(dir + "/" + schemaFile));
+        Files.copy(new File(getClass().getResource("/schema/" + schemaFile).getPath()),
+                new File(dir + "/" + schemaFile));
     }
 
     @Test
@@ -1288,11 +1082,7 @@ public class GraphTest {
         given(properties.getJobExecutorThreadCount()).willReturn(1);
 
         try {
-            new Graph.Builder()
-                    .config(new GraphConfig.Builder()
-                            .graphId("invalid-id")
-                            .build())
-                    .build();
+            new Graph.Builder().config(new GraphConfig.Builder().graphId("invalid-id").build()).build();
             fail("Exception expected");
         } catch (final IllegalArgumentException e) {
             assertNotNull(e.getMessage());
@@ -1306,81 +1096,45 @@ public class GraphTest {
         storeProperties.setStoreClass(TestStoreImpl.class.getName());
 
         final Schema schemaModule1 = new Schema.Builder()
-                .type(TestTypes.PROP_STRING, new TypeDefinition.Builder()
-                        .clazz(String.class)
-                        .build())
-                .type("vertex", new TypeDefinition.Builder()
-                        .clazz(String.class)
-                        .build())
-                .edge(TestGroups.EDGE, new SchemaEdgeDefinition.Builder()
-                        .property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
-                        .aggregate(false)
-                        .source("vertex")
-                        .destination("vertex")
-                        .directed(DIRECTED_EITHER)
-                        .build())
+                .type(TestTypes.PROP_STRING, new TypeDefinition.Builder().clazz(String.class).build())
+                .type("vertex", new TypeDefinition.Builder().clazz(String.class).build())
+                .edge(TestGroups.EDGE,
+                        new SchemaEdgeDefinition.Builder().property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
+                                .aggregate(false).source("vertex").destination("vertex").directed(DIRECTED_EITHER)
+                                .build())
                 .build();
 
         final Schema schemaModule2 = new Schema.Builder()
-                .type(TestTypes.PROP_INTEGER, new TypeDefinition.Builder()
-                        .clazz(Integer.class)
-                        .build())
-                .type("vertex2", new TypeDefinition.Builder()
-                        .clazz(String.class)
-                        .build())
-                .edge(TestGroups.EDGE_2, new SchemaEdgeDefinition.Builder()
-                        .property(TestPropertyNames.PROP_2, TestTypes.PROP_INTEGER)
-                        .aggregate(false)
-                        .source("vertex2")
-                        .destination("vertex2")
-                        .directed(DIRECTED_EITHER)
-                        .build())
+                .type(TestTypes.PROP_INTEGER, new TypeDefinition.Builder().clazz(Integer.class).build())
+                .type("vertex2", new TypeDefinition.Builder().clazz(String.class).build())
+                .edge(TestGroups.EDGE_2,
+                        new SchemaEdgeDefinition.Builder().property(TestPropertyNames.PROP_2, TestTypes.PROP_INTEGER)
+                                .aggregate(false).source("vertex2").destination("vertex2").directed(DIRECTED_EITHER)
+                                .build())
                 .build();
 
         final Schema schemaModule3 = new Schema.Builder()
-                .entity(TestGroups.ENTITY, new SchemaEntityDefinition.Builder()
-                        .property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
-                        .aggregate(false)
-                        .vertex("vertex3")
-                        .build())
-                .type("vertex3", new TypeDefinition.Builder()
-                        .clazz(String.class)
-                        .build())
-                .build();
+                .entity(TestGroups.ENTITY,
+                        new SchemaEntityDefinition.Builder().property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
+                                .aggregate(false).vertex("vertex3").build())
+                .type("vertex3", new TypeDefinition.Builder().clazz(String.class).build()).build();
 
         final Schema schemaModule4 = new Schema.Builder()
-                .entity(TestGroups.ENTITY_2, new SchemaEntityDefinition.Builder()
-                        .property(TestPropertyNames.PROP_2, TestTypes.PROP_INTEGER)
-                        .aggregate(false)
-                        .vertex("vertex4")
-                        .build())
-                .type("vertex4", new TypeDefinition.Builder()
-                        .clazz(String.class)
-                        .build())
-                .type(DIRECTED_EITHER, Boolean.class)
-                .build();
-
+                .entity(TestGroups.ENTITY_2,
+                        new SchemaEntityDefinition.Builder().property(TestPropertyNames.PROP_2, TestTypes.PROP_INTEGER)
+                                .aggregate(false).vertex("vertex4").build())
+                .type("vertex4", new TypeDefinition.Builder().clazz(String.class).build())
+                .type(DIRECTED_EITHER, Boolean.class).build();
 
         // When
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .library(new HashMapGraphLibrary())
-                        .build())
-                .addSchema(schemaModule1)
-                .addSchema(schemaModule2)
-                .addSchema(schemaModule3)
-                .addSchema(schemaModule4)
-                .storeProperties(storeProperties)
-                .build();
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).library(new HashMapGraphLibrary()).build())
+                .addSchema(schemaModule1).addSchema(schemaModule2).addSchema(schemaModule3).addSchema(schemaModule4)
+                .storeProperties(storeProperties).build();
 
         final Graph graph2 = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .library(new HashMapGraphLibrary())
-                        .build())
-                .storeProperties(storeProperties)
-                .build();
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).library(new HashMapGraphLibrary()).build())
+                .storeProperties(storeProperties).build();
 
         // Then
         JsonAssert.assertEquals(graph.getSchema().toJson(false), graph2.getSchema().toJson(false));
@@ -1396,16 +1150,12 @@ public class GraphTest {
 
         // When
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId("graphId")
-                        .addHooks(graphHook1, graphHook2)
-                        .build())
-                .storeProperties(storeProperties)
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .build();
+                .config(new GraphConfig.Builder().graphId("graphId").addHooks(graphHook1, graphHook2).build())
+                .storeProperties(storeProperties).addSchemas(StreamUtil.schemas(getClass())).build();
 
         // Then
-        assertEquals(Arrays.asList(NamedViewResolver.class, graphHook1.getClass(), graphHook2.getClass(), FunctionAuthoriser.class), graph.getGraphHooks());
+        assertEquals(Arrays.asList(NamedViewResolver.class, graphHook1.getClass(), graphHook2.getClass(),
+                FunctionAuthoriser.class), graph.getGraphHooks());
     }
 
     @Test
@@ -1420,17 +1170,13 @@ public class GraphTest {
         final Log4jLogger graphHook3 = mock(Log4jLogger.class);
 
         // When
-        final Graph graph = new Graph.Builder()
-                .graphId("graphId")
-                .storeProperties(storeProperties)
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .addHook(graphHook1)
-                .addHook(graphHook2)
-                .addHook(graphHook3)
+        final Graph graph = new Graph.Builder().graphId("graphId").storeProperties(storeProperties)
+                .addSchemas(StreamUtil.schemas(getClass())).addHook(graphHook1).addHook(graphHook2).addHook(graphHook3)
                 .build();
 
         // Then
-        assertEquals(Arrays.asList(NamedViewResolver.class, graphHook1.getClass(), graphHook2.getClass(), graphHook3.getClass(), FunctionAuthoriser.class), graph.getGraphHooks());
+        assertEquals(Arrays.asList(NamedViewResolver.class, graphHook1.getClass(), graphHook2.getClass(),
+                graphHook3.getClass(), FunctionAuthoriser.class), graph.getGraphHooks());
     }
 
     @Test
@@ -1445,17 +1191,12 @@ public class GraphTest {
 
         // When
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId("graphId")
-                        .addHook(graphHook1)
-                        .addHook(graphHook2)
-                        .build())
-                .storeProperties(storeProperties)
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .build();
+                .config(new GraphConfig.Builder().graphId("graphId").addHook(graphHook1).addHook(graphHook2).build())
+                .storeProperties(storeProperties).addSchemas(StreamUtil.schemas(getClass())).build();
 
         // Then
-        assertEquals(Arrays.asList(NamedOperationResolver.class, NamedViewResolver.class, graphHook1.getClass(), graphHook2.getClass(), FunctionAuthoriser.class), graph.getGraphHooks());
+        assertEquals(Arrays.asList(NamedOperationResolver.class, NamedViewResolver.class, graphHook1.getClass(),
+                graphHook2.getClass(), FunctionAuthoriser.class), graph.getGraphHooks());
     }
 
     @Test
@@ -1469,19 +1210,12 @@ public class GraphTest {
 
         // When
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId("graphId")
-                        .addHooks(Paths.get(graphHooks.getPath()))
-                        .build())
-                .storeProperties(storeProperties)
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .build();
+                .config(new GraphConfig.Builder().graphId("graphId").addHooks(Paths.get(graphHooks.getPath())).build())
+                .storeProperties(storeProperties).addSchemas(StreamUtil.schemas(getClass())).build();
 
         // Then
-        assertEquals(
-                Arrays.asList(NamedViewResolver.class, OperationChainLimiter.class, AddOperationsToChain.class, OperationAuthoriser.class, FunctionAuthoriser.class),
-                graph.getGraphHooks()
-        );
+        assertEquals(Arrays.asList(NamedViewResolver.class, OperationChainLimiter.class, AddOperationsToChain.class,
+                OperationAuthoriser.class, FunctionAuthoriser.class), graph.getGraphHooks());
     }
 
     @Test
@@ -1491,24 +1225,21 @@ public class GraphTest {
         storeProperties.setStoreClass(TestStoreImpl.class.getName());
 
         final File graphHook1File = tempDir.resolve("opChainLimiter.json").toFile();
-        FileUtils.writeLines(graphHook1File, IOUtils.readLines(StreamUtil.openStream(getClass(), "opChainLimiter.json")));
+        FileUtils.writeLines(graphHook1File,
+                IOUtils.readLines(StreamUtil.openStream(getClass(), "opChainLimiter.json")));
 
         final File graphHook2File = tempDir.resolve("opAuthoriser.json").toFile();
         FileUtils.writeLines(graphHook2File, IOUtils.readLines(StreamUtil.openStream(getClass(), "opAuthoriser.json")));
 
         // When
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId("graphId")
-                        .addHook(Paths.get(graphHook1File.getPath()))
-                        .addHook(Paths.get(graphHook2File.getPath()))
-                        .build())
-                .storeProperties(storeProperties)
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .build();
+                .config(new GraphConfig.Builder().graphId("graphId").addHook(Paths.get(graphHook1File.getPath()))
+                        .addHook(Paths.get(graphHook2File.getPath())).build())
+                .storeProperties(storeProperties).addSchemas(StreamUtil.schemas(getClass())).build();
 
         // Then
-        assertEquals(Arrays.asList(NamedViewResolver.class, OperationChainLimiter.class, OperationAuthoriser.class, FunctionAuthoriser.class), graph.getGraphHooks());
+        assertEquals(Arrays.asList(NamedViewResolver.class, OperationChainLimiter.class, OperationAuthoriser.class,
+                FunctionAuthoriser.class), graph.getGraphHooks());
     }
 
     @Test
@@ -1518,22 +1249,17 @@ public class GraphTest {
         storeProperties.setStoreClass(TestStoreImpl.class.getName());
 
         // When
-        final Graph graph = new Graph.Builder()
-                .config(StreamUtil.graphConfig(getClass()))
-                .storeProperties(storeProperties)
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .build();
+        final Graph graph = new Graph.Builder().config(StreamUtil.graphConfig(getClass()))
+                .storeProperties(storeProperties).addSchemas(StreamUtil.schemas(getClass())).build();
 
         // Then
         assertEquals("graphId1", graph.getGraphId());
-        assertEquals(new View.Builder()
-                .globalElements(new GlobalViewElementDefinition.Builder()
-                        .groupBy()
-                        .build())
-                .build(), graph.getView());
+        assertEquals(
+                new View.Builder().globalElements(new GlobalViewElementDefinition.Builder().groupBy().build()).build(),
+                graph.getView());
         assertEquals(HashMapGraphLibrary.class, graph.getGraphLibrary().getClass());
-        assertEquals(Arrays.asList(NamedViewResolver.class, OperationChainLimiter.class, AddOperationsToChain.class, FunctionAuthoriser.class),
-                graph.getGraphHooks());
+        assertEquals(Arrays.asList(NamedViewResolver.class, OperationChainLimiter.class, AddOperationsToChain.class,
+                FunctionAuthoriser.class), graph.getGraphHooks());
     }
 
     @Test
@@ -1556,30 +1282,19 @@ public class GraphTest {
         final GraphHook hook3 = mock(GraphHook.class);
 
         // When
-        final GraphConfig config = new GraphConfig.Builder()
-                .graphId(graphId2)
-                .library(library2)
-                .addHook(hook2)
-                .view(view2)
-                .build();
+        final GraphConfig config = new GraphConfig.Builder().graphId(graphId2).library(library2).addHook(hook2)
+                .view(view2).build();
 
-        final Graph graph = new Graph.Builder()
-                .graphId(graphId1)
-                .library(library1)
-                .view(view1)
-                .storeProperties(storeProperties)
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .addHook(hook1)
-                .config(config)
-                .addHook(hook3)
-                .build();
+        final Graph graph = new Graph.Builder().graphId(graphId1).library(library1).view(view1)
+                .storeProperties(storeProperties).addSchemas(StreamUtil.schemas(getClass())).addHook(hook1)
+                .config(config).addHook(hook3).build();
 
         // Then
         assertEquals(graphId2, graph.getGraphId());
         assertEquals(view2, graph.getView());
         assertEquals(library2, graph.getGraphLibrary());
-        assertEquals(Arrays.asList(NamedViewResolver.class, hook1.getClass(), hook2.getClass(), hook3.getClass(), FunctionAuthoriser.class),
-                graph.getGraphHooks());
+        assertEquals(Arrays.asList(NamedViewResolver.class, hook1.getClass(), hook2.getClass(), hook3.getClass(),
+                FunctionAuthoriser.class), graph.getGraphHooks());
     }
 
     @Test
@@ -1602,30 +1317,19 @@ public class GraphTest {
         final GraphHook hook3 = mock(GraphHook.class);
 
         // When
-        final GraphConfig config = new GraphConfig.Builder()
-                .graphId(graphId2)
-                .library(library2)
-                .addHook(hook2)
-                .view(view2)
-                .build();
+        final GraphConfig config = new GraphConfig.Builder().graphId(graphId2).library(library2).addHook(hook2)
+                .view(view2).build();
 
-        final Graph graph = new Graph.Builder()
-                .config(config)
-                .graphId(graphId1)
-                .library(library1)
-                .view(view1)
-                .storeProperties(storeProperties)
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .addHook(hook1)
-                .addHook(hook3)
-                .build();
+        final Graph graph = new Graph.Builder().config(config).graphId(graphId1).library(library1).view(view1)
+                .storeProperties(storeProperties).addSchemas(StreamUtil.schemas(getClass())).addHook(hook1)
+                .addHook(hook3).build();
 
         // Then
         assertEquals(graphId1, graph.getGraphId());
         assertEquals(view1, graph.getView());
         assertEquals(library1, graph.getGraphLibrary());
-        assertEquals(Arrays.asList(NamedViewResolver.class, hook2.getClass(), hook1.getClass(), hook3.getClass(), FunctionAuthoriser.class),
-                graph.getGraphHooks());
+        assertEquals(Arrays.asList(NamedViewResolver.class, hook2.getClass(), hook1.getClass(), hook3.getClass(),
+                FunctionAuthoriser.class), graph.getGraphHooks());
     }
 
     @Test
@@ -1639,16 +1343,10 @@ public class GraphTest {
         final View view = new View.Builder().entity(TestGroups.ENTITY).build();
 
         // When
-        final GraphConfig config = new GraphConfig.Builder()
-                .graphId(graphId)
-                .view(view)
-                .build();
+        final GraphConfig config = new GraphConfig.Builder().graphId(graphId).view(view).build();
 
-        final Graph graph = new Graph.Builder()
-                .config(config)
-                .storeProperties(storeProperties)
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .build();
+        final Graph graph = new Graph.Builder().config(config).storeProperties(storeProperties)
+                .addSchemas(StreamUtil.schemas(getClass())).build();
 
         // Then
         assertEquals(graphId, graph.getGraphId());
@@ -1676,19 +1374,11 @@ public class GraphTest {
         library.addProperties(STORE_PROPERTIES_ID_1, libraryStoreProperties);
 
         // When
-        final GraphConfig config = new GraphConfig.Builder()
-                .graphId(graphId1)
-                .library(library)
-                .build();
+        final GraphConfig config = new GraphConfig.Builder().graphId(graphId1).library(library).build();
 
-        final Graph graph1 = new Graph.Builder()
-                .config(config)
-                .addToLibrary(true)
-                .parentStorePropertiesId("storePropertiesId1")
-                .storeProperties(graphStoreProperties)
-                .addParentSchemaIds(SCHEMA_ID_1)
-                .addSchemas(graphSchema)
-                .build();
+        final Graph graph1 = new Graph.Builder().config(config).addToLibrary(true)
+                .parentStorePropertiesId("storePropertiesId1").storeProperties(graphStoreProperties)
+                .addParentSchemaIds(SCHEMA_ID_1).addSchemas(graphSchema).build();
 
         // Then
         assertEquals(graphId1, graph1.getGraphId());
@@ -1696,7 +1386,8 @@ public class GraphTest {
         final Pair<String, String> ids = library.getIds(graphId1);
         // Check that the schemaIds are different between the parent and supplied schema
         assertEquals(graphId1, ids.getFirst());
-        // Check that the storePropsIds are different between the parent and supplied storeProps
+        // Check that the storePropsIds are different between the parent and supplied
+        // storeProps
         assertEquals(graphId1, ids.getSecond());
     }
 
@@ -1716,26 +1407,20 @@ public class GraphTest {
         library.addProperties(storePropertiesId1, storeProperties);
 
         // When
-        final GraphConfig config = new GraphConfig.Builder()
-                .graphId(graphId1)
-                .library(library)
-                .build();
+        final GraphConfig config = new GraphConfig.Builder().graphId(graphId1).library(library).build();
 
-        final Graph graph1 = new Graph.Builder()
-                .config(config)
-                .addToLibrary(true)
-                .parentStorePropertiesId(storePropertiesId1)
-                .storeProperties(storeProperties)
-                .addParentSchemaIds(SCHEMA_ID_1)
-                .addSchemas(schema)
-                .build();
+        final Graph graph1 = new Graph.Builder().config(config).addToLibrary(true)
+                .parentStorePropertiesId(storePropertiesId1).storeProperties(storeProperties)
+                .addParentSchemaIds(SCHEMA_ID_1).addSchemas(schema).build();
 
         // Then
         assertEquals(graphId1, graph1.getGraphId());
         JsonAssert.assertEquals(library.getSchema(SCHEMA_ID_1).toJson(false), schema.toJson(false));
-        // Check that the schemaId = schemaId1 as both the parent and supplied schema have same id's
+        // Check that the schemaId = schemaId1 as both the parent and supplied schema
+        // have same id's
         assertTrue(library.getIds(graphId1).getFirst().equals(graphId1));
-        // Check that the storePropsId = storePropertiesId1 as both parent and supplied storeProps have same id's
+        // Check that the storePropsId = storePropertiesId1 as both parent and supplied
+        // storeProps have same id's
         assertTrue(library.getIds(graphId1).getSecond().equals(graphId1));
     }
 
@@ -1759,26 +1444,19 @@ public class GraphTest {
         library.addProperties(STORE_PROPERTIES_ID_1, libraryStoreProperties);
 
         // When
-        final GraphConfig config = new GraphConfig.Builder()
-                .graphId(graphId1)
-                .library(library)
-                .build();
+        final GraphConfig config = new GraphConfig.Builder().graphId(graphId1).library(library).build();
 
-        final Graph graph1 = new Graph.Builder()
-                .config(config)
-                .addToLibrary(true)
-                .parentStorePropertiesId("storePropertiesId1")
-                .storeProperties(graphStoreProperties)
-                .addParentSchemaIds(SCHEMA_ID_1)
-                .addSchemas(graphSchema)
-                .build();
+        final Graph graph1 = new Graph.Builder().config(config).addToLibrary(true)
+                .parentStorePropertiesId("storePropertiesId1").storeProperties(graphStoreProperties)
+                .addParentSchemaIds(SCHEMA_ID_1).addSchemas(graphSchema).build();
 
         // Then
         assertEquals(graphId1, graph1.getGraphId());
         JsonAssert.assertEquals(library.getSchema(SCHEMA_ID_1).toJson(false), librarySchema.toJson(false));
         // Check that the schemaId = schemaId1 as both the supplied schema id is null
         assertTrue(library.getIds(graphId1).getFirst().equals(graphId1));
-        // Check that the storePropsId = storePropertiesId1 as the supplied storeProps id is null
+        // Check that the storePropsId = storePropertiesId1 as the supplied storeProps
+        // id is null
         assertTrue(library.getIds(graphId1).getSecond().equals(graphId1));
     }
 
@@ -1786,36 +1464,22 @@ public class GraphTest {
     public void shouldCorrectlySetViewForNestedOperationChain() throws OperationException {
         // Given
         final Store store = new TestStore();
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .build())
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
                 .storeProperties(new StoreProperties())
                 .addSchema(new Schema.Builder()
-                        .edge(TestGroups.EDGE, new SchemaEdgeDefinition.Builder()
-                                .property(TestPropertyNames.PROP_1, TestTypes.PROP_INTEGER)
-                                .aggregate(false)
-                                .source("vertex2")
-                                .destination("vertex2")
-                                .directed(DIRECTED_EITHER)
-                                .build())
-                        .type(TestTypes.PROP_INTEGER, new TypeDefinition.Builder()
-                                .clazz(Integer.class)
-                                .build())
-                        .type("vertex2", new TypeDefinition.Builder()
-                                .clazz(String.class)
-                                .build())
-                        .type(DIRECTED_EITHER, Boolean.class)
-                        .build())
-                .store(store)
-                .build();
+                        .edge(TestGroups.EDGE,
+                                new SchemaEdgeDefinition.Builder()
+                                        .property(TestPropertyNames.PROP_1, TestTypes.PROP_INTEGER).aggregate(false)
+                                        .source("vertex2").destination("vertex2").directed(DIRECTED_EITHER).build())
+                        .type(TestTypes.PROP_INTEGER, new TypeDefinition.Builder().clazz(Integer.class).build())
+                        .type("vertex2", new TypeDefinition.Builder().clazz(String.class).build())
+                        .type(DIRECTED_EITHER, Boolean.class).build())
+                .store(store).build();
         final User user = new User();
         final Context context = new Context(user);
 
         final OperationChain<Iterable<? extends Element>> nestedChain = new OperationChain<>(
-                Arrays.asList(
-                        new GetAllElements(),
-                        new Limit<>(3, true)));
+                Arrays.asList(new GetAllElements(), new Limit<>(3, true)));
         final OperationChain<Iterable<? extends Element>> outerChain = new OperationChain<>(nestedChain);
 
         graph.execute(outerChain, context);
@@ -1830,13 +1494,8 @@ public class GraphTest {
         final Context context = null;
         final OperationChain opChain = mock(OperationChain.class);
 
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .build();
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).addSchemas(StreamUtil.schemas(getClass())).build();
 
         // When / Then
         try {
@@ -1853,13 +1512,8 @@ public class GraphTest {
         final Context context = null;
         final OperationChain opChain = mock(OperationChain.class);
 
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .build();
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).addSchemas(StreamUtil.schemas(getClass())).build();
 
         // When / Then
         try {
@@ -1876,13 +1530,8 @@ public class GraphTest {
         final User user = null;
         final OperationChain opChain = mock(OperationChain.class);
 
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .build();
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).addSchemas(StreamUtil.schemas(getClass())).build();
 
         // When / Then
         try {
@@ -1899,13 +1548,8 @@ public class GraphTest {
         final User user = null;
         final OperationChain opChain = mock(OperationChain.class);
 
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .build();
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).addSchemas(StreamUtil.schemas(getClass())).build();
 
         // When / Then
         try {
@@ -1922,13 +1566,8 @@ public class GraphTest {
         final Context context = null;
         final OperationChain opChain = mock(OperationChain.class);
 
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .build();
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).addSchemas(StreamUtil.schemas(getClass())).build();
 
         final Job job = new Job(null, opChain);
 
@@ -1946,13 +1585,8 @@ public class GraphTest {
         // Given
         final Context context = new Context();
 
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .build();
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).addSchemas(StreamUtil.schemas(getClass())).build();
 
         final Job job = new Job(new Repeat(), new OperationChain<>());
 
@@ -1970,13 +1604,8 @@ public class GraphTest {
         // Given
         final Context context = new Context();
 
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .build();
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).addSchemas(StreamUtil.schemas(getClass())).build();
 
         final Job job = null;
 
@@ -1995,13 +1624,8 @@ public class GraphTest {
         final User user = null;
         final OperationChain opChain = mock(OperationChain.class);
 
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .build();
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).addSchemas(StreamUtil.schemas(getClass())).build();
 
         final Job job = new Job(null, opChain);
 
@@ -2018,15 +1642,10 @@ public class GraphTest {
     public void shouldManipulateViewRemovingBlacklistedEdgeUsingUpdateViewHook() throws OperationException {
         // Given
         operation = new GetElements.Builder()
-                .view(new View.Builder()
-                        .edge(TestGroups.EDGE_5)
-                        .edge(TestGroups.EDGE)
-                        .build())
-                .build();
+                .view(new View.Builder().edge(TestGroups.EDGE_5).edge(TestGroups.EDGE).build()).build();
 
         final UpdateViewHook updateViewHook = new UpdateViewHook.Builder()
-                .blackListElementGroups(Collections.singleton(TestGroups.EDGE))
-                .build();
+                .blackListElementGroups(Collections.singleton(TestGroups.EDGE)).build();
 
         given(opChain.getOperations()).willReturn(Lists.newArrayList(operation));
         given(opChain.shallowClone()).willReturn(clonedOpChain);
@@ -2039,13 +1658,8 @@ public class GraphTest {
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(updateViewHook)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .build();
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(updateViewHook).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         final ArgumentCaptor<Context> contextCaptor1 = ArgumentCaptor.forClass(Context.class);
@@ -2062,17 +1676,13 @@ public class GraphTest {
     }
 
     @Test
-    public void shouldManipulateViewRemovingBlacklistedEdgeLeavingEmptyViewUsingUpdateViewHook() throws OperationException {
+    public void shouldManipulateViewRemovingBlacklistedEdgeLeavingEmptyViewUsingUpdateViewHook()
+            throws OperationException {
         // Given
-        operation = new GetElements.Builder()
-                .view(new View.Builder()
-                        .edge(TestGroups.EDGE)
-                        .build())
-                .build();
+        operation = new GetElements.Builder().view(new View.Builder().edge(TestGroups.EDGE).build()).build();
 
         final UpdateViewHook updateViewHook = new UpdateViewHook.Builder()
-                .blackListElementGroups(Collections.singleton(TestGroups.EDGE))
-                .build();
+                .blackListElementGroups(Collections.singleton(TestGroups.EDGE)).build();
 
         given(opChain.getOperations()).willReturn(Lists.newArrayList(operation));
         given(opChain.shallowClone()).willReturn(clonedOpChain);
@@ -2085,13 +1695,8 @@ public class GraphTest {
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(updateViewHook)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .build();
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(updateViewHook).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         final ArgumentCaptor<Context> contextCaptor1 = ArgumentCaptor.forClass(Context.class);
@@ -2111,20 +1716,14 @@ public class GraphTest {
     public void shouldRerunMultipleUpdateViewHooksToRemoveAllBlacklistedElements() throws OperationException {
         // Given
         operation = new GetElements.Builder()
-                .view(new View.Builder()
-                        .edge(TestGroups.EDGE)
-                        .edge(TestGroups.EDGE_2)
-                        .build())
-                .build();
+                .view(new View.Builder().edge(TestGroups.EDGE).edge(TestGroups.EDGE_2).build()).build();
 
         final UpdateViewHook first = new UpdateViewHook.Builder()
-                .blackListElementGroups(Collections.singleton(TestGroups.EDGE))
-                .withOpAuth(Sets.newHashSet("opAuth1"))
+                .blackListElementGroups(Collections.singleton(TestGroups.EDGE)).withOpAuth(Sets.newHashSet("opAuth1"))
                 .build();
 
         final UpdateViewHook second = new UpdateViewHook.Builder()
-                .blackListElementGroups(Collections.singleton(TestGroups.EDGE_2))
-                .withOpAuth(Sets.newHashSet("opAuth2"))
+                .blackListElementGroups(Collections.singleton(TestGroups.EDGE_2)).withOpAuth(Sets.newHashSet("opAuth2"))
                 .build();
 
         given(opChain.getOperations()).willReturn(Lists.newArrayList(operation));
@@ -2134,31 +1733,20 @@ public class GraphTest {
 
         final Store store = mock(Store.class);
 
-        given(store.getSchema()).willReturn(new Schema.Builder()
-                .edge(TestGroups.EDGE, new SchemaEdgeDefinition())
-                .edge(TestGroups.EDGE_2, new SchemaEdgeDefinition())
-        .build());
+        given(store.getSchema()).willReturn(new Schema.Builder().edge(TestGroups.EDGE, new SchemaEdgeDefinition())
+                .edge(TestGroups.EDGE_2, new SchemaEdgeDefinition()).build());
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(first)
-                        .addHook(second)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .build();
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(first).addHook(second).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         final ArgumentCaptor<Context> contextCaptor1 = ArgumentCaptor.forClass(Context.class);
 
         given(store.execute(captor.capture(), contextCaptor1.capture())).willReturn(new ArrayList<>());
 
-        User user = new User.Builder()
-                .userId("user")
-                .opAuths("opAuth1", "opAuth2")
-                .build();
+        User user = new User.Builder().userId("user").opAuths("opAuth1", "opAuth2").build();
         // When / Then
         graph.execute(opChain, user);
 
@@ -2169,14 +1757,13 @@ public class GraphTest {
     }
 
     @Test
-    public void shouldFillSchemaViewAndManipulateViewRemovingBlacklistedEdgeUsingUpdateViewHook() throws OperationException {
+    public void shouldFillSchemaViewAndManipulateViewRemovingBlacklistedEdgeUsingUpdateViewHook()
+            throws OperationException {
         // Given
-        operation = new GetElements.Builder()
-                .build();
+        operation = new GetElements.Builder().build();
 
         final UpdateViewHook updateViewHook = new UpdateViewHook.Builder()
-                .blackListElementGroups(Collections.singleton(TestGroups.EDGE))
-                .build();
+                .blackListElementGroups(Collections.singleton(TestGroups.EDGE)).build();
 
         given(opChain.getOperations()).willReturn(Lists.newArrayList(operation));
         given(opChain.shallowClone()).willReturn(clonedOpChain);
@@ -2185,20 +1772,13 @@ public class GraphTest {
 
         final Store store = mock(Store.class);
 
-        given(store.getSchema()).willReturn(new Schema.Builder()
-                .edge(TestGroups.EDGE, new SchemaEdgeDefinition())
-                .edge(TestGroups.EDGE_5, new SchemaEdgeDefinition())
-                .build());
+        given(store.getSchema()).willReturn(new Schema.Builder().edge(TestGroups.EDGE, new SchemaEdgeDefinition())
+                .edge(TestGroups.EDGE_5, new SchemaEdgeDefinition()).build());
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(updateViewHook)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .build();
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(updateViewHook).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         final ArgumentCaptor<Context> contextCaptor1 = ArgumentCaptor.forClass(Context.class);
@@ -2215,14 +1795,13 @@ public class GraphTest {
     }
 
     @Test
-    public void shouldFillSchemaViewAndManipulateViewRemovingBlacklistedEdgeLeavingEmptyViewUsingUpdateViewHook() throws OperationException {
+    public void shouldFillSchemaViewAndManipulateViewRemovingBlacklistedEdgeLeavingEmptyViewUsingUpdateViewHook()
+            throws OperationException {
         // Given
-        operation = new GetElements.Builder()
-                .build();
+        operation = new GetElements.Builder().build();
 
         final UpdateViewHook updateViewHook = new UpdateViewHook.Builder()
-                .blackListElementGroups(Collections.singleton(TestGroups.EDGE))
-                .build();
+                .blackListElementGroups(Collections.singleton(TestGroups.EDGE)).build();
 
         given(opChain.getOperations()).willReturn(Lists.newArrayList(operation));
         given(opChain.shallowClone()).willReturn(clonedOpChain);
@@ -2231,17 +1810,13 @@ public class GraphTest {
 
         final Store store = mock(Store.class);
 
-        given(store.getSchema()).willReturn(new Schema.Builder().edge(TestGroups.EDGE_5, new SchemaEdgeDefinition()).edge(TestGroups.EDGE, new SchemaEdgeDefinition()).build());
+        given(store.getSchema()).willReturn(new Schema.Builder().edge(TestGroups.EDGE_5, new SchemaEdgeDefinition())
+                .edge(TestGroups.EDGE, new SchemaEdgeDefinition()).build());
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(updateViewHook)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .build();
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(updateViewHook).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         final ArgumentCaptor<Context> contextCaptor1 = ArgumentCaptor.forClass(Context.class);
@@ -2258,15 +1833,13 @@ public class GraphTest {
     }
 
     @Test
-    public void shouldCorrectlyAddExtraGroupsFromSchemaViewWithUpdateViewHookWhenNotInBlacklist() throws OperationException {
+    public void shouldCorrectlyAddExtraGroupsFromSchemaViewWithUpdateViewHookWhenNotInBlacklist()
+            throws OperationException {
         // Given
-        operation = new GetElements.Builder()
-                .build();
+        operation = new GetElements.Builder().build();
 
-        final UpdateViewHook updateViewHook = new UpdateViewHook.Builder()
-                .addExtraGroups(true)
-                .blackListElementGroups(Collections.singleton(TestGroups.EDGE))
-                .build();
+        final UpdateViewHook updateViewHook = new UpdateViewHook.Builder().addExtraGroups(true)
+                .blackListElementGroups(Collections.singleton(TestGroups.EDGE)).build();
 
         given(opChain.getOperations()).willReturn(Lists.newArrayList(operation));
         given(opChain.shallowClone()).willReturn(clonedOpChain);
@@ -2275,21 +1848,14 @@ public class GraphTest {
 
         final Store store = mock(Store.class);
 
-        given(store.getSchema()).willReturn(new Schema.Builder()
-                .edge(TestGroups.EDGE_4, new SchemaEdgeDefinition())
-                .edge(TestGroups.EDGE_5, new SchemaEdgeDefinition())
-                .edge(TestGroups.EDGE, new SchemaEdgeDefinition())
+        given(store.getSchema()).willReturn(new Schema.Builder().edge(TestGroups.EDGE_4, new SchemaEdgeDefinition())
+                .edge(TestGroups.EDGE_5, new SchemaEdgeDefinition()).edge(TestGroups.EDGE, new SchemaEdgeDefinition())
                 .build());
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(updateViewHook)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .build();
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(updateViewHook).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         final ArgumentCaptor<Context> contextCaptor1 = ArgumentCaptor.forClass(Context.class);
@@ -2301,21 +1867,18 @@ public class GraphTest {
 
         final List<Operation> ops = captor.getValue().getOperations();
 
-        JsonAssert.assertEquals(new View.Builder().edge(TestGroups.EDGE_5).edge(TestGroups.EDGE_4).build().toCompactJson(),
+        JsonAssert.assertEquals(
+                new View.Builder().edge(TestGroups.EDGE_5).edge(TestGroups.EDGE_4).build().toCompactJson(),
                 ((GetElements) ops.get(0)).getView().toCompactJson());
     }
 
     @Test
     public void shouldNotAddExtraGroupsFromSchemaViewWithUpdateViewHookWhenInBlacklist() throws OperationException {
         // Given
-        operation = new GetElements.Builder()
-                .build();
+        operation = new GetElements.Builder().build();
 
-        final UpdateViewHook updateViewHook = new UpdateViewHook.Builder()
-                .addExtraGroups(true)
-                .blackListElementGroups(Sets.newHashSet(TestGroups.EDGE_4,
-                        TestGroups.EDGE))
-                .build();
+        final UpdateViewHook updateViewHook = new UpdateViewHook.Builder().addExtraGroups(true)
+                .blackListElementGroups(Sets.newHashSet(TestGroups.EDGE_4, TestGroups.EDGE)).build();
 
         given(opChain.getOperations()).willReturn(Lists.newArrayList(operation));
         given(opChain.shallowClone()).willReturn(clonedOpChain);
@@ -2324,21 +1887,14 @@ public class GraphTest {
 
         final Store store = mock(Store.class);
 
-        given(store.getSchema()).willReturn(new Schema.Builder()
-                .edge(TestGroups.EDGE_4, new SchemaEdgeDefinition())
-                .edge(TestGroups.EDGE_5, new SchemaEdgeDefinition())
-                .edge(TestGroups.EDGE, new SchemaEdgeDefinition())
+        given(store.getSchema()).willReturn(new Schema.Builder().edge(TestGroups.EDGE_4, new SchemaEdgeDefinition())
+                .edge(TestGroups.EDGE_5, new SchemaEdgeDefinition()).edge(TestGroups.EDGE, new SchemaEdgeDefinition())
                 .build());
         given(store.getProperties()).willReturn(new StoreProperties());
 
         final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .addHook(updateViewHook)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .build();
+                .config(new GraphConfig.Builder().graphId(GRAPH_ID).addHook(updateViewHook).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).build();
 
         final ArgumentCaptor<OperationChain> captor = ArgumentCaptor.forClass(OperationChain.class);
         final ArgumentCaptor<Context> contextCaptor1 = ArgumentCaptor.forClass(Context.class);
@@ -2361,20 +1917,13 @@ public class GraphTest {
 
         final Store store = mock(Store.class);
 
-        given(store.getSchema()).willReturn(new Schema.Builder()
-                .entity(TestGroups.ENTITY, new SchemaEntityDefinition())
-                .edge(TestGroups.EDGE, new SchemaEdgeDefinition())
-                .edge(TestGroups.EDGE_2, new SchemaEdgeDefinition())
+        given(store.getSchema()).willReturn(new Schema.Builder().entity(TestGroups.ENTITY, new SchemaEntityDefinition())
+                .edge(TestGroups.EDGE, new SchemaEdgeDefinition()).edge(TestGroups.EDGE_2, new SchemaEdgeDefinition())
                 .build());
         given(store.getProperties()).willReturn(new StoreProperties());
 
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .build();
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).build();
 
         final ArgumentCaptor<Job> jobCaptor = ArgumentCaptor.forClass(Job.class);
         final ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
@@ -2385,11 +1934,12 @@ public class GraphTest {
         graph.executeJob(job, context);
 
         // then
-        final GetAllElements operation = (GetAllElements) ((OperationChain) jobCaptor.getValue().getOperation()).getOperations().get(0);
+        final GetAllElements operation = (GetAllElements) ((OperationChain) jobCaptor.getValue().getOperation())
+                .getOperations().get(0);
 
         assertEquals(new View.Builder().entity(TestGroups.ENTITY, new ViewElementDefinition())
-                .edge(TestGroups.EDGE, new ViewElementDefinition())
-                .edge(TestGroups.EDGE_2, new ViewElementDefinition()).build(), operation.getView());
+                .edge(TestGroups.EDGE, new ViewElementDefinition()).edge(TestGroups.EDGE_2, new ViewElementDefinition())
+                .build(), operation.getView());
     }
 
     @Test
@@ -2400,19 +1950,16 @@ public class GraphTest {
         TestStore.mockStore = mock(Store.class);
         given(TestStore.mockStore.isSupported(NamedOperation.class)).willReturn(true);
         // When
-        final GraphConfig config = new GraphConfig.Builder()
-                .graphId("test")
-                .build();
+        final GraphConfig config = new GraphConfig.Builder().graphId("test").build();
 
-        final Graph graph = new Graph.Builder()
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .storeProperties(storeProperties)
-                .config(config)
-                .build();
+        final Graph graph = new Graph.Builder().addSchemas(StreamUtil.schemas(getClass()))
+                .storeProperties(storeProperties).config(config).build();
 
         // Then
-        assertEquals(Arrays.asList(NamedOperationResolver.class, NamedViewResolver.class, FunctionAuthoriser.class), graph.getGraphHooks());
-        assertEquals(CreateObject.class, ((FunctionAuthoriser) graph.getConfig().getHooks().get(2)).getUnauthorisedFunctions().get(0));
+        assertEquals(Arrays.asList(NamedOperationResolver.class, NamedViewResolver.class, FunctionAuthoriser.class),
+                graph.getGraphHooks());
+        assertEquals(CreateObject.class,
+                ((FunctionAuthoriser) graph.getConfig().getHooks().get(2)).getUnauthorisedFunctions().get(0));
     }
 
     @Test
@@ -2423,124 +1970,94 @@ public class GraphTest {
         TestStore.mockStore = mock(Store.class);
         given(TestStore.mockStore.isSupported(NamedOperation.class)).willReturn(true);
         // When
-        final GraphConfig config = new GraphConfig.Builder()
-                .graphId("test")
-                .addHook(new FunctionAuthoriser(Lists.newArrayList(Identity.class)))
-                .build();
+        final GraphConfig config = new GraphConfig.Builder().graphId("test")
+                .addHook(new FunctionAuthoriser(Lists.newArrayList(Identity.class))).build();
 
-        final Graph graph = new Graph.Builder()
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .storeProperties(storeProperties)
-                .config(config)
-                .build();
+        final Graph graph = new Graph.Builder().addSchemas(StreamUtil.schemas(getClass()))
+                .storeProperties(storeProperties).config(config).build();
 
         // Then
-        assertEquals(Arrays.asList(NamedOperationResolver.class, NamedViewResolver.class, FunctionAuthoriser.class), graph.getGraphHooks());
-        assertEquals(Identity.class, ((FunctionAuthoriser) graph.getConfig().getHooks().get(2)).getUnauthorisedFunctions().get(0));
+        assertEquals(Arrays.asList(NamedOperationResolver.class, NamedViewResolver.class, FunctionAuthoriser.class),
+                graph.getGraphHooks());
+        assertEquals(Identity.class,
+                ((FunctionAuthoriser) graph.getConfig().getHooks().get(2)).getUnauthorisedFunctions().get(0));
     }
-    
+
     @Test
     public void shouldExpandGlobalEdges() {
-    	
+
         final Schema twoEdgesNoEntities = new Schema.Builder()
-                .type(TestTypes.PROP_STRING, new TypeDefinition.Builder()
-                        .clazz(String.class)
-                        .build())
-                .type("vertex", new TypeDefinition.Builder()
-                        .clazz(String.class)
-                        .build())
-                .edge("firstEdge", new SchemaEdgeDefinition.Builder()
-                        .property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
-                        .aggregate(false)
-                        .source("vertex")
-                        .destination("vertex")
-                        .directed(DIRECTED_EITHER)
-                        .build())
-                .edge("secondEdge", new SchemaEdgeDefinition.Builder()
-                        .property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
-                        .aggregate(false)
-                        .source("vertex")
-                        .destination("vertex")
-                        .directed(DIRECTED_EITHER)
-                        .build())
+                .type(TestTypes.PROP_STRING, new TypeDefinition.Builder().clazz(String.class).build())
+                .type("vertex", new TypeDefinition.Builder().clazz(String.class).build())
+                .edge("firstEdge",
+                        new SchemaEdgeDefinition.Builder().property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
+                                .aggregate(false).source("vertex").destination("vertex").directed(DIRECTED_EITHER)
+                                .build())
+                .edge("secondEdge",
+                        new SchemaEdgeDefinition.Builder().property(TestPropertyNames.PROP_1, TestTypes.PROP_STRING)
+                                .aggregate(false).source("vertex").destination("vertex").directed(DIRECTED_EITHER)
+                                .build())
                 .build();
-        
-        
+
         final Store store = mock(Store.class);
         given(store.getSchema()).willReturn(twoEdgesNoEntities);
         given(store.getProperties()).willReturn(mock(StoreProperties.class));
-    	
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .addSchema(twoEdgesNoEntities)
-                .build();
-        
-    	final ElementFilter filter = mock(ElementFilter.class);
+
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(twoEdgesNoEntities).build();
+
+        final ElementFilter filter = mock(ElementFilter.class);
 
         final GlobalViewElementDefinition globalEdgeAggregate = new GlobalViewElementDefinition.Builder()
-        		.postAggregationFilter(filter)
-        		.build();
+                .postAggregationFilter(filter).build();
         final View view = new View.Builder().globalEdges(globalEdgeAggregate).build();
-    	
+
         operation = new GetElements.Builder().view(view).build();
         opChain = new OperationChain.Builder().first(operation).build();
-    	
-    	graph.updateOperationChainView(opChain);
-    	
-    	
-    	assertEquals(1, opChain.getOperations().size());
-    	assertEquals(GetElements.class, opChain.getOperations().get(0).getClass());
-    	final View mergedView = ((GetElements) opChain.getOperations().get(0)).getView();
-    	assertTrue(mergedView.getGlobalEdges() == null || mergedView.getGlobalEdges().size()==0);
-    	assertEquals(2, mergedView.getEdges().size());
-    	for (final Map.Entry<String, ViewElementDefinition> e : mergedView.getEdges().entrySet()) {
-    		assertNotNull(e.getValue().getPostAggregationFilter());
-    	}
-    	
+
+        graph.updateOperationChainView(opChain);
+
+        assertEquals(1, opChain.getOperations().size());
+        assertEquals(GetElements.class, opChain.getOperations().get(0).getClass());
+        final View mergedView = ((GetElements) opChain.getOperations().get(0)).getView();
+        assertTrue(mergedView.getGlobalEdges() == null || mergedView.getGlobalEdges().size() == 0);
+        assertEquals(2, mergedView.getEdges().size());
+        for (final Map.Entry<String, ViewElementDefinition> e : mergedView.getEdges().entrySet()) {
+            assertNotNull(e.getValue().getPostAggregationFilter());
+        }
+
     };
-    
+
     @Test
     public void shouldNotExpandGlobalEdgesWhereNotPresentInSchema() {
         final Schema federatedStoreSchema = new Schema.Builder().build();
-        
-        
+
         final Store store = mock(Store.class);
         given(store.getSchema()).willReturn(federatedStoreSchema);
         given(store.getProperties()).willReturn(mock(StoreProperties.class));
-    	
-        final Graph graph = new Graph.Builder()
-                .config(new GraphConfig.Builder()
-                        .graphId(GRAPH_ID)
-                        .build())
-                .storeProperties(StreamUtil.storeProps(getClass()))
-                .store(store)
-                .addSchema(federatedStoreSchema)
+
+        final Graph graph = new Graph.Builder().config(new GraphConfig.Builder().graphId(GRAPH_ID).build())
+                .storeProperties(StreamUtil.storeProps(getClass())).store(store).addSchema(federatedStoreSchema)
                 .build();
-        
-    	final ElementFilter filter = mock(ElementFilter.class);
+
+        final ElementFilter filter = mock(ElementFilter.class);
 
         final GlobalViewElementDefinition globalEdgeAggregate = new GlobalViewElementDefinition.Builder()
-        		.postAggregationFilter(filter)
-        		.build();
+                .postAggregationFilter(filter).build();
         final View view = new View.Builder().globalEdges(globalEdgeAggregate).build();
-    	
+
         operation = new GetElements.Builder().view(view).build();
         opChain = new OperationChain.Builder().first(operation).build();
-    	
-    	graph.updateOperationChainView(opChain);
-    	
-    	
-    	assertEquals(1, opChain.getOperations().size());
-    	assertEquals(GetElements.class, opChain.getOperations().get(0).getClass());
-    	final View mergedView = ((GetElements) opChain.getOperations().get(0)).getView();
-    	assertEquals(0, mergedView.getEdges().size());
-    	assertEquals(1, mergedView.getGlobalEdges().size());
-    	assertNotNull(mergedView.getGlobalEdges().get(0).getPostAggregationFilter());
-    	
+
+        graph.updateOperationChainView(opChain);
+
+        assertEquals(1, opChain.getOperations().size());
+        assertEquals(GetElements.class, opChain.getOperations().get(0).getClass());
+        final View mergedView = ((GetElements) opChain.getOperations().get(0)).getView();
+        assertEquals(0, mergedView.getEdges().size());
+        assertEquals(1, mergedView.getGlobalEdges().size());
+        assertNotNull(mergedView.getGlobalEdges().get(0).getPostAggregationFilter());
+
     }
 
     public static class TestStoreImpl extends Store {
@@ -2595,7 +2112,8 @@ public class GraphTest {
         }
 
         @Override
-        public <T> T onFailure(final T result, final OperationChain<?> opChain, final Context context, final Exception e) {
+        public <T> T onFailure(final T result, final OperationChain<?> opChain, final Context context,
+                final Exception e) {
             return result;
         }
     }

--- a/store-implementation/federated-store/pom.xml
+++ b/store-implementation/federated-store/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>uk.gov.gchq.gaffer</groupId>
         <artifactId>store-implementation</artifactId>
-        <version>1.13.4</version>
+        <version>1.13.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>federated-store</artifactId>

--- a/store-implementation/federated-store/pom.xml
+++ b/store-implementation/federated-store/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>uk.gov.gchq.gaffer</groupId>
         <artifactId>store-implementation</artifactId>
-        <version>1.13.5-SNAPSHOT</version>
+        <version>1.13.4</version>
     </parent>
 
     <artifactId>federated-store</artifactId>

--- a/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/operation/handler/impl/FederatedOperationChainHandlerTest.java
+++ b/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/operation/handler/impl/FederatedOperationChainHandlerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import uk.gov.gchq.gaffer.accumulostore.AccumuloProperties;
 import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
 import uk.gov.gchq.gaffer.commonutil.StreamUtil;
 import uk.gov.gchq.gaffer.commonutil.TestGroups;
@@ -56,11 +57,17 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreConstants.KEY_OPERATION_OPTIONS_GRAPH_IDS;
+import static uk.gov.gchq.gaffer.store.TestTypes.DIRECTED_EITHER;
 
 public class FederatedOperationChainHandlerTest {
 
+    private static Class currentClass = new Object() {
+    }.getClass().getEnclosingClass();
+
     public static final String GRAPH_IDS = PredefinedFederatedStore.ACCUMULO_GRAPH_WITH_ENTITIES + "," + PredefinedFederatedStore.ACCUMULO_GRAPH_WITH_EDGES;
-    private Element[] elements = new Element[]{
+    private static final AccumuloProperties PROPERTIES = AccumuloProperties.loadStoreProperties(StreamUtil.openStream(currentClass, "properties/accumuloStore.properties"));
+
+    private Element[] elements = new Element[] {
             new Entity.Builder()
                     .group(TestGroups.ENTITY)
                     .vertex("1")
@@ -73,7 +80,7 @@ public class FederatedOperationChainHandlerTest {
                     .build()
     };
 
-    private Element[] elements2 = new Element[]{
+    private Element[] elements2 = new Element[] {
             new Entity.Builder()
                     .group(TestGroups.ENTITY)
                     .vertex("2")
@@ -99,14 +106,13 @@ public class FederatedOperationChainHandlerTest {
         final FederatedStore store = createStore();
         final Context context = new Context();
 
-        final OperationChain<Iterable<? extends Element>> opChain =
-                new OperationChain.Builder()
-                        .first(new GetAllElements.Builder()
-                                // Ensure the elements are returned form the graphs in the right order
-                                .option(KEY_OPERATION_OPTIONS_GRAPH_IDS, GRAPH_IDS)
-                                .build())
-                        .then(new Limit<>(1))
-                        .build();
+        final OperationChain<Iterable<? extends Element>> opChain = new OperationChain.Builder()
+                .first(new GetAllElements.Builder()
+                        // Ensure the elements are returned form the graphs in the right order
+                        .option(KEY_OPERATION_OPTIONS_GRAPH_IDS, GRAPH_IDS)
+                        .build())
+                .then(new Limit<>(1))
+                .build();
 
         // When
         final Iterable result = store.execute(opChain, context);
@@ -143,7 +149,6 @@ public class FederatedOperationChainHandlerTest {
         final FederatedStore store = createStore();
         final Context context = new Context();
 
-
         final FederatedOperationChain<Object, Void> opChain = new FederatedOperationChain.Builder<Object, Void>()
                 .operationChain(
                         new OperationChain.Builder()
@@ -168,7 +173,6 @@ public class FederatedOperationChainHandlerTest {
         // Given
         final FederatedStore store = createStore();
         final Context context = new Context();
-
 
         final FederatedOperationChain<Void, Long> opChain = new FederatedOperationChain.Builder<Void, Long>()
                 .operationChain(
@@ -232,6 +236,15 @@ public class FederatedOperationChainHandlerTest {
         ElementUtil.assertElementEquals(Collections.singletonList(elements[0]), result);
     }
 
+    private SchemaEdgeDefinition getProp(final String propName) {
+        return new SchemaEdgeDefinition.Builder()
+                .source("string")
+                .destination("string")
+                .directed(DIRECTED_EITHER)
+                .property(propName, "string")
+                .build();
+    }
+
     private FederatedStore createStore() throws OperationException {
         final Schema schema = new Schema.Builder()
                 .entity(TestGroups.ENTITY, new SchemaEntityDefinition.Builder()
@@ -252,7 +265,8 @@ public class FederatedOperationChainHandlerTest {
                         .validateFunctions(new IsTrue())
                         .build())
                 .build();
-        final FederatedStore store = (FederatedStore) Store.createStore("federatedGraph", schema, StoreProperties.loadStoreProperties(StreamUtil.openStream(FederatedStoreITs.class, "predefinedFederatedStore.properties")));
+        final FederatedStore store = (FederatedStore) Store.createStore("federatedGraph", schema,
+                StoreProperties.loadStoreProperties(StreamUtil.openStream(FederatedStoreITs.class, "predefinedFederatedStore.properties")));
 
         final Context context = new Context();
 
@@ -262,4 +276,5 @@ public class FederatedOperationChainHandlerTest {
 
         return store;
     }
+
 }


### PR DESCRIPTION
Resolves #2293 

Only expand Global* elements in a View if the schema contains an entry with that element type in.  This supports stores such as the FederatedStore where the first Store a query gets run against is in some way a proxy of some other store(s) and doesn't have the schema information to do the expansion.

Also, update the logic in updateOperationChain such that it no longer expands  a View with no entities and edges but, e.g., a globalEntities element to include all of the edges.

When reviewing, please note that I've chosen to change updateOperationChain to default scope for testing purposes and because the code didn't feel like it was perfectly encapsulated by the logic of executing a query.  Alternatively, I could change the tests to run against the public execute method (which felt a bit broad) or use reflection to test the method as a private (but I'm not sure how you feel about that 'round these parts).  Lastly, where there's identical logic for Edges and Entities, I've only included a unit for the edges part, but let me know if you want a repeated unit test for the Entities logic