### PR TITLE
gh-2284 Add dynamic message to log after road-traffic example starts.

### DIFF
--- a/example/basic/basic-rest/pom.xml
+++ b/example/basic/basic-rest/pom.xml
@@ -121,6 +121,9 @@
                                 <gaffer.rest-api.basePath>
                                     ${standalone-path}
                                 </gaffer.rest-api.basePath>
+                                <gaffer.rest-api.port>
+                                    ${standalone-port}
+                                </gaffer.rest-api.port>
                                 <gaffer.graph.config>
                                     ${project.build.outputDirectory}/graphConfig.json
                                 </gaffer.graph.config>

--- a/example/road-traffic/road-traffic-demo/pom.xml
+++ b/example/road-traffic/road-traffic-demo/pom.xml
@@ -117,6 +117,9 @@
                                 <gaffer.rest-api.basePath>
                                     ${standalone-path}
                                 </gaffer.rest-api.basePath>
+                                <gaffer.rest-api.port>
+                                    ${standalone-port}
+                                </gaffer.rest-api.port>
                                 <gaffer.graph.config>
                                     ${project.build.outputDirectory}/graphConfig.json
                                 </gaffer.graph.config>

--- a/example/road-traffic/road-traffic-rest/src/main/java/uk/gov/gchq/gaffer/traffic/listeners/ConsoleBanner.java
+++ b/example/road-traffic/road-traffic-rest/src/main/java/uk/gov/gchq/gaffer/traffic/listeners/ConsoleBanner.java
@@ -1,7 +1,24 @@
+/*
+ * Copyright 2016-2021 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.gchq.gaffer.traffic.listeners;
 
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
+
 import java.util.logging.Logger;
 
 /**

--- a/example/road-traffic/road-traffic-rest/src/main/java/uk/gov/gchq/gaffer/traffic/listeners/ConsoleBanner.java
+++ b/example/road-traffic/road-traffic-rest/src/main/java/uk/gov/gchq/gaffer/traffic/listeners/ConsoleBanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 Crown Copyright
+ * Copyright 2021 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/example/road-traffic/road-traffic-rest/src/main/java/uk/gov/gchq/gaffer/traffic/listeners/ConsoleBanner.java
+++ b/example/road-traffic/road-traffic-rest/src/main/java/uk/gov/gchq/gaffer/traffic/listeners/ConsoleBanner.java
@@ -1,0 +1,26 @@
+package uk.gov.gchq.gaffer.traffic.listeners;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import java.util.logging.Logger;
+
+/**
+ * A {@link ServletContextListener}  to write a message to the logger once the application is ready.
+ */
+public class ConsoleBanner implements ServletContextListener {
+
+    private static final Logger LOGGER = Logger.getLogger(ConsoleBanner.class.getName());
+
+    @Override
+    public void contextInitialized(final ServletContextEvent servletContextEvent) {
+        final String port = System.getProperty("gaffer.rest-api.port", "8080");
+        final String path = System.getProperty("gaffer.rest-api.basePath", "rest");
+
+        LOGGER.info(String.format("Gaffer road-traffic example is ready at: http:/localhost:%s/%s", port, path));
+    }
+
+    @Override
+    public void contextDestroyed(final ServletContextEvent servletContextEvent) {
+        // Empty
+    }
+}

--- a/example/road-traffic/road-traffic-rest/src/main/resources/log4j.xml
+++ b/example/road-traffic/road-traffic-rest/src/main/resources/log4j.xml
@@ -44,6 +44,10 @@
         <level value="ERROR"/>
     </logger>
 
+    <logger name="swagger.jackson">
+        <level value="INFO"/>
+    </logger>
+
     <root>
         <priority value="info"/>
         <appender-ref ref="console"/>

--- a/example/road-traffic/road-traffic-rest/src/main/webapp/WEB-INF/web.xml
+++ b/example/road-traffic/road-traffic-rest/src/main/webapp/WEB-INF/web.xml
@@ -6,9 +6,9 @@
     <display-name>Road Traffic Rest Api</display-name>
 
     <listener>
-        <listener-class>uk.gov.gchq.gaffer.traffic.listeners.DataLoader
-        </listener-class>
+        <listener-class>uk.gov.gchq.gaffer.traffic.listeners.DataLoader</listener-class>
         <listener-class>uk.gov.gchq.gaffer.rest.ServletLifecycleListener</listener-class>
+        <listener-class>uk.gov.gchq.gaffer.traffic.listeners.ConsoleBanner</listener-class>
     </listener>
 
     <!-- Copied from Gaffer rest api web.xml-->


### PR DESCRIPTION
- Added listener which writes a message to the console once the application is ready
- Exposed the port as a system property so that a valid hyperlink can be included in the log message
- Suppressed some debug messages from Swagger to make it easier to see the "ready" message