### PR TITLE
Added hotfix check that skips merge develop

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,7 @@ jobs:
         git config user.email github-actions@github.com
 
     - name: Merge develop into master
+      if: ${{ ! contains(github.event.milestone.description, 'hotfix') }}
       run: |
         git remote set-branches --add origin develop
         git pull
@@ -162,14 +163,6 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.m2/repository
-          !~/.m2/repository/uk
-        key: gaffer-dependencies
 
     - name: Checkout master
       uses: actions/checkout@v2

--- a/.github/workflows/release_standalone.yaml
+++ b/.github/workflows/release_standalone.yaml
@@ -11,14 +11,6 @@ jobs:
       with:
         java-version: 1.8
 
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.m2/repository
-          !~/.m2/repository/uk
-        key: gaffer-dependencies
-
     - name: Checkout Branch
       uses: actions/checkout@v2
 


### PR DESCRIPTION
Also removed use of `.m2/repository` cache as it is unused in a release

# Related Issue

- Resolve #2468