### PR TITLE
gh-2205 Reverted test cases to use INPUT_CAMEL_CASE constant.

### DIFF
--- a/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/IfIT.java
+++ b/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/IfIT.java
@@ -76,16 +76,16 @@ public class IfIT extends AbstractStoreIT {
     public void shouldReturnOriginalInputWhenConditionIsFalseAndNoOtherwise() throws OperationException {
         // Given
         final If<Object, Object> ifOperation = new If<>();
-        ifOperation.setInput(404); //This test input has been changed to an integer to avoid triggering a bug JSONSerialisation.
-        ifOperation.setConditional(new Conditional(new IsA("java.lang.String")));
+        ifOperation.setInput(INPUT_CAMEL_CASE);
+        ifOperation.setConditional(new Conditional(new IsA("java.lang.Integer")));
         ifOperation.setThen(new Map<>(Lists.newArrayList(new ToLong(), new ToList())));
 
         // When
         final Object output = graph.execute(ifOperation, getUser());
 
         // Then
-        assertEquals(404, output);
-        assertTrue(output instanceof Integer);
+        assertEquals(INPUT_CAMEL_CASE, output);
+        assertTrue(output instanceof String);
     }
 
     @Test
@@ -108,15 +108,15 @@ public class IfIT extends AbstractStoreIT {
     public void shouldReturnOriginalInputWhenConditionIsTrueAndNoThen() throws OperationException {
         // Given
         final If<Object, Object> ifOperation = new If<>();
-        ifOperation.setInput(404); //This test input has been changed to an integer to avoid triggering a bug JSONSerialisation.
-        ifOperation.setConditional(new Conditional(new IsA("java.lang.Integer")));
+        ifOperation.setInput(INPUT_CAMEL_CASE);
+        ifOperation.setConditional(new Conditional(new IsA("java.lang.String")));
         ifOperation.setOtherwise(new Map<>(Lists.newArrayList(new ToLong(), new ToList())));
 
         // When
         final Object output = graph.execute(ifOperation, getUser());
 
         // Then
-        assertEquals(404, output);
-        assertTrue(output instanceof Integer);
+        assertEquals(INPUT_CAMEL_CASE, output);
+        assertTrue(output instanceof String);
     }
 }


### PR DESCRIPTION
I've reverted the test cases associated with this issue and have seen all of the relevant tests pass locally, so perhaps this JSON serialisation issue has been resolved since this issue was opened?

I've opened this PR to push the change through all of the CI tests, I'll have a closer look at any specific test failures that come up.