### PR TITLE
Gh 2562 GetElementsWithinSet not allowing for the exclusion of properties - Gaffer v1

### DIFF
--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/operation/handler/GetElementsWithinSetHandler.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/operation/handler/GetElementsWithinSetHandler.java
@@ -44,7 +44,8 @@ public class GetElementsWithinSetHandler implements OutputOperationHandler<GetEl
             throws OperationException {
         try {
             final IteratorSettingFactory iteratorFactory = store.getKeyPackage().getIteratorFactory();
-            return new AccumuloIDWithinSetRetriever(store, operation, user, iteratorFactory.getElementPreAggregationFilterIteratorSetting(operation.getView(), store),
+            return new AccumuloIDWithinSetRetriever(store, operation, user,
+                    iteratorFactory.getElementPreAggregationFilterIteratorSetting(operation.getView(), store),
                     iteratorFactory.getElementPostAggregationFilterIteratorSetting(operation.getView(), store),
                     iteratorFactory.getEdgeEntityDirectionFilterIteratorSetting(operation),
                     iteratorFactory.getQueryTimeAggregatorIteratorSetting(operation.getView(), store));

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/retriever/AccumuloSetRetriever.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/retriever/AccumuloSetRetriever.java
@@ -1,5 +1,5 @@
 /*
-F * Copyright 2016-2020 Crown Copyright
+ * Copyright 2016-2020 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/retriever/AccumuloSetRetriever.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/retriever/AccumuloSetRetriever.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Crown Copyright
+F * Copyright 2016-2020 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -259,8 +259,8 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
          *
          * @param elm the element to check
          * @return True if the provided element is an edge and Both ends are
-         *         contained in the provided seed sets or if the element is an
-         *         entity
+         * contained in the provided seed sets or if the element is an
+         * entity
          */
         private boolean checkIfBothEndsInSet(final Element elm) {
             if (Entity.class.isInstance(elm)) {

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/retriever/AccumuloSetRetriever.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/retriever/AccumuloSetRetriever.java
@@ -51,8 +51,10 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.Set;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 
 public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? extends EntityId>, CloseableIterable<? extends Element>> & GraphFilters>
         extends AccumuloRetriever<OP, Element> {
@@ -204,10 +206,10 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
 
         @Override
         public boolean hasNext() {
-            if (Objects.nonNull(nextElm)) {
+            if (nonNull(nextElm)) {
                 return true;
             }
-            if (Objects.isNull(iterator)) {
+            if (isNull(iterator)) {
                 throw new IllegalStateException(
                         "This iterator has not been initialised. Call initialise before using it.");
             }
@@ -216,8 +218,8 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
                 if (checkIfBothEndsInSet(nextElm)) {
                     if (doPostFilter(nextElm)) {
                         ViewUtil.removeProperties(operation.getView(), nextElm);
+                        return true;
                     }
-                    return true;
                 }
             }
             return false;
@@ -225,7 +227,7 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
 
         @Override
         public Element next() {
-            if (Objects.isNull(nextElm)) {
+            if (isNull(nextElm)) {
                 if (!hasNext()) {
                     close();
                     throw new NoSuchElementException();
@@ -296,7 +298,7 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
 
         @Override
         public boolean hasNext() {
-            if (Objects.nonNull(nextElm)) {
+            if (nonNull(nextElm)) {
                 return true;
             }
             try {
@@ -312,8 +314,8 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
                         doTransformation(nextElm);
                         if (doPostFilter(nextElm)) {
                             ViewUtil.removeProperties(operation.getView(), nextElm);
+                            return true;
                         }
-                        return true;
                     }
                 }
             } catch (final RetrieverException e) {
@@ -326,7 +328,7 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
 
         @Override
         public Element next() {
-            if (Objects.isNull(nextElm)) {
+            if (isNull(nextElm)) {
                 if (!hasNext()) {
                     throw new NoSuchElementException();
                 }

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/retriever/AccumuloSetRetriever.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/retriever/AccumuloSetRetriever.java
@@ -40,6 +40,7 @@ import uk.gov.gchq.gaffer.data.element.Edge;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.Entity;
 import uk.gov.gchq.gaffer.data.element.id.EntityId;
+import uk.gov.gchq.gaffer.data.elementdefinition.view.ViewUtil;
 import uk.gov.gchq.gaffer.operation.graph.GraphFilters;
 import uk.gov.gchq.gaffer.operation.io.InputOutput;
 import uk.gov.gchq.gaffer.store.StoreException;
@@ -50,10 +51,12 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 
 public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? extends EntityId>, CloseableIterable<? extends Element>> & GraphFilters>
         extends AccumuloRetriever<OP, Element> {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(AccumuloSetRetriever.class);
     private boolean readEntriesIntoMemory;
 
@@ -63,18 +66,21 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
     }
 
     public AccumuloSetRetriever(final AccumuloStore store, final OP operation, final User user,
-                                final boolean readEntriesIntoMemory) throws StoreException {
+                                final boolean readEntriesIntoMemory)
+            throws StoreException {
         super(store, operation, user);
         this.readEntriesIntoMemory = readEntriesIntoMemory;
     }
 
     public AccumuloSetRetriever(final AccumuloStore store, final OP operation, final User user,
-                                final IteratorSetting... iteratorSettings) throws StoreException {
+                                final IteratorSetting... iteratorSettings)
+            throws StoreException {
         this(store, operation, user, false, iteratorSettings);
     }
 
     public AccumuloSetRetriever(final AccumuloStore store, final OP operation, final User user,
-                                final boolean readEntriesIntoMemory, final IteratorSetting... iteratorSettings) throws StoreException {
+                                final boolean readEntriesIntoMemory, final IteratorSetting... iteratorSettings)
+            throws StoreException {
         super(store, operation, user, iteratorSettings);
         this.readEntriesIntoMemory = readEntriesIntoMemory;
     }
@@ -146,7 +152,8 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
     }
 
     protected void addToBloomFilter(final Iterator<? extends EntityId> seeds, final BloomFilter filter1,
-                                    final BloomFilter filter2) throws RetrieverException {
+                                    final BloomFilter filter2)
+            throws RetrieverException {
         try {
             while (seeds.hasNext()) {
                 addToBloomFilter(seeds.next(), filter1, filter2);
@@ -175,19 +182,19 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
         private Iterator<Element> iterator;
         private Element nextElm;
 
+        @SuppressWarnings({"unchecked", "rawtypes"})
         protected void initialise(final BloomFilter filter) throws RetrieverException {
             IteratorSetting bloomFilter = null;
-            IteratorSetting[] iteratorSettings1 = Arrays.copyOf(iteratorSettings, iteratorSettings.length + 1);
+            final IteratorSetting[] iteratorSettingsCopy = Arrays.copyOf(iteratorSettings, iteratorSettings.length + 1);
             try {
                 bloomFilter = iteratorSettingFactory.getBloomFilterIteratorSetting(filter);
             } catch (final IteratorSettingException e) {
-                LOGGER.error(
-                        "Failed to apply the bloom filter to the retriever, creating the gaffer.accumulostore.retriever without bloom filter",
-                        e);
+                LOGGER.error("Failed to apply the bloom filter to the retriever, "
+                        + "creating the gaffer.accumulostore.retriever without bloom filter", e);
             }
-            iteratorSettings1[iteratorSettings.length] = bloomFilter;
+            iteratorSettingsCopy[iteratorSettings.length] = bloomFilter;
             try {
-                parentRetriever = new AccumuloSingleIDRetriever(store, operation, user, iteratorSettings1);
+                parentRetriever = new AccumuloSingleIDRetriever(store, operation, user, iteratorSettingsCopy);
             } catch (final Exception e) {
                 CloseableUtil.close(operation);
                 throw new RetrieverException(e.getMessage(), e);
@@ -197,16 +204,19 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
 
         @Override
         public boolean hasNext() {
-            if (null != nextElm) {
+            if (Objects.nonNull(nextElm)) {
                 return true;
             }
-            if (null == iterator) {
+            if (Objects.isNull(iterator)) {
                 throw new IllegalStateException(
                         "This iterator has not been initialised. Call initialise before using it.");
             }
             while (iterator.hasNext()) {
                 nextElm = iterator.next();
                 if (checkIfBothEndsInSet(nextElm)) {
+                    if (doPostFilter(nextElm)) {
+                        ViewUtil.removeProperties(operation.getView(), nextElm);
+                    }
                     return true;
                 }
             }
@@ -215,13 +225,13 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
 
         @Override
         public Element next() {
-            if (null == nextElm) {
+            if (Objects.isNull(nextElm)) {
                 if (!hasNext()) {
                     close();
                     throw new NoSuchElementException();
                 }
             }
-            Element nextReturn = nextElm;
+            final Element nextReturn = nextElm;
             nextElm = null;
             return nextReturn;
 
@@ -234,9 +244,7 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
 
         @Override
         public void close() {
-            if (null != parentRetriever) {
-                parentRetriever.close();
-            }
+            CloseableUtil.close(parentRetriever);
         }
 
         protected abstract boolean checkIfBothEndsInSet(final Object source, final Object destination);
@@ -249,8 +257,8 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
          *
          * @param elm the element to check
          * @return True if the provided element is an edge and Both ends are
-         * contained in the provided seed sets or if the element is an
-         * entity
+         *         contained in the provided seed sets or if the element is an
+         *         entity
          */
         private boolean checkIfBothEndsInSet(final Element elm) {
             if (Entity.class.isInstance(elm)) {
@@ -288,7 +296,7 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
 
         @Override
         public boolean hasNext() {
-            if (null != nextElm) {
+            if (Objects.nonNull(nextElm)) {
                 return true;
             }
             try {
@@ -303,8 +311,9 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
                     if (secondaryCheck(nextElm)) {
                         doTransformation(nextElm);
                         if (doPostFilter(nextElm)) {
-                            return true;
+                            ViewUtil.removeProperties(operation.getView(), nextElm);
                         }
+                        return true;
                     }
                 }
             } catch (final RetrieverException e) {
@@ -317,12 +326,12 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
 
         @Override
         public Element next() {
-            if (null == nextElm) {
+            if (Objects.isNull(nextElm)) {
                 if (!hasNext()) {
                     throw new NoSuchElementException();
                 }
             }
-            Element nextReturn = nextElm;
+            final Element nextReturn = nextElm;
             nextElm = null;
             return nextReturn;
         }
@@ -335,9 +344,7 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
 
         @Override
         public void close() {
-            if (null != scanner) {
-                scanner.close();
-            }
+            CloseableUtil.close(scanner);
         }
 
         protected abstract void updateBloomFilterIfRequired(final EntityId seed) throws RetrieverException;
@@ -399,7 +406,7 @@ public abstract class AccumuloSetRetriever<OP extends InputOutput<Iterable<? ext
                 updateScanner();
             }
             if (!scannerIterator.hasNext()) {
-                scanner.close();
+                CloseableUtil.close(scanner);
             }
             return scannerIterator.hasNext();
         }

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/operation/handler/GetElementsWithinSetHandlerTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/operation/handler/GetElementsWithinSetHandlerTest.java
@@ -28,7 +28,6 @@ import uk.gov.gchq.gaffer.accumulostore.SingleUseMiniAccumuloStore;
 import uk.gov.gchq.gaffer.accumulostore.operation.impl.GetElementsWithinSet;
 import uk.gov.gchq.gaffer.accumulostore.utils.AccumuloPropertyNames;
 import uk.gov.gchq.gaffer.accumulostore.utils.TableUtils;
-import uk.gov.gchq.gaffer.commonutil.CloseableUtil;
 import uk.gov.gchq.gaffer.commonutil.StreamUtil;
 import uk.gov.gchq.gaffer.commonutil.TestGroups;
 import uk.gov.gchq.gaffer.data.element.Edge;
@@ -173,20 +172,16 @@ public class GetElementsWithinSetHandlerTest {
     private void shouldReturnElementsNoSummarisation(final AccumuloStore store) throws OperationException {
         final GetElementsWithinSet operation = new GetElementsWithinSet.Builder().view(defaultView).input(seeds).build();
         final GetElementsWithinSetHandler handler = new GetElementsWithinSetHandler();
-        Iterable<? extends Element> elements = null;
-        try {
-            elements = handler.doOperation(operation, user, store);
-            // Without query compaction the result size should be 5
-            final Set<Element> elementSet = Sets.newHashSet(elements);
-            assertThat(elementSet).hasSize(5);
-            assertThat(elementSet).containsOnly(expectedEdge1, expectedEdge2, expectedEdge3, expectedEntity1, expectedEntity2);
-            for (final Element element : elementSet) {
-                if (element instanceof Edge) {
-                    assertThat(((Edge) element).getMatchedVertex()).isEqualTo(EdgeId.MatchedVertex.SOURCE);
-                }
+
+        final Iterable<? extends Element> elements = handler.doOperation(operation, user, store);
+        // Without query compaction the result size should be 5
+        final Set<Element> elementSet = Sets.newHashSet(elements);
+        assertThat(elementSet).hasSize(5);
+        assertThat(elementSet).containsOnly(expectedEdge1, expectedEdge2, expectedEdge3, expectedEntity1, expectedEntity2);
+        for (final Element element : elementSet) {
+            if (element instanceof Edge) {
+                assertThat(((Edge) element).getMatchedVertex()).isEqualTo(EdgeId.MatchedVertex.SOURCE);
             }
-        } finally {
-            CloseableUtil.close(elements);
         }
     }
 
@@ -342,18 +337,13 @@ public class GetElementsWithinSetHandlerTest {
         final GetElementsWithinSet operation = new GetElementsWithinSet.Builder().view(view).input(seeds).build();
         final GetElementsWithinSetHandler handler = new GetElementsWithinSetHandler();
 
-        Iterable<? extends Element> elements = null;
-        try {
-            elements = handler.doOperation(operation, user, store);
+        final Iterable<? extends Element> elements = handler.doOperation(operation, user, store);
 
-            // After query compaction the result size should be 1
-            assertThat(elements)
-                    .hasSize(expectedElements.length)
-                    .asInstanceOf(InstanceOfAssertFactories.iterable(Element.class))
-                    .containsOnly(expectedElements);
-        } finally {
-            CloseableUtil.close(elements);
-        }
+        // After query compaction the result size should be 1
+        assertThat(elements)
+                .hasSize(expectedElements.length)
+                .asInstanceOf(InstanceOfAssertFactories.iterable(Element.class))
+                .containsOnly(expectedElements);
     }
 
     private static void setupGraph(final AccumuloStore store) throws OperationException, StoreException, TableExistsException {

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/operation/handler/GetElementsWithinSetHandlerTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/operation/handler/GetElementsWithinSetHandlerTest.java
@@ -16,9 +16,9 @@
 
 package uk.gov.gchq.gaffer.accumulostore.operation.handler;
 
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import org.apache.accumulo.core.client.TableExistsException;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,9 +28,9 @@ import uk.gov.gchq.gaffer.accumulostore.SingleUseMiniAccumuloStore;
 import uk.gov.gchq.gaffer.accumulostore.operation.impl.GetElementsWithinSet;
 import uk.gov.gchq.gaffer.accumulostore.utils.AccumuloPropertyNames;
 import uk.gov.gchq.gaffer.accumulostore.utils.TableUtils;
+import uk.gov.gchq.gaffer.commonutil.CloseableUtil;
 import uk.gov.gchq.gaffer.commonutil.StreamUtil;
 import uk.gov.gchq.gaffer.commonutil.TestGroups;
-import uk.gov.gchq.gaffer.commonutil.iterable.CloseableIterable;
 import uk.gov.gchq.gaffer.data.element.Edge;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.Entity;
@@ -48,23 +48,18 @@ import uk.gov.gchq.gaffer.user.User;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class GetElementsWithinSetHandlerTest {
 
     private static final Schema SCHEMA = Schema.fromJson(StreamUtil.schemas(GetElementsWithinSetHandlerTest.class));
-    private static final AccumuloProperties PROPERTIES = AccumuloProperties.loadStoreProperties(StreamUtil
-            .storeProps(GetElementsWithinSetHandlerTest.class));
-    private static final AccumuloProperties CLASSIC_PROPERTIES = AccumuloProperties
-            .loadStoreProperties(StreamUtil.openStream(GetElementsWithinSetHandlerTest.class, "/accumuloStoreClassicKeys.properties"));
+    private static final AccumuloProperties PROPERTIES = AccumuloProperties.loadStoreProperties(StreamUtil.storeProps(GetElementsWithinSetHandlerTest.class));
+    private static final AccumuloProperties CLASSIC_PROPERTIES = AccumuloProperties.loadStoreProperties(StreamUtil.openStream(GetElementsWithinSetHandlerTest.class, "/accumuloStoreClassicKeys.properties"));
     private static final AccumuloStore BYTE_ENTITY_STORE = new SingleUseMiniAccumuloStore();
     private static final AccumuloStore GAFFER_1_KEY_STORE = new SingleUseMiniAccumuloStore();
 
@@ -102,13 +97,26 @@ public class GetElementsWithinSetHandlerTest {
             .dest("A23")
             .directed(true)
             .build();
+    private static Edge expectedSummarisedEdgePropertiesEmptySet = new Edge.Builder()
+            .group(TestGroups.EDGE)
+            .source("A0")
+            .dest("A23")
+            .directed(true)
+            .build();
+    private static Edge expectedSummarisedEdgePropertiesFiltered = new Edge.Builder()
+            .group(TestGroups.EDGE)
+            .source("A0")
+            .dest("A23")
+            .directed(true)
+            .property(AccumuloPropertyNames.COUNT, 23 * 3)
+            .build();
+
     final Set<EntityId> seeds = new HashSet<>(Arrays.asList(new EntitySeed("A0"), new EntitySeed("A23")));
 
-    private User user = new User();
-
+    private final User user = new User();
 
     @BeforeEach
-    public void reInitialise() throws StoreException {
+    public void reInitialise() throws StoreException, OperationException, TableExistsException {
         expectedEdge1.putProperty(AccumuloPropertyNames.COLUMN_QUALIFIER, 1);
         expectedEdge1.putProperty(AccumuloPropertyNames.COUNT, 23);
         expectedEdge1.putProperty(AccumuloPropertyNames.PROP_1, 0);
@@ -165,30 +173,25 @@ public class GetElementsWithinSetHandlerTest {
     private void shouldReturnElementsNoSummarisation(final AccumuloStore store) throws OperationException {
         final GetElementsWithinSet operation = new GetElementsWithinSet.Builder().view(defaultView).input(seeds).build();
         final GetElementsWithinSetHandler handler = new GetElementsWithinSetHandler();
-        final CloseableIterable<? extends Element> elements = handler.doOperation(operation, user, store);
-
-        //Without query compaction the result size should be 5
-        final Set<Element> elementSet = Sets.newHashSet(elements);
-        assertThat(elementSet).hasSize(5);
-        assertEquals(Sets.newHashSet(expectedEdge1, expectedEdge2, expectedEdge3, expectedEntity1, expectedEntity2), elementSet);
-        for (final Element element : elementSet) {
-            if (element instanceof Edge) {
-                assertEquals(EdgeId.MatchedVertex.SOURCE, ((Edge) element).getMatchedVertex());
+        Iterable<? extends Element> elements = null;
+        try {
+            elements = handler.doOperation(operation, user, store);
+            // Without query compaction the result size should be 5
+            final Set<Element> elementSet = Sets.newHashSet(elements);
+            assertThat(elementSet).hasSize(5);
+            assertThat(elementSet).containsOnly(expectedEdge1, expectedEdge2, expectedEdge3, expectedEntity1, expectedEntity2);
+            for (final Element element : elementSet) {
+                if (element instanceof Edge) {
+                    assertThat(((Edge) element).getMatchedVertex()).isEqualTo(EdgeId.MatchedVertex.SOURCE);
+                }
             }
+        } finally {
+            CloseableUtil.close(elements);
         }
     }
 
     @Test
     public void shouldSummariseByteEntityStore() throws OperationException {
-        shouldSummarise(BYTE_ENTITY_STORE);
-    }
-
-    @Test
-    public void shouldSummariseGaffer1Store() throws OperationException {
-        shouldSummarise(GAFFER_1_KEY_STORE);
-    }
-
-    private void shouldSummarise(final AccumuloStore store) throws OperationException {
         final View view = new View.Builder(defaultView)
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .groupBy()
@@ -200,27 +203,29 @@ public class GetElementsWithinSetHandlerTest {
                         .groupBy()
                         .build())
                 .build();
-        final GetElementsWithinSet operation = new GetElementsWithinSet.Builder().view(view).input(seeds).build();
-        final GetElementsWithinSetHandler handler = new GetElementsWithinSetHandler();
-        final CloseableIterable<? extends Element> elements = handler.doOperation(operation, user, store);
 
-        //After query compaction the result size should be 3
-        assertEquals(3, Iterables.size(elements));
-        assertThat((CloseableIterable<Element>) elements).contains(expectedSummarisedEdge, expectedEntity1, expectedEntity2);
-        elements.close();
+        runTest(BYTE_ENTITY_STORE, view, expectedSummarisedEdge, expectedEntity1, expectedEntity2);
+    }
+
+    @Test
+    public void shouldSummariseGaffer1Store() throws OperationException {
+        final View view = new View.Builder(defaultView)
+                .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
+                        .groupBy()
+                        .build())
+                .edge(TestGroups.EDGE, new ViewElementDefinition.Builder()
+                        .groupBy()
+                        .build())
+                .edge(TestGroups.EDGE_2, new ViewElementDefinition.Builder()
+                        .groupBy()
+                        .build())
+                .build();
+
+        runTest(GAFFER_1_KEY_STORE, view, expectedSummarisedEdge, expectedEntity1, expectedEntity2);
     }
 
     @Test
     public void shouldReturnOnlyEdgesWhenViewContainsNoEntitiesByteEntityStore() throws OperationException {
-        shouldReturnOnlyEdgesWhenViewContainsNoEntities(BYTE_ENTITY_STORE);
-    }
-
-    @Test
-    public void shouldReturnOnlyEdgesWhenViewContainsNoEntitiesGaffer1Store() throws OperationException {
-        shouldReturnOnlyEdgesWhenViewContainsNoEntities(GAFFER_1_KEY_STORE);
-    }
-
-    private void shouldReturnOnlyEdgesWhenViewContainsNoEntities(final AccumuloStore store) throws OperationException {
         final View view = new View.Builder()
                 .edge(TestGroups.EDGE, new ViewElementDefinition.Builder()
                         .groupBy()
@@ -229,121 +234,191 @@ public class GetElementsWithinSetHandlerTest {
                         .groupBy()
                         .build())
                 .build();
-        final GetElementsWithinSet operation = new GetElementsWithinSet.Builder().view(view).input(seeds).build();
-        final GetElementsWithinSetHandler handler = new GetElementsWithinSetHandler();
-        final CloseableIterable<? extends Element> elements = handler.doOperation(operation, user, store);
 
-        final Collection<Element> forTest = new LinkedList<>();
-        Iterables.addAll(forTest, elements);
+        runTest(BYTE_ENTITY_STORE, view, expectedSummarisedEdge);
+    }
 
-        //After query compaction the result size should be 1
-        assertEquals(1, Iterables.size(elements));
-        assertThat((CloseableIterable<Element>) elements).contains(expectedSummarisedEdge);
-        elements.close();
+    @Test
+    public void shouldReturnOnlyEdgesWhenViewContainsNoEntitiesGaffer1Store() throws OperationException {
+        final View view = new View.Builder()
+                .edge(TestGroups.EDGE, new ViewElementDefinition.Builder()
+                        .groupBy()
+                        .build())
+                .edge(TestGroups.EDGE_2, new ViewElementDefinition.Builder()
+                        .groupBy()
+                        .build())
+                .build();
+
+        runTest(GAFFER_1_KEY_STORE, view, expectedSummarisedEdge);
+    }
+
+    @Test
+    public void shouldReturnOnlyEdgesWhenViewContainsNoEntitiesPropertiesFilteredByteEntityStore() throws OperationException {
+        final View view = new View.Builder()
+                .edge(TestGroups.EDGE, new ViewElementDefinition.Builder()
+                        .properties(Collections.singleton(AccumuloPropertyNames.COUNT))
+                        .groupBy()
+                        .build())
+                .edge(TestGroups.EDGE_2, new ViewElementDefinition.Builder()
+                        .properties(Collections.singleton(AccumuloPropertyNames.COUNT))
+                        .groupBy()
+                        .build())
+                .build();
+
+        runTest(BYTE_ENTITY_STORE, view, expectedSummarisedEdgePropertiesFiltered);
+    }
+
+    @Test
+    public void shouldReturnOnlyEdgesWhenViewContainsNoEntitiesPropertiesFilteredGaffer1Store() throws OperationException {
+        final View view = new View.Builder()
+                .edge(TestGroups.EDGE, new ViewElementDefinition.Builder()
+                        .properties(Collections.singleton(AccumuloPropertyNames.COUNT))
+                        .groupBy()
+                        .build())
+                .edge(TestGroups.EDGE_2, new ViewElementDefinition.Builder()
+                        .properties(Collections.singleton(AccumuloPropertyNames.COUNT))
+                        .groupBy()
+                        .build())
+                .build();
+
+        runTest(GAFFER_1_KEY_STORE, view, expectedSummarisedEdgePropertiesFiltered);
+    }
+
+    @Test
+    public void shouldReturnOnlyEdgesWhenViewContainsNoEntitiesPropertiesEmptySetByteEntityStore() throws OperationException {
+        final View view = new View.Builder()
+                .edge(TestGroups.EDGE, new ViewElementDefinition.Builder()
+                        .properties(Collections.emptySet())
+                        .groupBy()
+                        .build())
+                .edge(TestGroups.EDGE_2, new ViewElementDefinition.Builder()
+                        .properties(Collections.emptySet())
+                        .groupBy()
+                        .build())
+                .build();
+
+        runTest(BYTE_ENTITY_STORE, view, expectedSummarisedEdgePropertiesEmptySet);
+    }
+
+    @Test
+    public void shouldReturnOnlyEdgesWhenViewContainsNoEntitiesPropertiesEmptySetGaffer1Store() throws OperationException {
+        final View view = new View.Builder()
+                .edge(TestGroups.EDGE, new ViewElementDefinition.Builder()
+                        .properties(Collections.emptySet())
+                        .groupBy()
+                        .build())
+                .edge(TestGroups.EDGE_2, new ViewElementDefinition.Builder()
+                        .properties(Collections.emptySet())
+                        .groupBy()
+                        .build())
+                .build();
+
+        runTest(GAFFER_1_KEY_STORE, view, expectedSummarisedEdgePropertiesEmptySet);
     }
 
     @Test
     public void shouldReturnOnlyEntitiesWhenViewContainsNoEdgesByteEntityStore() throws OperationException {
-        shouldReturnOnlyEntitiesWhenViewContainsNoEdges(BYTE_ENTITY_STORE);
-    }
-
-    @Test
-    public void shouldReturnOnlyEntitiesWhenViewContainsNoEdgesGaffer1Store() throws OperationException {
-        shouldReturnOnlyEntitiesWhenViewContainsNoEdges(GAFFER_1_KEY_STORE);
-    }
-
-    private void shouldReturnOnlyEntitiesWhenViewContainsNoEdges(final AccumuloStore store) throws OperationException {
         final View view = new View.Builder()
                 .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
                         .groupBy()
                         .build())
                 .build();
+
+        runTest(BYTE_ENTITY_STORE, view, expectedEntity1, expectedEntity2);
+    }
+
+    @Test
+    public void shouldReturnOnlyEntitiesWhenViewContainsNoEdgesGaffer1Store() throws OperationException {
+        final View view = new View.Builder()
+                .entity(TestGroups.ENTITY, new ViewElementDefinition.Builder()
+                        .groupBy()
+                        .build())
+                .build();
+
+        runTest(GAFFER_1_KEY_STORE, view, expectedEntity1, expectedEntity2);
+    }
+
+    private void runTest(final AccumuloStore store, final View view, final Element... expectedElements) throws OperationException {
         final GetElementsWithinSet operation = new GetElementsWithinSet.Builder().view(view).input(seeds).build();
-
         final GetElementsWithinSetHandler handler = new GetElementsWithinSetHandler();
-        final CloseableIterable<? extends Element> elements = handler.doOperation(operation, user, store);
 
-        //The result size should be 2
-        assertEquals(2, Iterables.size(elements));
-        assertThat((CloseableIterable<Element>) elements).contains(expectedEntity1, expectedEntity2);
-        elements.close();
-    }
-
-    private static void setupGraph(final AccumuloStore store) {
+        Iterable<? extends Element> elements = null;
         try {
-            // Create table
-            // (this method creates the table, removes the versioning iterator, and adds the SetOfStatisticsCombiner iterator,
-            // and sets the age off iterator to age data off after it is more than ageOffTimeInMilliseconds milliseconds old).
-            TableUtils.createTable(store);
+            elements = handler.doOperation(operation, user, store);
 
-            final List<Element> data = new ArrayList<>();
-            // Create edges A0 -> A1, A0 -> A2, ..., A0 -> A99. Also create an Entity for each.
-            final Entity entity = new Entity(TestGroups.ENTITY);
-            entity.setVertex("A0");
-            entity.putProperty(AccumuloPropertyNames.COUNT, 10000);
-            data.add(entity);
-            for (int i = 1; i < 100; i++) {
-                data.add(new Edge.Builder()
-                        .group(TestGroups.EDGE)
-                        .source("A0")
-                        .dest("A" + i)
-                        .directed(true)
-                        .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
-                        .property(AccumuloPropertyNames.COUNT, i)
-                        .property(AccumuloPropertyNames.PROP_1, 0)
-                        .property(AccumuloPropertyNames.PROP_2, 0)
-                        .property(AccumuloPropertyNames.PROP_3, 0)
-                        .property(AccumuloPropertyNames.PROP_4, 0)
-                        .build()
-                );
-
-                data.add(new Edge.Builder()
-                        .group(TestGroups.EDGE)
-                        .source("A0")
-                        .dest("A" + i)
-                        .directed(true)
-                        .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 2)
-                        .property(AccumuloPropertyNames.COUNT, i)
-                        .property(AccumuloPropertyNames.PROP_1, 0)
-                        .property(AccumuloPropertyNames.PROP_2, 0)
-                        .property(AccumuloPropertyNames.PROP_3, 0)
-                        .property(AccumuloPropertyNames.PROP_4, 0)
-                        .build()
-                );
-
-                data.add(new Edge.Builder()
-                        .group(TestGroups.EDGE)
-                        .source("A0")
-                        .dest("A" + i)
-                        .directed(true)
-                        .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 3)
-                        .property(AccumuloPropertyNames.COUNT, i)
-                        .property(AccumuloPropertyNames.PROP_1, 0)
-                        .property(AccumuloPropertyNames.PROP_2, 0)
-                        .property(AccumuloPropertyNames.PROP_3, 0)
-                        .property(AccumuloPropertyNames.PROP_4, 0)
-                        .build()
-                );
-
-                data.add(new Entity.Builder()
-                        .group(TestGroups.ENTITY)
-                        .vertex("A" + i)
-                        .property(AccumuloPropertyNames.COUNT, i)
-                        .build()
-                );
-            }
-            final User user = new User();
-            addElements(data, user, store);
-        } catch (final TableExistsException | StoreException e) {
-            fail("Failed to set up graph in Accumulo with exception: " + e);
+            // After query compaction the result size should be 1
+            assertThat(elements)
+                    .hasSize(expectedElements.length)
+                    .asInstanceOf(InstanceOfAssertFactories.iterable(Element.class))
+                    .containsOnly(expectedElements);
+        } finally {
+            CloseableUtil.close(elements);
         }
     }
 
-    private static void addElements(final Iterable<Element> data, final User user, final AccumuloStore store) {
-        try {
-            store.execute(new AddElements.Builder().input(data).build(), new Context(user));
-        } catch (final OperationException e) {
-            fail("Failed to set up graph in Accumulo with exception: " + e);
+    private static void setupGraph(final AccumuloStore store) throws OperationException, StoreException, TableExistsException {
+        // Create table
+        // (this method creates the table, removes the versioning iterator, and adds the SetOfStatisticsCombiner iterator,
+        // and sets the age off iterator to age data off after it is more than ageOffTimeInMilliseconds milliseconds old).
+        TableUtils.createTable(store);
+
+        final List<Element> data = new ArrayList<>();
+        // Create edges A0 -> A1, A0 -> A2, ..., A0 -> A99. Also create an Entity for each.
+        final Entity entity = new Entity(TestGroups.ENTITY);
+        entity.setVertex("A0");
+        entity.putProperty(AccumuloPropertyNames.COUNT, 10000);
+        data.add(entity);
+        for (int i = 1; i < 100; i++) {
+            data.add(new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("A0")
+                    .dest("A" + i)
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.COUNT, i)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build());
+
+            data.add(new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("A0")
+                    .dest("A" + i)
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 2)
+                    .property(AccumuloPropertyNames.COUNT, i)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build());
+
+            data.add(new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("A0")
+                    .dest("A" + i)
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 3)
+                    .property(AccumuloPropertyNames.COUNT, i)
+                    .property(AccumuloPropertyNames.PROP_1, 0)
+                    .property(AccumuloPropertyNames.PROP_2, 0)
+                    .property(AccumuloPropertyNames.PROP_3, 0)
+                    .property(AccumuloPropertyNames.PROP_4, 0)
+                    .build());
+
+            data.add(new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("A" + i)
+                    .property(AccumuloPropertyNames.COUNT, i)
+                    .build());
         }
+        final User user = new User();
+        addElements(data, user, store);
+    }
+
+    private static void addElements(final Iterable<Element> data, final User user, final AccumuloStore store) throws OperationException {
+        store.execute(new AddElements.Builder().input(data).build(), new Context(user));
     }
 }

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/retriever/impl/AccumuloIDWithinSetRetrieverTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/retriever/impl/AccumuloIDWithinSetRetrieverTest.java
@@ -57,7 +57,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 public class AccumuloIDWithinSetRetrieverTest {
 
@@ -395,9 +394,8 @@ public class AccumuloIDWithinSetRetrieverTest {
                 break;
             }
         }
-        if (count == maxNumberOfTries) {
-            fail("Didn't find a false positive");
-        }
+
+        assertThat(count).isNotEqualTo(maxNumberOfTries);
 
         // False positive is "" + count so create an edge from seeds to that
         final GetElementsWithinSet op = new GetElementsWithinSet.Builder().view(defaultView)

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/retriever/impl/AccumuloIDWithinSetRetrieverTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/retriever/impl/AccumuloIDWithinSetRetrieverTest.java
@@ -32,6 +32,7 @@ import uk.gov.gchq.gaffer.accumulostore.retriever.AccumuloRetriever;
 import uk.gov.gchq.gaffer.accumulostore.utils.AccumuloPropertyNames;
 import uk.gov.gchq.gaffer.accumulostore.utils.AccumuloTestData;
 import uk.gov.gchq.gaffer.accumulostore.utils.TableUtils;
+import uk.gov.gchq.gaffer.commonutil.CloseableUtil;
 import uk.gov.gchq.gaffer.commonutil.StreamUtil;
 import uk.gov.gchq.gaffer.commonutil.TestGroups;
 import uk.gov.gchq.gaffer.data.element.Edge;
@@ -40,6 +41,7 @@ import uk.gov.gchq.gaffer.data.element.Entity;
 import uk.gov.gchq.gaffer.data.element.id.DirectedType;
 import uk.gov.gchq.gaffer.data.element.id.EntityId;
 import uk.gov.gchq.gaffer.data.elementdefinition.view.View;
+import uk.gov.gchq.gaffer.data.elementdefinition.view.ViewElementDefinition;
 import uk.gov.gchq.gaffer.operation.OperationException;
 import uk.gov.gchq.gaffer.operation.data.EntitySeed;
 import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
@@ -48,16 +50,16 @@ import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.store.schema.Schema;
 import uk.gov.gchq.gaffer.user.User;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 public class AccumuloIDWithinSetRetrieverTest {
-
-    private static View defaultView;
 
     private static final Schema SCHEMA = Schema.fromJson(StreamUtil.schemas(AccumuloIDWithinSetRetrieverTest.class));
     private static final AccumuloProperties PROPERTIES = AccumuloProperties.loadStoreProperties(StreamUtil.storeProps(AccumuloIDWithinSetRetrieverTest.class));
@@ -65,13 +67,41 @@ public class AccumuloIDWithinSetRetrieverTest {
     private static final AccumuloStore BYTE_ENTITY_STORE = new SingleUseMiniAccumuloStore();
     private static final AccumuloStore GAFFER_1_KEY_STORE = new SingleUseMiniAccumuloStore();
 
+    private static View defaultView;
+    private static View viewEdgesPropertiesFiltered;
+    private static View viewEdgesPropertiesEmptySet;
+
+    private static Edge edgePropertiesFiltrered;
+    private static Edge edgePropertiesEmptySet;
+
     @BeforeAll
     public static void setup() throws StoreException {
-        defaultView = new View.Builder().edge(TestGroups.EDGE).entity(TestGroups.ENTITY).build();
+        defaultView = new View.Builder()
+                .edge(TestGroups.EDGE)
+                .entity(TestGroups.ENTITY)
+                .build();
+
+        viewEdgesPropertiesFiltered = new View.Builder()
+                .edge(TestGroups.EDGE, new ViewElementDefinition.Builder()
+                        .properties(Collections.singleton(AccumuloPropertyNames.COUNT))
+                        .build())
+                .build();
+
+        viewEdgesPropertiesEmptySet = new View.Builder()
+                .edge(TestGroups.EDGE, new ViewElementDefinition.Builder()
+                        .properties(Collections.emptySet())
+                        .build())
+                .build();
+
+        edgePropertiesFiltrered = AccumuloTestData.EDGE_A0_A23.shallowClone();
+        edgePropertiesFiltrered.getProperties().remove(AccumuloPropertyNames.COLUMN_QUALIFIER);
+
+        edgePropertiesEmptySet = AccumuloTestData.EDGE_A0_A23.shallowClone();
+        edgePropertiesEmptySet.getProperties().clear();
     }
 
     @BeforeEach
-    public void reInitialise() throws StoreException {
+    public void reInitialise() throws StoreException, OperationException, TableExistsException {
         BYTE_ENTITY_STORE.initialise("byteEntityGraph", SCHEMA, PROPERTIES);
         GAFFER_1_KEY_STORE.initialise("gaffer1Graph", SCHEMA, CLASSIC_PROPERTIES);
 
@@ -79,31 +109,13 @@ public class AccumuloIDWithinSetRetrieverTest {
         setupGraph(GAFFER_1_KEY_STORE);
     }
 
-    private Set<Element> returnElementsFromOperation(final AccumuloStore store, final GetElementsWithinSet operation, final User user, final boolean loadIntoMemory) throws StoreException {
-        final Set<Element> results = new HashSet<>();
-        AccumuloRetriever<?, Element> retriever = null;
-        try {
-            retriever = new AccumuloIDWithinSetRetriever(store, operation, user, loadIntoMemory);
-
-            for (final Element elm : retriever) {
-                results.add(elm);
-            }
-        } finally {
-            if (retriever != null) {
-                retriever.close();
-            }
-        }
-
-        return results;
-    }
-
-    /**
-     * Tests that the correct {@link uk.gov.gchq.gaffer.data.element.Edge}s are returned. Tests that {@link uk.gov.gchq.gaffer.data.element.Entity}s are also returned
-     * (unless the return edges only option has been set on the {@link GetElementsWithinSet}). It is desirable
-     * for {@link uk.gov.gchq.gaffer.data.element.Entity}s to be returned as a common use-case is to use this method to complete the "half-hop"
-     * in a breadth-first search, and then getting all the information about the nodes is often required.
-     *
-     * @throws StoreException if StoreException
+    /*
+     * Tests that the correct {@link uk.gov.gchq.gaffer.data.element.Edge}s are returned. Tests that
+     * {@link uk.gov.gchq.gaffer.data.element.Entity}s are also returned (unless the return edges only
+     * option has been set on the {@link GetElementsWithinSet}). It is desirable for
+     * {@link uk.gov.gchq.gaffer.data.element.Entity}s to be returned as a common use-case is to use this
+     * method to complete the "half-hop" in a breadth-first search, and then getting all the information
+     * about the nodes is often required.
      */
     @Test
     public void shouldGetCorrectEdgesInMemoryFromByteEntityStore() throws StoreException {
@@ -160,7 +172,68 @@ public class AccumuloIDWithinSetRetrieverTest {
                 .contains(AccumuloTestData.A1_ENTITY, AccumuloTestData.A2_ENTITY);
     }
 
-    /**
+    /*
+     * Testing that properties are filtered correctly when a view with property filtering is used.
+     */
+    @Test
+    public void shouldGetCorrectEdgesPropertiesFilteredInMemoryFromByteEntityStore() throws StoreException {
+        shouldGetCorrectEdgesFilteredProperties(true, BYTE_ENTITY_STORE, viewEdgesPropertiesFiltered, edgePropertiesFiltrered);
+    }
+
+    @Test
+    public void shouldGetCorrectEdgesPropertiesFilteredInMemoryFromGaffer1Store() throws StoreException {
+        shouldGetCorrectEdgesFilteredProperties(true, GAFFER_1_KEY_STORE, viewEdgesPropertiesFiltered, edgePropertiesFiltrered);
+    }
+
+    @Test
+    public void shouldGetCorrectEdgesPropertiesFilteredFromByteEntityStore() throws StoreException {
+        shouldGetCorrectEdgesFilteredProperties(false, BYTE_ENTITY_STORE, viewEdgesPropertiesFiltered, edgePropertiesFiltrered);
+    }
+
+    @Test
+    public void shouldGetCorrectEdgesPropertiesFilteredFromGaffer1Store() throws StoreException {
+        shouldGetCorrectEdgesFilteredProperties(false, GAFFER_1_KEY_STORE, viewEdgesPropertiesFiltered, edgePropertiesFiltrered);
+    }
+
+    @Test
+    public void shouldGetCorrectEdgesPropertiesEmptySetInMemoryFromByteEntityStore() throws StoreException {
+        shouldGetCorrectEdgesFilteredProperties(true, BYTE_ENTITY_STORE, viewEdgesPropertiesEmptySet, edgePropertiesEmptySet);
+    }
+
+    @Test
+    public void shouldGetCorrectEdgesPropertiesEmptySetInMemoryFromGaffer1Store() throws StoreException {
+        shouldGetCorrectEdgesFilteredProperties(true, GAFFER_1_KEY_STORE, viewEdgesPropertiesEmptySet, edgePropertiesEmptySet);
+    }
+
+    @Test
+    public void shouldGetCorrectEdgesPropertiesEmptySetFromByteEntityStore() throws StoreException {
+        shouldGetCorrectEdgesFilteredProperties(false, BYTE_ENTITY_STORE, viewEdgesPropertiesEmptySet, edgePropertiesEmptySet);
+    }
+
+    @Test
+    public void shouldGetCorrectEdgesPropertiesEmptySetFromGaffer1Store() throws StoreException {
+        shouldGetCorrectEdgesFilteredProperties(false, GAFFER_1_KEY_STORE, viewEdgesPropertiesEmptySet, edgePropertiesEmptySet);
+    }
+
+    private void shouldGetCorrectEdgesFilteredProperties(final boolean loadIntoMemory, final AccumuloStore store,
+                                                         final View view, final Element... expectedElements)
+            throws StoreException {
+        // Query for all edges in set {A0, A23}
+        final Set<EntityId> seeds = new HashSet<>();
+        seeds.add(AccumuloTestData.SEED_A0);
+        seeds.add(AccumuloTestData.SEED_A23);
+
+        final GetElementsWithinSet op = new GetElementsWithinSet.Builder()
+                .view(view)
+                .input(seeds)
+                .build();
+        final Set<Element> results = returnElementsFromOperation(store, op, new User(), loadIntoMemory);
+        assertThat(results)
+                .hasSize(1)
+                .containsOnly(expectedElements);
+    }
+
+    /*
      * Tests that the subtle case of setting outgoing or incoming edges only option is dealt with correctly.
      * When querying for edges within a set, the outgoing or incoming edges only needs to be turned off, for
      * two reasons. First, it doesn't make conceptual sense. If the each is from a member of set X to another
@@ -174,39 +247,34 @@ public class AccumuloIDWithinSetRetrieverTest {
      * returned, as it is not an edge out of B.
      */
     @Test
-    public void shouldDealWithOutgoingEdgesOnlyOptionGaffer1KeyStore() {
+    public void shouldDealWithOutgoingEdgesOnlyOptionGaffer1KeyStore() throws StoreException {
         shouldDealWithOutgoingEdgesOnlyOption(GAFFER_1_KEY_STORE);
     }
 
     @Test
-    public void shouldDealWithOutgoingEdgesOnlyOptionByteEntityStore() {
+    public void shouldDealWithOutgoingEdgesOnlyOptionByteEntityStore() throws StoreException {
         shouldDealWithOutgoingEdgesOnlyOption(BYTE_ENTITY_STORE);
     }
 
-    private void shouldDealWithOutgoingEdgesOnlyOption(final AccumuloStore store) {
-        try {
-            // Set outgoing edges only option, and query for the set {C,D}.
-            final Set<EntityId> seeds = new HashSet<>();
-            seeds.add(new EntitySeed("C"));
-            seeds.add(new EntitySeed("D"));
-            final Set<Element> expectedResults = new HashSet<>();
-            expectedResults.add(AccumuloTestData.EDGE_C_D_DIRECTED);
-            expectedResults.add(AccumuloTestData.EDGE_C_D_UNDIRECTED);
-            final GetElementsWithinSet op = new GetElementsWithinSet.Builder()
-                    .view(defaultView)
-                    .input(seeds)
-                    .build();
-            final Set<Element> results = returnElementsFromOperation(store, op, new User(), true);
-            assertEquals(expectedResults, results);
-        } catch (final StoreException e) {
-            fail("Failed to set up graph in Accumulo with exception: " + e);
-        }
+    private void shouldDealWithOutgoingEdgesOnlyOption(final AccumuloStore store) throws StoreException {
+
+        // Set outgoing edges only option, and query for the set {C,D}.
+        final Set<EntityId> seeds = new HashSet<>();
+        seeds.add(new EntitySeed("C"));
+        seeds.add(new EntitySeed("D"));
+        final Set<Element> expectedResults = new HashSet<>();
+        expectedResults.add(AccumuloTestData.EDGE_C_D_DIRECTED);
+        expectedResults.add(AccumuloTestData.EDGE_C_D_UNDIRECTED);
+        final GetElementsWithinSet op = new GetElementsWithinSet.Builder()
+                .view(defaultView)
+                .input(seeds)
+                .build();
+        final Set<Element> results = returnElementsFromOperation(store, op, new User(), true);
+        assertThat(expectedResults).isEqualTo(results);
     }
 
-    /**
+    /*
      * Tests that the directed edges only and undirected edges only options are respected.
-     *
-     * @throws StoreException if StoreException
      */
     @Test
     public void shouldDealWithDirectedEdgesOnlyInMemoryByteEntityStore() throws StoreException {
@@ -255,15 +323,13 @@ public class AccumuloIDWithinSetRetrieverTest {
         // Turn off directed / undirected edges only option and check get both the undirected and directed edge
         bothDirectedAndUndirectedOp.setDirectedType(DirectedType.EITHER);
         final Set<Element> bothDirectedAndUndirectedResults = returnElementsFromOperation(store, bothDirectedAndUndirectedOp, new User(), loadIntoMemory);
-        assertThat(bothDirectedAndUndirectedResults).contains(AccumuloTestData.EDGE_C_D_DIRECTED, (Element) AccumuloTestData.EDGE_C_D_UNDIRECTED);
+        assertThat(bothDirectedAndUndirectedResults).contains(AccumuloTestData.EDGE_C_D_DIRECTED, AccumuloTestData.EDGE_C_D_UNDIRECTED);
     }
 
-    /**
+    /*
      * Tests that false positives are filtered out. It does this by explicitly finding a false positive (i.e. something
      * that matches the Bloom filter but that wasn't put into the filter) and adding that to the data, and then
      * checking that isn't returned.
-     *
-     * @throws StoreException if StoreException
      */
     @Test
     public void shouldDealWithFalsePositivesInMemoryByteEntityStore() throws StoreException {
@@ -322,7 +388,7 @@ public class AccumuloIDWithinSetRetrieverTest {
         // Test random items against it - should only have to shouldRetrieveElementsInRangeBetweenSeeds MAX_SIZE_BLOOM_FILTER / 2 on average before find a
         // false positive (but impose an arbitrary limit to avoid an infinite loop if there's a problem).
         int count = 0;
-        int maxNumberOfTries = 50 * store.getProperties().getMaxBloomFilterToPassToAnIterator();
+        final int maxNumberOfTries = 50 * store.getProperties().getMaxBloomFilterToPassToAnIterator();
         while (count < maxNumberOfTries) {
             count++;
             if (filter.membershipTest(new Key(("" + count).getBytes()))) {
@@ -344,11 +410,9 @@ public class AccumuloIDWithinSetRetrieverTest {
         assertThat(results).contains(AccumuloTestData.EDGE_A0_A23, AccumuloTestData.A0_ENTITY, AccumuloTestData.A23_ENTITY);
     }
 
-    /**
+    /*
      * Tests that standard filtering (e.g. by summary type, or by time window, or to only receive entities) is still
      * applied.
-     *
-     * @throws StoreException if StoreException
      */
     @Test
     public void shouldStillApplyOtherFilterByteEntityStoreInMemoryEntities() throws StoreException {
@@ -463,53 +527,53 @@ public class AccumuloIDWithinSetRetrieverTest {
                 .contains(AccumuloTestData.A1_ENTITY, AccumuloTestData.A2_ENTITY);
     }
 
-    private static void setupGraph(final AccumuloStore store) {
+    private Set<Element> returnElementsFromOperation(final AccumuloStore store, final GetElementsWithinSet operation, final User user, final boolean loadIntoMemory) throws StoreException {
+        AccumuloRetriever<?, Element> retriever = null;
         try {
-            // Create table
-            // (this method creates the table, removes the versioning iterator, and adds the SetOfStatisticsCombiner iterator,
-            // and sets the age off iterator to age data off after it is more than ageOffTimeInMilliseconds milliseconds old).
-            TableUtils.createTable(store);
-
-            final Set<Element> data = new HashSet<>();
-            // Create edges A0 -> A1, A0 -> A2, ..., A0 -> A99. Also create an Entity for each.
-            final Entity entity = new Entity(TestGroups.ENTITY);
-            entity.setVertex("A0");
-            entity.putProperty(AccumuloPropertyNames.COUNT, 10000);
-            data.add(entity);
-            for (int i = 1; i < 100; i++) {
-                data.add(new Edge.Builder()
-                        .group(TestGroups.EDGE)
-                        .source("A0")
-                        .dest("A" + i)
-                        .directed(true)
-                        .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
-                        .property(AccumuloPropertyNames.COUNT, i)
-                        .build());
-
-                data.add(new Entity.Builder()
-                        .group(TestGroups.ENTITY)
-                        .vertex("A" + i)
-                        .property(AccumuloPropertyNames.COUNT, i)
-                        .build()
-                );
-            }
-            data.add(AccumuloTestData.EDGE_C_D_DIRECTED);
-            data.add(AccumuloTestData.EDGE_C_D_UNDIRECTED);
-            addElements(data, store, new User());
-        } catch (final TableExistsException | StoreException e) {
-            fail("Failed to set up graph in Accumulo with exception: " + e);
+            retriever = new AccumuloIDWithinSetRetriever(store, operation, user, loadIntoMemory);
+            return StreamSupport.stream(retriever.spliterator(), false).collect(Collectors.toSet());
+        } finally {
+            CloseableUtil.close(retriever);
         }
     }
 
-    private static void addElements(final Iterable<Element> data, final AccumuloStore store, final User user) {
-        try {
-            store.execute(new AddElements.Builder()
-                            .input(data)
-                            .build(),
-                    new Context(user));
-        } catch (final OperationException e) {
-            fail("Failed to set up graph in Accumulo with exception: " + e);
+    private static void setupGraph(final AccumuloStore store) throws OperationException, StoreException, TableExistsException {
+        // Create table
+        // (this method creates the table, removes the versioning iterator, and adds the SetOfStatisticsCombiner iterator,
+        // and sets the age off iterator to age data off after it is more than ageOffTimeInMilliseconds milliseconds old).
+        TableUtils.createTable(store);
+
+        final Set<Element> data = new HashSet<>();
+        // Create edges A0 -> A1, A0 -> A2, ..., A0 -> A99. Also create an Entity for each.
+        final Entity entity = new Entity(TestGroups.ENTITY);
+        entity.setVertex("A0");
+        entity.putProperty(AccumuloPropertyNames.COUNT, 10000);
+        data.add(entity);
+        for (int i = 1; i < 100; i++) {
+            data.add(new Edge.Builder()
+                    .group(TestGroups.EDGE)
+                    .source("A0")
+                    .dest("A" + i)
+                    .directed(true)
+                    .property(AccumuloPropertyNames.COLUMN_QUALIFIER, 1)
+                    .property(AccumuloPropertyNames.COUNT, i)
+                    .build());
+
+            data.add(new Entity.Builder()
+                    .group(TestGroups.ENTITY)
+                    .vertex("A" + i)
+                    .property(AccumuloPropertyNames.COUNT, i)
+                    .build());
         }
+        data.add(AccumuloTestData.EDGE_C_D_DIRECTED);
+        data.add(AccumuloTestData.EDGE_C_D_UNDIRECTED);
+        addElements(data, store, new User());
     }
 
+    private static void addElements(final Iterable<Element> data, final AccumuloStore store, final User user) throws OperationException {
+        store.execute(new AddElements.Builder()
+                .input(data)
+                .build(),
+                new Context(user));
+    }
 }

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/retriever/impl/AccumuloIDWithinSetRetrieverTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/retriever/impl/AccumuloIDWithinSetRetrieverTest.java
@@ -395,7 +395,9 @@ public class AccumuloIDWithinSetRetrieverTest {
             }
         }
 
-        assertThat(count).isNotEqualTo(maxNumberOfTries);
+        assertThat(count)
+                .isNotEqualTo(maxNumberOfTries)
+                .withFailMessage("Didn't find a false positive");
 
         // False positive is "" + count so create an edge from seeds to that
         final GetElementsWithinSet op = new GetElementsWithinSet.Builder().view(defaultView)


### PR DESCRIPTION
GetElementsWithinSet was not filtering view properties. The bug has been identified and fixed. Further tests have been added to check that the fix is functioning correctly.

# Related Issue

- Resolve #2562