### PR TITLE
gh-2421: Change MapStore GetElements to handle Elements

### DIFF
--- a/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/GetElementsIT.java
+++ b/integration-test/src/test/java/uk/gov/gchq/gaffer/integration/impl/GetElementsIT.java
@@ -56,6 +56,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.gchq.gaffer.operation.SeedMatching.SeedMatchingType;
@@ -546,7 +548,7 @@ public class GetElementsIT extends AbstractStoreIT {
             viewBuilder.edge(TestGroups.EDGE);
         }
 
-        final GetElements op = new GetElements.Builder()
+        final GetElements opSeed = new GetElements.Builder()
                 .input(seeds)
                 .directedType(directedType)
                 .inOutType(inOutType)
@@ -554,11 +556,24 @@ public class GetElementsIT extends AbstractStoreIT {
                 .seedMatching(seedMatching)
                 .build();
 
+        Collection<ElementId> seedCollection = StreamSupport.stream(seeds.spliterator(), false)
+                .collect(Collectors.toList());
+
+        final GetElements opElement = new GetElements.Builder()
+                .input(getElements(seedCollection, null))
+                .directedType(directedType)
+                .inOutType(inOutType)
+                .view(viewBuilder.build())
+                .seedMatching(seedMatching)
+                .build();
+
         // When
-        final CloseableIterable<? extends Element> results = graph.execute(op, user);
+        final CloseableIterable<? extends Element> resultsSeed = graph.execute(opSeed, user);
+        final CloseableIterable<? extends Element> resultsElement = graph.execute(opElement, user);
 
         // Then
-        ElementUtil.assertElementEquals(expectedElements, results, true);
+        ElementUtil.assertElementEquals(expectedElements, resultsSeed, true);
+        ElementUtil.assertElementEquals(expectedElements, resultsElement, true);
     }
 
     private static Collection<Element> getElements(final Collection<ElementId> seeds, final Boolean direction) {

--- a/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/AddElementsHandler.java
+++ b/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/AddElementsHandler.java
@@ -22,8 +22,6 @@ import uk.gov.gchq.gaffer.data.element.Edge;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.Entity;
 import uk.gov.gchq.gaffer.data.element.GroupedProperties;
-import uk.gov.gchq.gaffer.data.element.id.EdgeId;
-import uk.gov.gchq.gaffer.data.element.id.EntityId;
 import uk.gov.gchq.gaffer.mapstore.MapStore;
 import uk.gov.gchq.gaffer.operation.OperationException;
 import uk.gov.gchq.gaffer.operation.data.EdgeSeed;
@@ -146,20 +144,20 @@ public class AddElementsHandler implements OperationHandler<AddElements> {
     private void updateElementIndex(final Element element, final MapImpl mapImpl) {
         if (element instanceof Entity) {
             final Entity entity = (Entity) element;
-            final EntityId entityId = new EntitySeed(entity.getVertex());
-            mapImpl.addIndex(entityId, element);
+            final EntitySeed entitySeed = new EntitySeed(entity.getVertex());
+            mapImpl.addIndex(entitySeed, element);
         } else {
             final Edge edge = (Edge) element;
-            edge.setIdentifiers(edge.getSource(), edge.getDestination(), edge.isDirected(), EdgeId.MatchedVertex.SOURCE);
-            final EntityId sourceEntityId = new EntitySeed(edge.getSource());
-            mapImpl.addIndex(sourceEntityId, edge);
+            edge.setIdentifiers(edge.getSource(), edge.getDestination(), edge.isDirected(), EdgeSeed.MatchedVertex.SOURCE);
+            final EntitySeed sourceEntitySeed = new EntitySeed(edge.getSource());
+            mapImpl.addIndex(sourceEntitySeed, edge);
 
-            final Edge destMatchedEdge = new Edge(edge.getGroup(), edge.getSource(), edge.getDestination(), edge.isDirected(), EdgeId.MatchedVertex.DESTINATION, edge.getProperties());
-            final EntityId destinationEntityId = new EntitySeed(edge.getDestination());
-            mapImpl.addIndex(destinationEntityId, destMatchedEdge);
+            final Edge destMatchedEdge = new Edge(edge.getGroup(), edge.getSource(), edge.getDestination(), edge.isDirected(), EdgeSeed.MatchedVertex.DESTINATION, edge.getProperties());
+            final EntitySeed destinationEntitySeed = new EntitySeed(edge.getDestination());
+            mapImpl.addIndex(destinationEntitySeed, destMatchedEdge);
 
-            final EdgeId edgeId = new EdgeSeed(edge.getSource(), edge.getDestination(), edge.isDirected());
-            mapImpl.addIndex(edgeId, edge);
+            final EdgeSeed edgeSeed = new EdgeSeed(edge.getSource(), edge.getDestination(), edge.isDirected());
+            mapImpl.addIndex(edgeSeed, edge);
         }
     }
 }

--- a/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/GetElementsUtil.java
+++ b/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/GetElementsUtil.java
@@ -99,12 +99,13 @@ public final class GetElementsUtil {
         } else {
             relevantElements = new HashSet<>();
 
-            final EdgeId edgeId = (EdgeSeed) elementId;
+            final EdgeId edgeId = (EdgeId) elementId;
+
             if (DirectedType.isEither(edgeId.getDirectedType())) {
                 relevantElements.addAll(mapImpl.lookup(new EdgeSeed(edgeId.getSource(), edgeId.getDestination(), false)));
                 relevantElements.addAll(mapImpl.lookup(new EdgeSeed(edgeId.getSource(), edgeId.getDestination(), true)));
             } else {
-                relevantElements.addAll(mapImpl.lookup(edgeId));
+                relevantElements.addAll(mapImpl.lookup(new EdgeSeed(edgeId.getSource(), edgeId.getDestination(), edgeId.getDirectedType())));
             }
 
             mapImpl.lookup(new EntitySeed(edgeId.getSource()))

--- a/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/MapImpl.java
+++ b/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/MapImpl.java
@@ -25,6 +25,8 @@ import uk.gov.gchq.gaffer.mapstore.MapStoreProperties;
 import uk.gov.gchq.gaffer.mapstore.factory.MapFactory;
 import uk.gov.gchq.gaffer.mapstore.factory.SimpleMapFactory;
 import uk.gov.gchq.gaffer.mapstore.multimap.MultiMap;
+import uk.gov.gchq.gaffer.operation.data.EdgeSeed;
+import uk.gov.gchq.gaffer.operation.data.EntitySeed;
 import uk.gov.gchq.gaffer.store.schema.Schema;
 import uk.gov.gchq.gaffer.store.schema.SchemaElementDefinition;
 import uk.gov.gchq.gaffer.store.util.AggregatorUtil;
@@ -202,12 +204,12 @@ public class MapImpl {
         return Stream.concat(getAllAggElements(groups), getAllNonAggElements(groups));
     }
 
-    void addIndex(final EntityId entityId, final Element element) {
-        entityIdToElements.put(entityId, element);
+    void addIndex(final EntitySeed entitySeed, final Element element) {
+        entityIdToElements.put(entitySeed, element);
     }
 
-    void addIndex(final EdgeId edgeId, final Element element) {
-        edgeIdToElements.put(edgeId, element);
+    void addIndex(final EdgeSeed edgeSeed, final Element element) {
+        edgeIdToElements.put(edgeSeed, element);
     }
 
     boolean isMaintainIndex() {

--- a/store-implementation/parquet-store/src/main/java/uk/gov/gchq/gaffer/parquetstore/query/QueryGenerator.java
+++ b/store-implementation/parquet-store/src/main/java/uk/gov/gchq/gaffer/parquetstore/query/QueryGenerator.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import uk.gov.gchq.gaffer.commonutil.pair.Pair;
 import uk.gov.gchq.gaffer.data.element.id.DirectedType;
+import uk.gov.gchq.gaffer.data.element.id.EdgeId;
 import uk.gov.gchq.gaffer.data.element.id.ElementId;
 import uk.gov.gchq.gaffer.data.element.id.EntityId;
 import uk.gov.gchq.gaffer.data.elementdefinition.view.View;
@@ -32,8 +33,6 @@ import uk.gov.gchq.gaffer.exception.SerialisationException;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.OperationException;
 import uk.gov.gchq.gaffer.operation.SeedMatching;
-import uk.gov.gchq.gaffer.operation.data.EdgeSeed;
-import uk.gov.gchq.gaffer.operation.data.EntitySeed;
 import uk.gov.gchq.gaffer.operation.graph.SeededGraphFilters;
 import uk.gov.gchq.gaffer.operation.impl.get.GetAllElements;
 import uk.gov.gchq.gaffer.operation.impl.get.GetElements;
@@ -279,11 +278,11 @@ public class QueryGenerator {
         } else {
             column = ParquetStore.SOURCE;
         }
-        if (seed instanceof EntitySeed) {
-            return new ParquetEntitySeed(seed, converter.gafferObjectToParquetObjects(column, ((EntitySeed) seed).getVertex()));
+        if (seed instanceof EntityId) {
+            return new ParquetEntitySeed(seed, converter.gafferObjectToParquetObjects(column, ((EntityId) seed).getVertex()));
 
         } else {
-            return converter.edgeIdToParquetObjects((EdgeSeed) seed);
+            return converter.edgeIdToParquetObjects((EdgeId) seed);
         }
     }
 


### PR DESCRIPTION
This should let the input to the `MapStore`'s `GetElements` be an `Element`, as well as well as an `ElementSeed`.
Marked as draft as some test for this might be a good idea.

# Related Issue

- Resolve #2421