### PR TITLE
gh-2463 Added version number to spring boot maven plugin

### DIFF
--- a/rest-api/spring-rest/pom.xml
+++ b/rest-api/spring-rest/pom.xml
@@ -135,6 +135,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring.boot.version}</version>
         <configuration>
           <layout>ZIP</layout>
           <executable>true</executable>


### PR DESCRIPTION
The spring boot maven plugin did not have a version set.

https://github.com/gchq/Gaffer/blob/b22d7a7ab1974399edad87f6f7962b2aa5b6f4f6/rest-api/spring-rest/pom.xml#L135-L138

This had been causing unnoticed build warnings about build stability: 
```
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for uk.gov.gchq.gaffer:spring-rest:jar:1.17.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. @ line 135, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] ------------------------------------------------------------------------
```

This explains why builds used to work but stopped working: maven was using the latest release of the plugin as the version was not specified and at some point the latest version became incompatible with our code. This has been fixed by specifying the version to the same as the other use of the plugin and other spring dependencies: `<version>${spring.boot.version}</version>`


# Related Issue

- Resolve #2463