### PR TITLE
gh-2544: Revert "gh-2543: Change release standalone jdk to v1 (#2545)"

### DIFF
--- a/.github/workflows/release-standalone.yaml
+++ b/.github/workflows/release-standalone.yaml
@@ -7,9 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        distribution: 'zulu'
+        java-version: '8'
 
     - name: Checkout Branch
       uses: actions/checkout@v2


### PR DESCRIPTION
This reverts commit aec4d49b5f96ac66b9abe9d5546d641addd7a3a8.