### PR TITLE
gh-2556: Add HBaseStore deprecated tag, javadocs and note to README

### DIFF
--- a/store-implementation/hbase-store/README.md
+++ b/store-implementation/hbase-store/README.md
@@ -14,6 +14,11 @@ limitations under the License.
 
 The master copy of this page is the README in the hbase-store module.
 
+Deprecated
+===================
+The HBase Store has been [deprecated](https://github.com/gchq/Gaffer/issues/2556). It will be deleted during the Gaffer 2 development process and Gaffer v2.0.0 will not have a HBase Store implementation included with it.  
+
+
 HBase Store
 ===================
 

--- a/store-implementation/hbase-store/src/main/java/uk/gov/gchq/gaffer/hbasestore/HBaseStore.java
+++ b/store-implementation/hbase-store/src/main/java/uk/gov/gchq/gaffer/hbasestore/HBaseStore.java
@@ -93,7 +93,7 @@ import static uk.gov.gchq.gaffer.store.StoreTrait.VISIBILITY;
  * only one end of the edge.
  * </p>
  * @deprecated
- * The HBase Store will be removed in Gaffer 2.0.
+ * The HBase Store will be removed in Gaffer v2.0.0.
  */
 @Deprecated
 public class HBaseStore extends Store {

--- a/store-implementation/hbase-store/src/main/java/uk/gov/gchq/gaffer/hbasestore/HBaseStore.java
+++ b/store-implementation/hbase-store/src/main/java/uk/gov/gchq/gaffer/hbasestore/HBaseStore.java
@@ -92,7 +92,10 @@ import static uk.gov.gchq.gaffer.store.StoreTrait.VISIBILITY;
  * the rowId. This is to enable an edge to be found in a Range scan when providing
  * only one end of the edge.
  * </p>
+ * @deprecated
+ * The HBase Store will be removed in Gaffer 2.0.
  */
+@Deprecated
 public class HBaseStore extends Store {
     public static final Set<StoreTrait> TRAITS =
             Collections.unmodifiableSet(Sets.newHashSet(


### PR DESCRIPTION
# Related Issue

- Resolve #2556