### PR TITLE
gh-2476 Stop defaulting access roles to empty arrays. 

### DIFF
--- a/core/graph/src/test/java/uk/gov/gchq/gaffer/integration/operation/named/cache/NamedOperationCacheIT.java
+++ b/core/graph/src/test/java/uk/gov/gchq/gaffer/integration/operation/named/cache/NamedOperationCacheIT.java
@@ -130,8 +130,6 @@ public class NamedOperationCacheIT {
                 .operationName(add.getOperationName())
                 .operationChain(add.getOperationChainAsString())
                 .creatorId(user.getUserId())
-                .readers(new ArrayList<>())
-                .writers(new ArrayList<>())
                 .description(add.getDescription())
                 .score(0)
                 .parameters(null)
@@ -197,8 +195,6 @@ public class NamedOperationCacheIT {
                 .operationChain(update.getOperationChainAsString())
                 .description(update.getDescription())
                 .creatorId(user.getUserId())
-                .readers(new ArrayList<>())
-                .writers(new ArrayList<>())
                 .score(0)
                 .parameters(null)
                 .build();
@@ -237,8 +233,6 @@ public class NamedOperationCacheIT {
                 .operationChain(update.getOperationChainAsString())
                 .description(update.getDescription())
                 .creatorId(user.getUserId())
-                .readers(new ArrayList<>())
-                .writers(new ArrayList<>())
                 .score(0)
                 .parameters(null)
                 .build();
@@ -259,8 +253,6 @@ public class NamedOperationCacheIT {
                 .operationChain(add.getOperationChainAsString())
                 .description(add.getDescription())
                 .creatorId(authorisedUser.getUserId())
-                .readers(new ArrayList<>())
-                .writers(new ArrayList<>())
                 .score(0)
                 .parameters(null)
                 .build();
@@ -301,8 +293,6 @@ public class NamedOperationCacheIT {
                 .operationChain(update.getOperationChainAsString())
                 .description(update.getDescription())
                 .creatorId(adminAuthUser.getUserId())
-                .readers(new ArrayList<>())
-                .writers(new ArrayList<>())
                 .score(0)
                 .parameters(null)
                 .build();

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/AddNamedOperation.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/AddNamedOperation.java
@@ -52,7 +52,7 @@ import static java.util.Objects.nonNull;
  * A {@code AddNamedOperation} is an {@link Operation} for creating a new {@link NamedOperation}
  * and adding it to a Gaffer graph.
  */
-@JsonPropertyOrder(value = {"class", "operationName", "description", "score", "labels", "operationChain", "input", "overwriteFlag", "parameters", "readAccessRoles", "writeAccessRoles", "readAccessPredicate", "writeAccessPredicate"}, alphabetic = true)
+@JsonPropertyOrder(value = {"class", "operationName", "description", "score", "operations"}, alphabetic = true)
 @Since("1.0.0")
 @Summary("Adds a new named operation")
 public class AddNamedOperation implements Operation, Operations<Operation> {
@@ -174,8 +174,8 @@ public class AddNamedOperation implements Operation, Operations<Operation> {
                 .name(operationName)
                 .labels(labels)
                 .description(description)
-                .readAccessRoles(readAccessRoles == null ? null : readAccessRoles.toArray(new String[readAccessRoles.size()]))
-                .writeAccessRoles(writeAccessRoles == null ? null : writeAccessRoles.toArray(new String[writeAccessRoles.size()]))
+                .readAccessRoles(isNull(readAccessRoles) ? null : readAccessRoles.toArray(new String[readAccessRoles.size()]))
+                .writeAccessRoles(isNull(writeAccessRoles) ? null : writeAccessRoles.toArray(new String[writeAccessRoles.size()]))
                 .overwrite(overwriteFlag)
                 .parameters(parameters)
                 .options(options)
@@ -236,7 +236,7 @@ public class AddNamedOperation implements Operation, Operations<Operation> {
     private Collection<Operation> getOperationsWithDefaultParams() {
         String opStringWithDefaults = operations;
 
-        if (null != parameters) {
+        if (nonNull(parameters)) {
             for (final Map.Entry<String, ParameterDetail> parameterDetailPair : parameters.entrySet()) {
                 String paramKey = parameterDetailPair.getKey();
 
@@ -302,9 +302,9 @@ public class AddNamedOperation implements Operation, Operations<Operation> {
         }
 
         public Builder readAccessRoles(final String... roles) {
-            if (null == roles) {
+            if (isNull(roles)) {
                 _getOp().setReadAccessRoles(null);
-            } else if (null == _getOp().getReadAccessRoles()) {
+            } else if (isNull(_getOp().getReadAccessRoles())) {
                 _getOp().setReadAccessRoles(Arrays.asList(roles));
             } else {
                 Collections.addAll(_getOp().getReadAccessRoles(), roles);
@@ -313,9 +313,9 @@ public class AddNamedOperation implements Operation, Operations<Operation> {
         }
 
         public Builder writeAccessRoles(final String... roles) {
-            if (null == roles) {
+            if (isNull(roles)) {
                 _getOp().setWriteAccessRoles(null);
-            } else if (null == _getOp().getWriteAccessRoles()) {
+            } else if (isNull(_getOp().getWriteAccessRoles())) {
                 _getOp().setWriteAccessRoles(Arrays.asList(roles));
             } else {
                 Collections.addAll(_getOp().getWriteAccessRoles(), roles);

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/AddNamedOperation.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/AddNamedOperation.java
@@ -38,6 +38,7 @@ import uk.gov.gchq.koryphe.Summary;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -51,7 +52,7 @@ import static java.util.Objects.nonNull;
  * A {@code AddNamedOperation} is an {@link Operation} for creating a new {@link NamedOperation}
  * and adding it to a Gaffer graph.
  */
-@JsonPropertyOrder(value = {"class", "operationName", "description", "score", "operations"}, alphabetic = true)
+@JsonPropertyOrder(value = {"class", "operationName", "description", "score", "labels", "operationChain", "input", "overwriteFlag", "parameters", "readAccessRoles", "writeAccessRoles", "readAccessPredicate", "writeAccessPredicate"}, alphabetic = true)
 @Since("1.0.0")
 @Summary("Adds a new named operation")
 public class AddNamedOperation implements Operation, Operations<Operation> {
@@ -61,8 +62,8 @@ public class AddNamedOperation implements Operation, Operations<Operation> {
     private String operationName;
     private List<String> labels;
     private String description;
-    private List<String> readAccessRoles = new ArrayList<>();
-    private List<String> writeAccessRoles = new ArrayList<>();
+    private List<String> readAccessRoles;
+    private List<String> writeAccessRoles;
     private boolean overwriteFlag = false;
     private Map<String, ParameterDetail> parameters;
     private Map<String, String> options;
@@ -173,8 +174,8 @@ public class AddNamedOperation implements Operation, Operations<Operation> {
                 .name(operationName)
                 .labels(labels)
                 .description(description)
-                .readAccessRoles(readAccessRoles.toArray(new String[readAccessRoles.size()]))
-                .writeAccessRoles(writeAccessRoles.toArray(new String[writeAccessRoles.size()]))
+                .readAccessRoles(readAccessRoles == null ? null : readAccessRoles.toArray(new String[readAccessRoles.size()]))
+                .writeAccessRoles(writeAccessRoles == null ? null : writeAccessRoles.toArray(new String[writeAccessRoles.size()]))
                 .overwrite(overwriteFlag)
                 .parameters(parameters)
                 .options(options)
@@ -301,12 +302,24 @@ public class AddNamedOperation implements Operation, Operations<Operation> {
         }
 
         public Builder readAccessRoles(final String... roles) {
-            Collections.addAll(_getOp().getReadAccessRoles(), roles);
+            if (null == roles) {
+                _getOp().setReadAccessRoles(null);
+            } else if (null == _getOp().getReadAccessRoles()) {
+                _getOp().setReadAccessRoles(Arrays.asList(roles));
+            } else {
+                Collections.addAll(_getOp().getReadAccessRoles(), roles);
+            }
             return _self();
         }
 
         public Builder writeAccessRoles(final String... roles) {
-            Collections.addAll(_getOp().getWriteAccessRoles(), roles);
+            if (null == roles) {
+                _getOp().setWriteAccessRoles(null);
+            } else if (null == _getOp().getWriteAccessRoles()) {
+                _getOp().setWriteAccessRoles(Arrays.asList(roles));
+            } else {
+                Collections.addAll(_getOp().getWriteAccessRoles(), roles);
+            }
             return _self();
         }
 

--- a/core/operation/src/test/java/uk/gov/gchq/gaffer/named/operation/AddNamedOperationTest.java
+++ b/core/operation/src/test/java/uk/gov/gchq/gaffer/named/operation/AddNamedOperationTest.java
@@ -46,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
@@ -55,6 +56,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
     private static final AccessPredicate READ_ACCESS_PREDICATE = new AccessPredicate(new CustomUserPredicate());
     private static final AccessPredicate WRITE_ACCESS_PREDICATE = new AccessPredicate(new CustomUserPredicate());
 
+    @Test
     @Override
     public void shouldJsonSerialiseAndDeserialise() {
         //Given
@@ -94,20 +96,16 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
                 " \"readAccessRoles\" : [ \"User\" ],%n" +
                 " \"writeAccessRoles\" : [ \"User\" ],%n" +
                 " \"readAccessPredicate\" : {%n" +
-                "    \"class\" : \"uk.gov.gchq.gaffer.access.predicate.CustomAccessPredicate\",%n" +
-                "    \"userId\" : \"CreatingUserId\",%n" +
-                "    \"map\" : {%n" +
-                "        \"ReadKey\": \"ReadValue\"%n" +
-                "    },%n" +
-                "    \"auths\" : [ \"CustomReadAuth1\", \"CustomReadAuth2\" ]%n" +
+                "    \"class\" : \"uk.gov.gchq.gaffer.access.predicate.AccessPredicate\",%n" +
+                "    \"userPredicate\" : {%n" +
+                "       \"class\" : \"uk.gov.gchq.gaffer.access.predicate.user.CustomUserPredicate\"%n" +
+                "    }%n" +
                 "},%n" +
                 "\"writeAccessPredicate\" : {%n" +
-                "    \"class\" : \"uk.gov.gchq.gaffer.access.predicate.CustomAccessPredicate\",%n" +
-                "    \"userId\" : \"CreatingUserId\",%n" +
-                "    \"map\" : {%n" +
-                "        \"WriteKey\": \"WriteValue\"%n" +
-                "    },%n" +
-                "    \"auths\" : [ \"CustomWriteAuth1\", \"CustomWriteAuth2\" ]%n" +
+                "    \"class\" : \"uk.gov.gchq.gaffer.access.predicate.AccessPredicate\",%n" +
+                "    \"userPredicate\" : {%n" +
+                "       \"class\" : \"uk.gov.gchq.gaffer.access.predicate.user.CustomUserPredicate\"%n" +
+                "    }%n" +
                 "}%n" +
                 "}"), new String(json));
         assertNotNull(deserialisedObj);
@@ -152,6 +150,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
         assertNotNull(deserialisedObj);
     }
 
+    @Test
     @Override
     public void builderShouldCreatePopulatedOperation() {
         AddNamedOperation addNamedOperation = new AddNamedOperation.Builder()
@@ -181,6 +180,7 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
         assertEquals(WRITE_ACCESS_PREDICATE, addNamedOperation.getWriteAccessPredicate());
     }
 
+    @Test
     @Override
     public void shouldShallowCloneOperation() {
         // Given
@@ -225,6 +225,23 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
         assertNotNull(clone.getParameters().get("optionTestParameter").getOptions());
         assertEquals(READ_ACCESS_PREDICATE, clone.getReadAccessPredicate());
         assertEquals(WRITE_ACCESS_PREDICATE, clone.getWriteAccessPredicate());
+    }
+
+    @Test
+    public void shouldShallowCloneOperationWithNoAccessRoles() {
+        // Given
+        AddNamedOperation addNamedOperation = new AddNamedOperation.Builder()
+                .operationChain(OPERATION_CHAIN)
+                .description("Test Named Operation")
+                .name("Test")
+                .build();
+
+        // When
+        AddNamedOperation clone = addNamedOperation.shallowClone();
+
+        // Then
+        assertNull(clone.getReadAccessRoles());
+        assertNull(clone.getWriteAccessRoles());
     }
 
     @Test
@@ -300,5 +317,19 @@ public class AddNamedOperationTest extends OperationTest<AddNamedOperation> {
     @Override
     protected Set<String> getRequiredFields() {
         return Sets.newHashSet("operations");
+    }
+
+    @Test
+    public void shouldNotDefaultAnyAccessControlConfiguration() {
+        final AddNamedOperation addNamedOperation = new AddNamedOperation.Builder()
+                .operationChain("{\"operations\":[{\"class\": \"uk.gov.gchq.gaffer.operation.impl.get.GetAdjacentIds\", \"input\": [{\"vertex\": \"${testParameter}\", \"class\": \"uk.gov.gchq.gaffer.operation.data.EntitySeed\"}]}]}")
+                .description("Test Named Operation")
+                .name("Test")
+                .build();
+
+        assertNull(addNamedOperation.getReadAccessRoles());
+        assertNull(addNamedOperation.getWriteAccessRoles());
+        assertNull(addNamedOperation.getReadAccessPredicate());
+        assertNull(addNamedOperation.getWriteAccessPredicate());
     }
 }

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/named/GetAllNamedOperationsHandlerTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/named/GetAllNamedOperationsHandlerTest.java
@@ -32,7 +32,6 @@ import uk.gov.gchq.gaffer.store.StoreProperties;
 import uk.gov.gchq.gaffer.store.operation.handler.named.cache.NamedOperationCache;
 import uk.gov.gchq.gaffer.user.User;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,8 +52,6 @@ public class GetAllNamedOperationsHandlerTest {
             .inputType("uk.gov.gchq.gaffer.data.element.Element[]")
             .creatorId(User.UNKNOWN_USER_ID)
             .operationChain("{\"operations\":[{\"class\":\"uk.gov.gchq.gaffer.operation.impl.add.AddElements\",\"skipInvalidElements\":false,\"validate\":true}]}")
-            .readers(new ArrayList<>())
-            .writers(new ArrayList<>())
             .parameters(null)
             .build();
 
@@ -63,8 +60,6 @@ public class GetAllNamedOperationsHandlerTest {
             .inputType(null)
             .creatorId(User.UNKNOWN_USER_ID)
             .operationChain("{\"operations\":[{\"class\":\"uk.gov.gchq.gaffer.store.operation.GetSchema\",\"compact\":false}]}")
-            .readers(new ArrayList<>())
-            .writers(new ArrayList<>())
             .parameters(null)
             .build();
 

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/impl/OperationServiceIT.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/impl/OperationServiceIT.java
@@ -77,8 +77,6 @@ public abstract class OperationServiceIT extends AbstractRestApiIT {
                 .operationChain("{\"operations\":[{\"class\":\"uk.gov.gchq.gaffer.operation.impl.add.AddElements\",\"skipInvalidElements\":false,\"validate\":true}]}")
                 .inputType("uk.gov.gchq.gaffer.data.element.Element[]")
                 .creatorId("UNKNOWN")
-                .readers(Arrays.asList())
-                .writers(Arrays.asList())
                 .parameters(null)
                 .build();
 


### PR DESCRIPTION
Read and Write access role properties are mutually exclusive with read and write AccessPredicate properties.
Also added some @Test annotations (see #2452) and corrected the tests which were broken and now executing again.