### PR TITLE
gh-2499: Upgraded miscellaneous tests to JUnit 5

### DIFF
--- a/core/data/src/test/java/uk/gov/gchq/gaffer/integration/ViewIT.java
+++ b/core/data/src/test/java/uk/gov/gchq/gaffer/integration/ViewIT.java
@@ -16,7 +16,7 @@
 
 package uk.gov.gchq.gaffer.integration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.commonutil.StreamUtil;
 import uk.gov.gchq.gaffer.data.elementdefinition.view.View;

--- a/core/graph/src/test/java/uk/gov/gchq/gaffer/integration/graph/GraphIT.java
+++ b/core/graph/src/test/java/uk/gov/gchq/gaffer/integration/graph/GraphIT.java
@@ -16,7 +16,7 @@
 
 package uk.gov.gchq.gaffer.integration.graph;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.commonutil.StreamUtil;
 import uk.gov.gchq.gaffer.graph.Graph;

--- a/core/graph/src/test/java/uk/gov/gchq/gaffer/integration/graph/SchemaHidingIT.java
+++ b/core/graph/src/test/java/uk/gov/gchq/gaffer/integration/graph/SchemaHidingIT.java
@@ -16,9 +16,9 @@
 package uk.gov.gchq.gaffer.integration.graph;
 
 import com.google.common.collect.Sets;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.commonutil.StreamUtil;
 import uk.gov.gchq.gaffer.commonutil.TestGroups;
@@ -55,7 +55,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Integration tests to check that an store can be configured with a schema
+ * Integration tests to check that a store can be configured with a schema
  * containing groups 1 and 2. Then a new Graph can be constructed with a limited
  * schema, perhaps just containing group 1. The graph should then just
  * completely hide group 2 and never read any group 2 data from the store.
@@ -78,12 +78,12 @@ public abstract class SchemaHidingIT {
         this.storeProperties = storeProperties;
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         cleanUp();
     }
 
-    @After
+    @AfterEach
     public void after() {
         cleanUp();
     }

--- a/core/graph/src/test/java/uk/gov/gchq/gaffer/integration/operation/named/cache/NamedOperationCacheIT.java
+++ b/core/graph/src/test/java/uk/gov/gchq/gaffer/integration/operation/named/cache/NamedOperationCacheIT.java
@@ -17,9 +17,9 @@
 package uk.gov.gchq.gaffer.integration.operation.named.cache;
 
 import com.google.common.collect.Lists;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
 import uk.gov.gchq.gaffer.cache.exception.CacheOperationException;
@@ -77,14 +77,14 @@ public class NamedOperationCacheIT {
     private DeleteNamedOperationHandler deleteNamedOperationHandler = new DeleteNamedOperationHandler();
     private GetAllNamedOperations get = new GetAllNamedOperations();
 
-    @Before
+    @BeforeEach
     public void before() throws CacheOperationException {
         cacheProps.clear();
         properties.setAdminAuth(adminAuth);
         given(store.getProperties()).willReturn(properties);
     }
 
-    @After
+    @AfterEach
     public void after() throws CacheOperationException {
         CacheServiceLoader.getService().clearCache(CACHE_NAME);
     }

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/named/cache/NamedViewCacheBackwardCompatibilityTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/named/cache/NamedViewCacheBackwardCompatibilityTest.java
@@ -16,8 +16,8 @@
 
 package uk.gov.gchq.gaffer.store.operation.handler.named.cache;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
 import uk.gov.gchq.gaffer.cache.impl.JcsCacheService;
@@ -36,7 +36,7 @@ public class NamedViewCacheBackwardCompatibilityTest {
     private static final User ADDING_USER = new User("user1");
     private static final String VIEW_NAME = "TestView";
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         final Properties properties = new Properties();
         properties.setProperty(CacheProperties.CACHE_SERVICE_CLASS, JcsCacheService.class.getName());

--- a/library/flink-library/src/test/java/uk/gov/gchq/gaffer/flink/integration/operation/handler/AddElementsFromFileHandlerIT.java
+++ b/library/flink-library/src/test/java/uk/gov/gchq/gaffer/flink/integration/operation/handler/AddElementsFromFileHandlerIT.java
@@ -17,12 +17,9 @@
 package uk.gov.gchq.gaffer.flink.integration.operation.handler;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import uk.gov.gchq.gaffer.commonutil.CommonTestConstants;
 import uk.gov.gchq.gaffer.flink.operation.FlinkTest;
 import uk.gov.gchq.gaffer.flink.operation.TestFileOutput;
 import uk.gov.gchq.gaffer.flink.operation.handler.AddElementsFromFileHandler;
@@ -36,18 +33,20 @@ import uk.gov.gchq.gaffer.user.User;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 public class AddElementsFromFileHandlerIT extends FlinkTest {
-
-    @Rule
-    public final TemporaryFolder testFolder = new TemporaryFolder(CommonTestConstants.TMP_DIRECTORY);
     private File file;
     private TestFileOutput testFileOutput;
 
-    @Before
+    @BeforeEach
     public void before() throws IOException {
-        file = testFolder.newFile("inputFile.txt");
-        FileUtils.write(file, DATA);
+        String filename = "inputFile.txt";
+        file = new File(testFolder.getAbsolutePath(), filename);
+        file.delete();
+        file.createNewFile();
+
+        FileUtils.write(file, DATA, StandardCharsets.UTF_8);
         MapStore.resetStaticMap();
         testFileOutput = createTestFileOutput();
     }
@@ -81,7 +80,7 @@ public class AddElementsFromFileHandlerIT extends FlinkTest {
         return store;
     }
 
-    private TestFileOutput createTestFileOutput() throws IOException {
-        return new TestFileOutput(testFolder.newFolder("testFileOutput").toPath().toString());
+    protected TestFileOutput createTestFileOutput() throws IOException {
+        return new TestFileOutput(createTemporaryDirectory("testFileOutput").toPath().toString());
     }
 }

--- a/library/flink-library/src/test/java/uk/gov/gchq/gaffer/flink/integration/operation/handler/AddElementsFromFileHandlerIT.java
+++ b/library/flink-library/src/test/java/uk/gov/gchq/gaffer/flink/integration/operation/handler/AddElementsFromFileHandlerIT.java
@@ -80,7 +80,7 @@ public class AddElementsFromFileHandlerIT extends FlinkTest {
         return store;
     }
 
-    protected TestFileOutput createTestFileOutput() throws IOException {
+    private TestFileOutput createTestFileOutput() throws IOException {
         return new TestFileOutput(createTemporaryDirectory("testFileOutput").toPath().toString());
     }
 }

--- a/library/flink-library/src/test/java/uk/gov/gchq/gaffer/flink/integration/operation/handler/AddElementsFromSocketHandlerIT.java
+++ b/library/flink-library/src/test/java/uk/gov/gchq/gaffer/flink/integration/operation/handler/AddElementsFromSocketHandlerIT.java
@@ -16,8 +16,8 @@
 
 package uk.gov.gchq.gaffer.flink.integration.operation.handler;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.flink.operation.FlinkTest;
 import uk.gov.gchq.gaffer.flink.operation.TestFileSink;
@@ -40,7 +40,7 @@ public class AddElementsFromSocketHandlerIT extends FlinkTest {
 
     private TestFileSink testFileSink;
 
-    @Before
+    @BeforeEach
     public void create() throws IOException {
         testFileSink = createTestFileSink();
     }
@@ -90,7 +90,4 @@ public class AddElementsFromSocketHandlerIT extends FlinkTest {
         return store;
     }
 
-    private TestFileSink createTestFileSink() throws IOException {
-        return new TestFileSink(testFolder.newFolder("testFileSink").toPath().toString());
-    }
 }

--- a/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/integration/operation/handler/javaardd/SplitStoreFromJavaRDDOfElementsHandlerIT.java
+++ b/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/integration/operation/handler/javaardd/SplitStoreFromJavaRDDOfElementsHandlerIT.java
@@ -20,8 +20,8 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.io.Text;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.accumulostore.AccumuloProperties;
 import uk.gov.gchq.gaffer.accumulostore.SingleUseAccumuloStore;
@@ -58,7 +58,7 @@ public class SplitStoreFromJavaRDDOfElementsHandlerIT {
     private static final AccumuloProperties PROPERTIES = AccumuloProperties.loadStoreProperties(StreamUtil.storeProps(currentClass));
 
 
-    @Before
+    @BeforeEach
     public void setUp() {
 
         elements = createElements();

--- a/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/integration/operation/handler/scalardd/SplitStoreFromRDDOfElementsHandlerIT.java
+++ b/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/integration/operation/handler/scalardd/SplitStoreFromRDDOfElementsHandlerIT.java
@@ -19,8 +19,8 @@ import com.google.common.collect.Lists;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.io.Text;
 import org.apache.spark.rdd.RDD;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import scala.collection.mutable.ArrayBuffer;
 import scala.reflect.ClassTag;
 
@@ -59,7 +59,7 @@ public class SplitStoreFromRDDOfElementsHandlerIT {
     private static Class currentClass = new Object() { }.getClass().getEnclosingClass();
     private static final AccumuloProperties PROPERTIES = AccumuloProperties.loadStoreProperties(StreamUtil.storeProps(currentClass));
 
-    @Before
+    @BeforeEach
     public void setUp() {
 
         elements = createElements();

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/RestApiTestClient.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/RestApiTestClient.java
@@ -80,7 +80,7 @@ public abstract class RestApiTestClient {
             if (tempSchema.exists()) {
                 FileUtils.forceDelete(tempSchema);
             }
-            if (tempSchema.exists()) {
+            if (tempStoreProperties.exists()) {
                 FileUtils.forceDelete(tempStoreProperties);
             }
         } catch (IOException e) {

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/RestApiTestClient.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/RestApiTestClient.java
@@ -23,7 +23,6 @@ import org.glassfish.grizzly.servlet.WebappContext;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
-import org.junit.rules.TemporaryFolder;
 
 import uk.gov.gchq.gaffer.commonutil.StreamUtil;
 import uk.gov.gchq.gaffer.data.element.Element;
@@ -74,19 +73,23 @@ public abstract class RestApiTestClient {
         }
     }
 
+    public void cleanUpTempFiles(File folder) {
+        File tempSchema = new File(folder, "/schema.json");
+        File tempStoreProperties = new File(folder, "/store.properties");
+        try {
+            if (tempSchema.exists()) {
+                FileUtils.forceDelete(tempSchema);
+            }
+            if (tempSchema.exists()) {
+                FileUtils.forceDelete(tempStoreProperties);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to clean up temp files from " + folder.getAbsolutePath());
+        }
+    }
+
     public boolean isRunning() {
         return null != server;
-    }
-
-    public void reinitialiseGraph(final TemporaryFolder testFolder) throws IOException {
-        reinitialiseGraph(testFolder, StreamUtil.SCHEMA, StreamUtil.STORE_PROPERTIES);
-    }
-
-    public void reinitialiseGraph(final TemporaryFolder testFolder, final String schemaResourcePath, final String storePropertiesResourcePath) throws IOException {
-        reinitialiseGraph(testFolder,
-                Schema.fromJson(StreamUtil.openStream(RestApiTestClient.class, schemaResourcePath)),
-                StoreProperties.loadStoreProperties(StreamUtil.openStream(RestApiTestClient.class, storePropertiesResourcePath))
-        );
     }
 
     public void reinitialiseGraph(final File tempDir, final String schemaResourcePath, final String storePropertiesResourcePath) throws IOException {
@@ -94,20 +97,6 @@ public abstract class RestApiTestClient {
                 Schema.fromJson(StreamUtil.openStream(RestApiTestClient.class, schemaResourcePath)),
                 StoreProperties.loadStoreProperties(StreamUtil.openStream(RestApiTestClient.class, storePropertiesResourcePath))
         );
-    }
-
-    public void reinitialiseGraph(final TemporaryFolder testFolder, final Schema schema, final StoreProperties storeProperties) throws IOException {
-        FileUtils.writeByteArrayToFile(testFolder.newFile("schema.json"), schema
-                .toJson(true));
-
-        try (OutputStream out = new FileOutputStream(testFolder.newFile("store.properties"))) {
-            storeProperties.getProperties()
-                    .store(out, "This is an optional header comment string");
-        }
-
-        // set properties for REST service
-        setSystemProperties(testFolder.getRoot() + "/store.properties", testFolder.getRoot() + "/schema.json");
-        reinitialiseGraph();
     }
 
     public void reinitialiseGraph(final File testFolder, final Schema schema, final StoreProperties storeProperties) throws IOException {
@@ -130,7 +119,7 @@ public abstract class RestApiTestClient {
     }
 
     public void reinitialiseGraph(final Graph graph) {
-        DefaultGraphFactory.setGraph(graph);
+        defaultGraphFactory.setGraph(graph);
 
         startServer();
 

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v1/OperationServiceV1IT.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v1/OperationServiceV1IT.java
@@ -16,8 +16,6 @@
 
 package uk.gov.gchq.gaffer.rest.service.v1;
 
-//import org.junit.Ignore;
-
 import uk.gov.gchq.gaffer.rest.RestApiTestClient;
 import uk.gov.gchq.gaffer.rest.service.impl.OperationServiceIT;
 
@@ -25,7 +23,6 @@ import uk.gov.gchq.gaffer.rest.service.impl.OperationServiceIT;
  * TODO: look in to why this fails when run other integration tests but passes
  *       when run in isolation.
  */
-//@Ignore
 public class OperationServiceV1IT extends OperationServiceIT {
 
     @Override

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/AccumuloAggregationIT.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/AccumuloAggregationIT.java
@@ -16,7 +16,7 @@
 package uk.gov.gchq.gaffer.accumulostore.integration;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.accumulostore.AccumuloProperties;
 import uk.gov.gchq.gaffer.accumulostore.utils.AccumuloPropertyNames;

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/GetElementsInRangesIT.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/GetElementsInRangesIT.java
@@ -18,7 +18,7 @@ package uk.gov.gchq.gaffer.accumulostore.integration;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.accumulostore.AccumuloProperties;
 import uk.gov.gchq.gaffer.accumulostore.AccumuloStoreTest;

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/delete/AbstractDeletedElementsIT.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/delete/AbstractDeletedElementsIT.java
@@ -27,14 +27,11 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.io.Text;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.accumulostore.AccumuloProperties;
 import uk.gov.gchq.gaffer.accumulostore.AccumuloStore;
 import uk.gov.gchq.gaffer.accumulostore.key.AccumuloElementConverter;
-import uk.gov.gchq.gaffer.commonutil.CommonTestConstants;
 import uk.gov.gchq.gaffer.commonutil.StreamUtil;
 import uk.gov.gchq.gaffer.commonutil.TestGroups;
 import uk.gov.gchq.gaffer.commonutil.pair.Pair;
@@ -68,10 +65,6 @@ public abstract class AbstractDeletedElementsIT<OP extends Output<O>, O> {
 
     private static Class currentClass = new Object() { }.getClass().getEnclosingClass();
     private static final AccumuloProperties PROPERTIES = AccumuloProperties.loadStoreProperties(StreamUtil.storeProps(currentClass));
-
-    @ClassRule
-    public static TemporaryFolder storeBaseFolder = new TemporaryFolder(CommonTestConstants.TMP_DIRECTORY);
-
 
     protected void assertElements(final Iterable<ElementId> expected, final O actual) {
         ElementUtil.assertElementEquals(expected, (Iterable) actual);

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/performance/BloomFilterIT.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/performance/BloomFilterIT.java
@@ -29,10 +29,9 @@ import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,14 +78,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class BloomFilterIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(BloomFilterIT.class);
-    @Rule
-    public TemporaryFolder tempFolder = new TemporaryFolder(CommonTestConstants.TMP_DIRECTORY);
+    @TempDir
+    public File tempFolder = CommonTestConstants.TMP_DIRECTORY;
     private RangeFactory byteEntityRangeFactory;
     private AccumuloElementConverter byteEntityElementConverter;
     private RangeFactory gaffer1RangeFactory;
     private AccumuloElementConverter gafferV1ElementConverter;
 
-    @Before
+    @BeforeEach
     public void setup() {
         Schema schema = new Schema.Builder()
                 .type(TestTypes.PROP_INTEGER, Integer.class)
@@ -164,7 +163,7 @@ public class BloomFilterIT {
 
         // Open file
         final String suffix = FileOperations.getNewFileExtension(accumuloConf);
-        final String filenameTemp = tempFolder.getRoot().getAbsolutePath();
+        final String filenameTemp = tempFolder.getAbsolutePath();
         final String filename = filenameTemp + "." + suffix;
         final File file = new File(filename);
         if (file.exists()) {

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/operation/impl/CreateSplitPointsTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/operation/impl/CreateSplitPointsTest.java
@@ -22,10 +22,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,6 +49,7 @@ import uk.gov.gchq.gaffer.user.User;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
@@ -64,8 +64,8 @@ public class CreateSplitPointsTest {
     public static final int NUM_ENTITIES = 100;
     private static final Logger LOGGER = LoggerFactory.getLogger(CreateSplitPointsTest.class);
 
-    @Rule
-    public final TemporaryFolder testFolder = new TemporaryFolder(CommonTestConstants.TMP_DIRECTORY);
+    @TempDir
+    public final File testFolder = CommonTestConstants.TMP_DIRECTORY;
 
     private FileSystem fs;
 
@@ -76,14 +76,14 @@ public class CreateSplitPointsTest {
     private static Class currentClass = new Object() { }.getClass().getEnclosingClass();
     private static final AccumuloProperties PROPERTIES = AccumuloProperties.loadStoreProperties(StreamUtil.storeProps(currentClass));
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
 
         fs = createFileSystem();
 
         final String root = fs.resolvePath(new Path("/")).toString()
                 .replaceFirst("/$", "")
-                + testFolder.getRoot().getAbsolutePath();
+                + testFolder.getAbsolutePath();
 
 
         LOGGER.info("using root dir: " + root);

--- a/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/DoubleProxyTest.java
+++ b/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/DoubleProxyTest.java
@@ -16,7 +16,7 @@
 
 package uk.gov.gchq.gaffer.federatedstore;
 
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -83,7 +83,7 @@ public class DoubleProxyTest {
         assertThatNoException().isThrownBy(() -> federatedStoreGraph.execute(new GetAllElements(), new Context()));
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         SingleUseProxyMapStore.cleanUp();
     }

--- a/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreToFederatedStoreTest.java
+++ b/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreToFederatedStoreTest.java
@@ -17,7 +17,7 @@
 package uk.gov.gchq.gaffer.federatedstore;
 
 import com.google.common.collect.Lists;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -185,8 +185,8 @@ public class FederatedStoreToFederatedStoreTest {
         assertEquals(entity, results.get(0));
     }
 
-    @AfterClass
-    public static void afterClass() {
+    @AfterAll
+    public static void afterAll() {
         SingleUseFederatedStore.cleanUp();
     }
 }

--- a/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/integration/FederatedStoreRecursionIT.java
+++ b/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/integration/FederatedStoreRecursionIT.java
@@ -17,7 +17,7 @@ package uk.gov.gchq.gaffer.federatedstore.integration;
 
 import com.google.common.collect.Lists;
 import org.assertj.core.api.Assertions;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -194,7 +194,7 @@ public class FederatedStoreRecursionIT {
         this.proxyToRestServiceFederatedGraph = proxyToRestServiceFederatedGraph;
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         SingleUseFederatedStore.cleanUp();
     }

--- a/store-implementation/hbase-store/src/test/java/uk/gov/gchq/gaffer/hbasestore/serialisation/LazyElementCellTest.java
+++ b/store-implementation/hbase-store/src/test/java/uk/gov/gchq/gaffer/hbasestore/serialisation/LazyElementCellTest.java
@@ -17,7 +17,7 @@ package uk.gov.gchq.gaffer.hbasestore.serialisation;
 
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.KeyValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.exception.SerialisationException;

--- a/store-implementation/proxy-store/src/test/java/uk/gov/gchq/gaffer/proxystore/SingleUseProxyStore.java
+++ b/store-implementation/proxy-store/src/test/java/uk/gov/gchq/gaffer/proxystore/SingleUseProxyStore.java
@@ -16,8 +16,6 @@
 
 package uk.gov.gchq.gaffer.proxystore;
 
-import org.junit.rules.TemporaryFolder;
-
 import uk.gov.gchq.gaffer.commonutil.CommonTestConstants;
 import uk.gov.gchq.gaffer.commonutil.StreamUtil;
 import uk.gov.gchq.gaffer.rest.RestApiTestClient;
@@ -26,6 +24,7 @@ import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.store.StoreProperties;
 import uk.gov.gchq.gaffer.store.schema.Schema;
 
+import java.io.File;
 import java.io.IOException;
 
 /**
@@ -37,10 +36,10 @@ import java.io.IOException;
  * server will not be restarted every time.
  * <p>
  * After using this store you must remember to call
- * SingleUseMapProxyStore.cleanUp to stop the server and delete the temporary folder.
+ * SingleUseProxyStore.cleanUp to stop the server and delete the temporary folder.
  */
 public abstract class SingleUseProxyStore extends ProxyStore {
-    public static final TemporaryFolder TEST_FOLDER = new TemporaryFolder(CommonTestConstants.TMP_DIRECTORY);
+    public static final File TEST_FOLDER = CommonTestConstants.TMP_DIRECTORY;
     private static final RestApiTestClient CLIENT = new RestApiV2TestClient();
 
     @Override
@@ -50,13 +49,6 @@ public abstract class SingleUseProxyStore extends ProxyStore {
     }
 
     protected void startMapStoreRestApi(final Schema schema) throws StoreException {
-        try {
-            TEST_FOLDER.delete();
-            TEST_FOLDER.create();
-        } catch (final IOException e) {
-            throw new StoreException("Unable to create temporary folder", e);
-        }
-
         final StoreProperties storeProperties = StoreProperties.loadStoreProperties(
                 StreamUtil.openStream(getClass(), getPathToDelegateProperties()));
         try {
@@ -67,8 +59,8 @@ public abstract class SingleUseProxyStore extends ProxyStore {
     }
 
     public static void cleanUp() {
-        TEST_FOLDER.delete();
         CLIENT.stopServer();
+        CLIENT.cleanUpTempFiles(TEST_FOLDER);
     }
 
     protected abstract String getPathToDelegateProperties();

--- a/store-implementation/proxy-store/src/test/java/uk/gov/gchq/gaffer/proxystore/integration/ProxyStoreBasicIT.java
+++ b/store-implementation/proxy-store/src/test/java/uk/gov/gchq/gaffer/proxystore/integration/ProxyStoreBasicIT.java
@@ -17,12 +17,11 @@
 package uk.gov.gchq.gaffer.proxystore.integration;
 
 import com.google.common.collect.Iterables;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import uk.gov.gchq.gaffer.commonutil.CommonTestConstants;
 import uk.gov.gchq.gaffer.commonutil.StreamUtil;
@@ -55,6 +54,7 @@ import uk.gov.gchq.gaffer.rest.service.v2.RestApiV2TestClient;
 import uk.gov.gchq.gaffer.store.StoreTrait;
 import uk.gov.gchq.gaffer.user.User;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
@@ -67,8 +67,8 @@ public class ProxyStoreBasicIT {
 
     private static final RestApiTestClient CLIENT = new RestApiV2TestClient();
 
-    @Rule
-    public final TemporaryFolder testFolder = new TemporaryFolder(CommonTestConstants.TMP_DIRECTORY);
+    @TempDir
+    public final File testFolder = CommonTestConstants.TMP_DIRECTORY;
 
     public static final User USER = new User();
     public static final Element[] DEFAULT_ELEMENTS = new Element[]{
@@ -103,17 +103,17 @@ public class ProxyStoreBasicIT {
                     .build()
     };
 
-    @BeforeClass
-    public static void beforeClass() throws Exception {
+    @BeforeAll
+    public static void beforeAll() throws Exception {
         CLIENT.startServer();
     }
 
-    @AfterClass
-    public static void afterClass() {
+    @AfterAll
+    public static void afterAll() {
         CLIENT.stopServer();
     }
 
-    @Before
+    @BeforeEach
     public void before() throws IOException {
         CLIENT.reinitialiseGraph(testFolder, StreamUtil.SCHEMA, "map-store.properties");
 

--- a/store-implementation/proxy-store/src/test/java/uk/gov/gchq/gaffer/proxystore/integration/ProxyStoreResponseDeserialiserIT.java
+++ b/store-implementation/proxy-store/src/test/java/uk/gov/gchq/gaffer/proxystore/integration/ProxyStoreResponseDeserialiserIT.java
@@ -15,12 +15,11 @@
  */
 package uk.gov.gchq.gaffer.proxystore.integration;
 
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import uk.gov.gchq.gaffer.commonutil.CommonTestConstants;
 import uk.gov.gchq.gaffer.commonutil.StreamUtil;
@@ -37,6 +36,7 @@ import uk.gov.gchq.gaffer.rest.service.v2.RestApiV2TestClient;
 import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.store.schema.Schema;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
@@ -53,20 +53,20 @@ public class ProxyStoreResponseDeserialiserIT {
 
     private static final RestApiTestClient CLIENT = new RestApiV2TestClient();
 
-    @Rule
-    public final TemporaryFolder testFolder = new TemporaryFolder(CommonTestConstants.TMP_DIRECTORY);
+    @TempDir
+    public final File testFolder = CommonTestConstants.TMP_DIRECTORY;
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         CLIENT.startServer();
     }
 
-    @AfterClass
-    public static void afterClass() {
+    @AfterAll
+    public static void afterAll() {
         CLIENT.stopServer();
     }
 
-    @Before
+    @BeforeEach
     public void before() throws IOException {
         CLIENT.reinitialiseGraph(testFolder, StreamUtil.SCHEMA, "map-store.properties");
     }


### PR DESCRIPTION
This PR should remove all usages of JUnit4 that aren't to do with either store integration tests or spring rest tests.
Particular points of interest are [RestApiTestClient](https://github.com/gchq/Gaffer/blob/c7028e7f9c9f363959b7e19f4f1b477e88aafb29/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/RestApiTestClient.java) and [FlinkTest](https://github.com/gchq/Gaffer/blob/c7028e7f9c9f363959b7e19f4f1b477e88aafb29/library/flink-library/src/test/java/uk/gov/gchq/gaffer/flink/operation/FlinkTest.java) which had to be cleaned up and I would like confirming that the clean up was okay.

# Related Issue

- Resolve #2499