### PR TITLE
Gh-2201: Add support for Accumulo 2 while retaining Accumulo 1

### DIFF
--- a/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/AbstractGetRDDHandler.java
+++ b/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/AbstractGetRDDHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Crown Copyright
+ * Copyright 2016-2022 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.sparkaccumulo.operation.handler;
 
 import org.apache.accumulo.core.client.IteratorSetting;

--- a/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/AbstractGetRDDHandler.java
+++ b/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/AbstractGetRDDHandler.java
@@ -17,7 +17,6 @@ package uk.gov.gchq.gaffer.sparkaccumulo.operation.handler;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
-import org.apache.accumulo.core.client.mapreduce.lib.impl.InputConfigurator;
 import org.apache.accumulo.core.data.Range;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.output.ByteArrayOutputStream;
@@ -29,6 +28,7 @@ import scala.runtime.AbstractFunction1;
 import uk.gov.gchq.gaffer.accumulostore.AccumuloStore;
 import uk.gov.gchq.gaffer.accumulostore.key.exception.IteratorSettingException;
 import uk.gov.gchq.gaffer.accumulostore.key.exception.RangeFactoryException;
+import uk.gov.gchq.gaffer.accumulostore.utils.LegacySupport;
 import uk.gov.gchq.gaffer.commonutil.pair.Pair;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.id.ElementId;
@@ -81,13 +81,13 @@ public abstract class AbstractGetRDDHandler<OP extends Output<O> & GraphFilters,
                     .getIteratorFactory()
                     .getQueryTimeAggregatorIteratorSetting(operation.getView(), accumuloStore);
             if (null != queryTimeAggregator) {
-                InputConfigurator.addIterator(AccumuloInputFormat.class, conf, queryTimeAggregator);
+                LegacySupport.InputConfigurator.addIterator(AccumuloInputFormat.class, conf, queryTimeAggregator);
             }
             final IteratorSetting propertyFilter = accumuloStore.getKeyPackage()
                     .getIteratorFactory()
                     .getElementPropertyRangeQueryFilter(derivedOperation);
             if (null != propertyFilter) {
-                InputConfigurator.addIterator(AccumuloInputFormat.class, conf, propertyFilter);
+                LegacySupport.InputConfigurator.addIterator(AccumuloInputFormat.class, conf, propertyFilter);
             }
         } catch (final StoreException | IteratorSettingException e) {
             throw new OperationException("Failed to update configuration", e);
@@ -117,7 +117,7 @@ public abstract class AbstractGetRDDHandler<OP extends Output<O> & GraphFilters,
                 throw new OperationException("Failed to add ranges to configuration", e);
             }
         }
-        InputConfigurator.setRanges(AccumuloInputFormat.class, conf, ranges);
+        LegacySupport.InputConfigurator.setRanges(AccumuloInputFormat.class, conf, ranges);
     }
 
     public <INPUT_OP extends Operation & GraphFilters & Input<Iterable<? extends Pair<? extends ElementId, ? extends ElementId>>>>
@@ -135,7 +135,7 @@ public abstract class AbstractGetRDDHandler<OP extends Output<O> & GraphFilters,
                 throw new OperationException("Failed to add ranges to configuration", e);
             }
         }
-        InputConfigurator.setRanges(AccumuloInputFormat.class, conf, ranges);
+        LegacySupport.InputConfigurator.setRanges(AccumuloInputFormat.class, conf, ranges);
     }
 
     protected Configuration getConfiguration(final OP operation) throws OperationException {

--- a/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/javardd/GetJavaRDDOfElementsHandler.java
+++ b/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/javardd/GetJavaRDDOfElementsHandler.java
@@ -16,7 +16,6 @@
 package uk.gov.gchq.gaffer.sparkaccumulo.operation.handler.javardd;
 
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
-import org.apache.accumulo.core.client.mapreduce.lib.impl.InputConfigurator;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.spark.api.java.JavaPairRDD;
@@ -27,6 +26,7 @@ import scala.Tuple2;
 
 import uk.gov.gchq.gaffer.accumulostore.AccumuloStore;
 import uk.gov.gchq.gaffer.accumulostore.inputformat.ElementInputFormat;
+import uk.gov.gchq.gaffer.accumulostore.utils.LegacySupport;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.operation.OperationException;
 import uk.gov.gchq.gaffer.spark.SparkContextUtil;
@@ -52,7 +52,7 @@ public class GetJavaRDDOfElementsHandler extends AbstractGetRDDHandler<GetJavaRD
         final JavaSparkContext sparkContext = JavaSparkContext.fromSparkContext(SparkContextUtil.getSparkSession(context, accumuloStore.getProperties()).sparkContext());
         final Configuration conf = getConfiguration(operation);
         // Use batch scan option when performing seeded operation
-        InputConfigurator.setBatchScan(AccumuloInputFormat.class, conf, true);
+        LegacySupport.InputConfigurator.setBatchScan(AccumuloInputFormat.class, conf, true);
         addIterators(accumuloStore, conf, context.getUser(), operation);
         addRanges(accumuloStore, conf, operation);
         final JavaPairRDD<Element, NullWritable> pairRDD = sparkContext.newAPIHadoopRDD(conf,

--- a/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/javardd/GetJavaRDDOfElementsHandler.java
+++ b/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/javardd/GetJavaRDDOfElementsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Crown Copyright
+ * Copyright 2016-2022 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.sparkaccumulo.operation.handler.javardd;
 
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;

--- a/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/javardd/GetJavaRDDOfElementsInRangesHandler.java
+++ b/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/javardd/GetJavaRDDOfElementsInRangesHandler.java
@@ -16,7 +16,6 @@
 package uk.gov.gchq.gaffer.sparkaccumulo.operation.handler.javardd;
 
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
-import org.apache.accumulo.core.client.mapreduce.lib.impl.InputConfigurator;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.spark.api.java.JavaPairRDD;
@@ -27,6 +26,7 @@ import scala.Tuple2;
 
 import uk.gov.gchq.gaffer.accumulostore.AccumuloStore;
 import uk.gov.gchq.gaffer.accumulostore.inputformat.ElementInputFormat;
+import uk.gov.gchq.gaffer.accumulostore.utils.LegacySupport;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.operation.OperationException;
 import uk.gov.gchq.gaffer.spark.SparkContextUtil;
@@ -52,7 +52,7 @@ public class GetJavaRDDOfElementsInRangesHandler extends AbstractGetRDDHandler<G
         final JavaSparkContext sparkContext = JavaSparkContext.fromSparkContext(SparkContextUtil.getSparkSession(context, accumuloStore.getProperties()).sparkContext());
         final Configuration conf = getConfiguration(operation);
         // Use batch scan option when performing seeded operation
-        InputConfigurator.setBatchScan(AccumuloInputFormat.class, conf, true);
+        LegacySupport.InputConfigurator.setBatchScan(AccumuloInputFormat.class, conf, true);
         addIterators(accumuloStore, conf, context.getUser(), operation);
         addRangesFromPairs(accumuloStore, conf, operation);
         final JavaPairRDD<Element, NullWritable> pairRDD = sparkContext.newAPIHadoopRDD(conf,

--- a/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/javardd/GetJavaRDDOfElementsInRangesHandler.java
+++ b/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/javardd/GetJavaRDDOfElementsInRangesHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Crown Copyright
+ * Copyright 2016-2022 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.sparkaccumulo.operation.handler.javardd;
 
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;

--- a/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/scalardd/GetRDDOfAllElementsHandler.java
+++ b/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/scalardd/GetRDDOfAllElementsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Crown Copyright
+ * Copyright 2016-2022 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.sparkaccumulo.operation.handler.scalardd;
 
 import org.apache.accumulo.core.client.IteratorSetting;

--- a/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/scalardd/GetRDDOfAllElementsHandler.java
+++ b/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/scalardd/GetRDDOfAllElementsHandler.java
@@ -17,7 +17,6 @@ package uk.gov.gchq.gaffer.sparkaccumulo.operation.handler.scalardd;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
-import org.apache.accumulo.core.client.mapreduce.lib.impl.InputConfigurator;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.hadoop.conf.Configuration;
@@ -35,6 +34,7 @@ import uk.gov.gchq.gaffer.accumulostore.inputformat.ElementInputFormat;
 import uk.gov.gchq.gaffer.accumulostore.key.AccumuloElementConverter;
 import uk.gov.gchq.gaffer.accumulostore.key.AccumuloKeyPackage;
 import uk.gov.gchq.gaffer.accumulostore.key.exception.IteratorSettingException;
+import uk.gov.gchq.gaffer.accumulostore.utils.LegacySupport;
 import uk.gov.gchq.gaffer.commonutil.CommonConstants;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.function.ElementTransformer;
@@ -110,7 +110,7 @@ public class GetRDDOfAllElementsHandler extends AbstractGetRDDHandler<GetRDDOfAl
         addIterators(accumuloStore, conf, context.getUser(), operation);
         final String useBatchScannerRDD = operation.getOption(USE_BATCH_SCANNER_RDD);
         if (Boolean.parseBoolean(useBatchScannerRDD)) {
-            InputConfigurator.setBatchScan(AccumuloInputFormat.class, conf, true);
+            LegacySupport.InputConfigurator.setBatchScan(AccumuloInputFormat.class, conf, true);
         }
         final RDD<Tuple2<Element, NullWritable>> pairRDD = SparkContextUtil.getSparkSession(context, accumuloStore.getProperties()).sparkContext().newAPIHadoopRDD(conf,
                 ElementInputFormat.class,
@@ -163,7 +163,7 @@ public class GetRDDOfAllElementsHandler extends AbstractGetRDDHandler<GetRDDOfAl
                 LOGGER.info("Not adding validation iterator as no validation functions are defined in the schema");
             } else {
                 LOGGER.info("Adding validation iterator");
-                InputConfigurator.addIterator(AccumuloInputFormat.class, conf, itrSetting);
+                LegacySupport.InputConfigurator.addIterator(AccumuloInputFormat.class, conf, itrSetting);
             }
         }
     }
@@ -175,7 +175,7 @@ public class GetRDDOfAllElementsHandler extends AbstractGetRDDHandler<GetRDDOfAl
             LOGGER.info("Adding aggregator iterator");
             final IteratorSetting itrSetting = accumuloStore
                     .getKeyPackage().getIteratorFactory().getAggregatorIteratorSetting(accumuloStore);
-            InputConfigurator.addIterator(AccumuloInputFormat.class, conf, itrSetting);
+            LegacySupport.InputConfigurator.addIterator(AccumuloInputFormat.class, conf, itrSetting);
         } else {
             LOGGER.info("Not adding aggregator iterator as aggregation is not enabled");
         }

--- a/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/scalardd/GetRDDOfElementsHandler.java
+++ b/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/scalardd/GetRDDOfElementsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Crown Copyright
+ * Copyright 2016-2022 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.sparkaccumulo.operation.handler.scalardd;
 
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;

--- a/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/scalardd/GetRDDOfElementsHandler.java
+++ b/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/scalardd/GetRDDOfElementsHandler.java
@@ -16,7 +16,6 @@
 package uk.gov.gchq.gaffer.sparkaccumulo.operation.handler.scalardd;
 
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
-import org.apache.accumulo.core.client.mapreduce.lib.impl.InputConfigurator;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.spark.SparkContext;
@@ -25,6 +24,7 @@ import scala.Tuple2;
 
 import uk.gov.gchq.gaffer.accumulostore.AccumuloStore;
 import uk.gov.gchq.gaffer.accumulostore.inputformat.ElementInputFormat;
+import uk.gov.gchq.gaffer.accumulostore.utils.LegacySupport;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.operation.OperationException;
 import uk.gov.gchq.gaffer.spark.SparkContextUtil;
@@ -52,7 +52,7 @@ public class GetRDDOfElementsHandler extends AbstractGetRDDHandler<GetRDDOfEleme
         final SparkContext sparkContext = SparkContextUtil.getSparkSession(context, accumuloStore.getProperties()).sparkContext();
         sparkContext.hadoopConfiguration().addResource(conf);
         // Use batch scan option when performing seeded operation
-        InputConfigurator.setBatchScan(AccumuloInputFormat.class, conf, true);
+        LegacySupport.InputConfigurator.setBatchScan(AccumuloInputFormat.class, conf, true);
         addIterators(accumuloStore, conf, context.getUser(), operation);
         addRanges(accumuloStore, conf, operation);
         final RDD<Tuple2<Element, NullWritable>> pairRDD = sparkContext.newAPIHadoopRDD(conf,

--- a/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/scalardd/GetRDDOfElementsInRangesHandler.java
+++ b/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/scalardd/GetRDDOfElementsInRangesHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Crown Copyright
+ * Copyright 2016-2022 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.sparkaccumulo.operation.handler.scalardd;
 
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;

--- a/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/scalardd/GetRDDOfElementsInRangesHandler.java
+++ b/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/handler/scalardd/GetRDDOfElementsInRangesHandler.java
@@ -16,7 +16,6 @@
 package uk.gov.gchq.gaffer.sparkaccumulo.operation.handler.scalardd;
 
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
-import org.apache.accumulo.core.client.mapreduce.lib.impl.InputConfigurator;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.spark.SparkContext;
@@ -25,6 +24,7 @@ import scala.Tuple2;
 
 import uk.gov.gchq.gaffer.accumulostore.AccumuloStore;
 import uk.gov.gchq.gaffer.accumulostore.inputformat.ElementInputFormat;
+import uk.gov.gchq.gaffer.accumulostore.utils.LegacySupport;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.operation.OperationException;
 import uk.gov.gchq.gaffer.spark.SparkContextUtil;
@@ -51,7 +51,7 @@ public class GetRDDOfElementsInRangesHandler extends AbstractGetRDDHandler<GetRD
         final SparkContext sparkContext = SparkContextUtil.getSparkSession(context, accumuloStore.getProperties()).sparkContext();
         sparkContext.hadoopConfiguration().addResource(conf);
         // Use batch scan option when performing seeded operation
-        InputConfigurator.setBatchScan(AccumuloInputFormat.class, conf, true);
+        LegacySupport.InputConfigurator.setBatchScan(AccumuloInputFormat.class, conf, true);
         addIterators(accumuloStore, conf, context.getUser(), operation);
         addRangesFromPairs(accumuloStore, conf, operation);
         final RDD<Tuple2<Element, NullWritable>> pairRDD = sparkContext.newAPIHadoopRDD(conf,

--- a/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/rfilereaderrdd/RFileReaderIterator.java
+++ b/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/rfilereaderrdd/RFileReaderIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Crown Copyright
+ * Copyright 2017-2022 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.sparkaccumulo.operation.rfilereaderrdd;
 
 import org.apache.accumulo.core.client.IteratorSetting;

--- a/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/rfilereaderrdd/RFileReaderIterator.java
+++ b/library/spark/spark-accumulo-library/src/main/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/rfilereaderrdd/RFileReaderIterator.java
@@ -17,16 +17,13 @@ package uk.gov.gchq.gaffer.sparkaccumulo.operation.rfilereaderrdd;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
-import org.apache.accumulo.core.client.mapreduce.lib.impl.InputConfigurator;
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
-import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.file.blockfile.impl.CachableBlockFile;
 import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.IteratorUtil;
@@ -44,6 +41,8 @@ import org.apache.spark.TaskContext;
 import org.apache.spark.util.TaskCompletionListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import uk.gov.gchq.gaffer.accumulostore.utils.LegacySupport;
 
 import java.io.IOException;
 import java.util.AbstractMap;
@@ -103,10 +102,9 @@ public class RFileReaderIterator implements java.util.Iterator<Map.Entry<Key, Va
     private void init() throws IOException {
         final AccumuloTablet accumuloTablet = (AccumuloTablet) partition;
         LOGGER.info("Initialising RFileReaderIterator for files {}", StringUtils.join(accumuloTablet.getFiles(), ','));
-        final AccumuloConfiguration accumuloConfiguration = SiteConfiguration.getInstance();
 
         // Required column families according to the configuration
-        final Set<ByteSequence> requiredColumnFamilies = InputConfigurator
+        final Set<ByteSequence> requiredColumnFamilies = LegacySupport.InputConfigurator
                 .getFetchedColumns(AccumuloInputFormat.class, configuration)
                 .stream()
                 .map(Pair::getFirst)
@@ -120,8 +118,8 @@ public class RFileReaderIterator implements java.util.Iterator<Map.Entry<Key, Va
             final Path path = new Path(filename);
             final FileSystem fs = path.getFileSystem(configuration);
 
-            final RFile.Reader rFileReader = new RFile.Reader(
-                    new CachableBlockFile.Reader(fs, path, configuration, null, null, accumuloConfiguration));
+            final RFile.Reader rFileReader = LegacySupport.BackwardsCompatibleCachableBlockFileReader.create(fs, path, configuration);
+
             iterators.add(rFileReader);
         }
         mergedIterator = new MultiIterator(iterators, true);
@@ -130,8 +128,6 @@ public class RFileReaderIterator implements java.util.Iterator<Map.Entry<Key, Va
         if (null != auths) {
             final Authorizations authorizations = new Authorizations(auths.toArray(new String[auths.size()]));
             final SortedKeyValueIterator<Key, Value> visibilityFilter = VisibilityFilter.wrap(mergedIterator, authorizations, new byte[]{});
-            final IteratorSetting visibilityIteratorSetting = new IteratorSetting(1, "auth", VisibilityFilter.class);
-            visibilityFilter.init(mergedIterator, visibilityIteratorSetting.getOptions(), null);
             iteratorAfterIterators = visibilityFilter;
             LOGGER.info("Set authorizations to {}", authorizations);
         } else {
@@ -210,7 +206,7 @@ public class RFileReaderIterator implements java.util.Iterator<Map.Entry<Key, Va
     }
 
     private List<IteratorSetting> getIteratorSettings() {
-        return InputConfigurator.getIterators(AccumuloInputFormat.class, configuration);
+        return LegacySupport.InputConfigurator.getIterators(AccumuloInputFormat.class, configuration);
     }
 
     private void close() {

--- a/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/integration/rfilereaderrdd/RFileReaderRddIT.java
+++ b/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/integration/rfilereaderrdd/RFileReaderRddIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Crown Copyright
+ * Copyright 2017-2022 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.sparkaccumulo.integration.rfilereaderrdd;
 
 import com.google.common.collect.Sets;

--- a/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/integration/rfilereaderrdd/RFileReaderRddIT.java
+++ b/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/integration/rfilereaderrdd/RFileReaderRddIT.java
@@ -26,7 +26,6 @@ import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
-import org.apache.accumulo.core.client.mapreduce.lib.impl.InputConfigurator;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.iterators.user.GrepIterator;
 import org.apache.accumulo.core.util.Pair;
@@ -38,6 +37,7 @@ import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import uk.gov.gchq.gaffer.accumulostore.utils.LegacySupport;
 import uk.gov.gchq.gaffer.spark.SparkSessionProvider;
 import uk.gov.gchq.gaffer.sparkaccumulo.operation.handler.MiniAccumuloClusterProvider;
 import uk.gov.gchq.gaffer.sparkaccumulo.operation.rfilereaderrdd.RFileReaderRDD;
@@ -200,7 +200,7 @@ public class RFileReaderRddIT {
         connector.tableOperations().compact(tableName, new CompactionConfig());
         Thread.sleep(1000L);
 
-        InputConfigurator.fetchColumns(AccumuloInputFormat.class, configuration,
+        LegacySupport.InputConfigurator.fetchColumns(AccumuloInputFormat.class, configuration,
                 Sets.newHashSet(new Pair<>(new Text("CF"), new Text("CQ"))));
 
         return cluster;

--- a/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/rfilereaderrdd/RFileReaderIteratorTest.java
+++ b/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/rfilereaderrdd/RFileReaderIteratorTest.java
@@ -75,7 +75,7 @@ public class RFileReaderIteratorTest {
 
         assertThatExceptionOfType(RuntimeException.class)
                 .isThrownBy(() -> new RFileReaderIterator(partition, taskContext, new Configuration(), auths))
-                .withMessage("IOException initialising RFileReaderIterator");
+                .withStackTraceContaining("java.io.FileNotFoundException: File invalid file does not exist");
     }
 
     @Test

--- a/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/rfilereaderrdd/RFileReaderIteratorTest.java
+++ b/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/rfilereaderrdd/RFileReaderIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Crown Copyright
+ * Copyright 2020-2022 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/utils/AccumuloKeyRangePartitionerTest.java
+++ b/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/utils/AccumuloKeyRangePartitionerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Crown Copyright
+ * Copyright 2018-2022 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/utils/AccumuloKeyRangePartitionerTest.java
+++ b/library/spark/spark-accumulo-library/src/test/java/uk/gov/gchq/gaffer/sparkaccumulo/operation/utils/AccumuloKeyRangePartitionerTest.java
@@ -18,7 +18,6 @@ package uk.gov.gchq.gaffer.sparkaccumulo.operation.utils;
 
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.admin.TableOperations;
-import org.apache.accumulo.core.client.impl.ConnectorImpl;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +36,7 @@ public class AccumuloKeyRangePartitionerTest {
     public void shouldGetSplitsInOrder() throws Exception {
         // Given
         final AccumuloStore store = mock(AccumuloStore.class);
-        final Connector connector = mock(ConnectorImpl.class);
+        final Connector connector = mock(Connector.class);
         final TableOperations tableOperations = mock(TableOperations.class);
         final String testTableName = "tableName";
         final List<Text> unsortedTextCollection = Arrays.asList(new Text("z"), new Text("f"), new Text("g"), new Text("a"));

--- a/pom.xml
+++ b/pom.xml
@@ -61,9 +61,9 @@
         <spark.version>${spark.minor.version}.5</spark.version>
 
         <koryphe.version>2.4.0</koryphe.version>
-        <accumulo.version>1.9.3</accumulo.version>
+        <accumulo.version>2.0.1</accumulo.version>
         <avro.version>1.8.2</avro.version>
-        <hadoop.version>2.6.5</hadoop.version>
+        <hadoop.version>3.3.2</hadoop.version>
         <jackson.version>2.12.6</jackson.version>
         <jackson.minor.version>2.11</jackson.minor.version>
 
@@ -76,8 +76,9 @@
         <commons-math.version>2.2</commons-math.version>
         <commons-math3.version>3.6.1</commons-math3.version>
         <commons-csv.version>1.9.0</commons-csv.version>
+        <commons-text.version>1.9</commons-text.version>
         <curator.version>2.11.1</curator.version>
-        <guava.version>13.0.1</guava.version>
+        <guava.version>29.0-jre</guava.version>
         <javassist.version>3.28.0-GA</javassist.version>
         <javax-activation.version>1.1.1</javax-activation.version>
         <javax-annotation.version>1.3.2</javax-annotation.version>
@@ -227,6 +228,11 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-math</artifactId>
                 <version>${commons-math.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${commons-text.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.activation</groupId>
@@ -705,6 +711,11 @@
                     <exclusion>
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <!-- Conflicts with jersey -->
+                    <exclusion>
+                        <groupId>org.apache.accumulo</groupId>
+                        <artifactId>accumulo-monitor</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1497,6 +1508,20 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>classic</id>
+            <activation>
+                <property>
+                    <name>classic</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <accumulo.version>1.9.3</accumulo.version>
+                <hadoop.version>2.6.5</hadoop.version>
+                <guava.version>13.0.1</guava.version>
+            </properties>
         </profile>
         <profile>
             <id>java11</id>

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/AccumuloStore.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/AccumuloStore.java
@@ -25,7 +25,6 @@ import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
-import org.apache.accumulo.core.client.mapreduce.lib.impl.InputConfigurator;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
@@ -62,6 +61,7 @@ import uk.gov.gchq.gaffer.accumulostore.operation.impl.GetElementsInRanges;
 import uk.gov.gchq.gaffer.accumulostore.operation.impl.GetElementsWithinSet;
 import uk.gov.gchq.gaffer.accumulostore.operation.impl.SummariseGroupOverRanges;
 import uk.gov.gchq.gaffer.accumulostore.utils.AccumuloStoreConstants;
+import uk.gov.gchq.gaffer.accumulostore.utils.LegacySupport;
 import uk.gov.gchq.gaffer.accumulostore.utils.TableUtils;
 import uk.gov.gchq.gaffer.commonutil.CommonConstants;
 import uk.gov.gchq.gaffer.commonutil.pair.Pair;
@@ -243,7 +243,7 @@ public class AccumuloStore extends Store {
 
             // Table name
             LOGGER.info("Updating configuration with table name of {}", getTableName());
-            InputConfigurator.setInputTableName(AccumuloInputFormat.class,
+            LegacySupport.InputConfigurator.setInputTableName(AccumuloInputFormat.class,
                     conf,
                     getTableName());
             // User
@@ -255,7 +255,7 @@ public class AccumuloStore extends Store {
             } else {
                 authorisations = new Authorizations();
             }
-            InputConfigurator.setScanAuthorizations(AccumuloInputFormat.class,
+            LegacySupport.InputConfigurator.setScanAuthorizations(AccumuloInputFormat.class,
                     conf,
                     authorisations);
             LOGGER.info("Updating configuration with authorizations of {}", authorisations);
@@ -275,7 +275,7 @@ public class AccumuloStore extends Store {
                         .concat(view.getEntityGroups().stream(), view.getEdgeGroups().stream())
                         .map(g -> new org.apache.accumulo.core.util.Pair<>(new Text(g), (Text) null))
                         .collect(Collectors.toSet());
-                InputConfigurator.fetchColumns(AccumuloInputFormat.class, conf, columnFamilyColumnQualifierPairs);
+                LegacySupport.InputConfigurator.fetchColumns(AccumuloInputFormat.class, conf, columnFamilyColumnQualifierPairs);
                 LOGGER.info("Updated configuration with column family/qualifiers of {}",
                         StringUtils.join(columnFamilyColumnQualifierPairs, ','));
 
@@ -284,21 +284,21 @@ public class AccumuloStore extends Store {
                         .getIteratorFactory()
                         .getElementPreAggregationFilterIteratorSetting(view, this);
                 if (nonNull(elementPreFilter)) {
-                    InputConfigurator.addIterator(AccumuloInputFormat.class, conf, elementPreFilter);
+                    LegacySupport.InputConfigurator.addIterator(AccumuloInputFormat.class, conf, elementPreFilter);
                     LOGGER.info("Added pre-aggregation filter iterator of {}", elementPreFilter);
                 }
                 final IteratorSetting elementPostFilter = getKeyPackage()
                         .getIteratorFactory()
                         .getElementPostAggregationFilterIteratorSetting(view, this);
                 if (nonNull(elementPostFilter)) {
-                    InputConfigurator.addIterator(AccumuloInputFormat.class, conf, elementPostFilter);
+                    LegacySupport.InputConfigurator.addIterator(AccumuloInputFormat.class, conf, elementPostFilter);
                     LOGGER.info("Added post-aggregation filter iterator of {}", elementPostFilter);
                 }
                 final IteratorSetting edgeEntityDirFilter = getKeyPackage()
                         .getIteratorFactory()
                         .getEdgeEntityDirectionFilterIteratorSetting(graphFilters);
                 if (nonNull(edgeEntityDirFilter)) {
-                    InputConfigurator.addIterator(AccumuloInputFormat.class, conf, edgeEntityDirFilter);
+                    LegacySupport.InputConfigurator.addIterator(AccumuloInputFormat.class, conf, edgeEntityDirFilter);
                     LOGGER.info("Added edge direction filter iterator of {}", edgeEntityDirFilter);
                 }
             }
@@ -333,16 +333,16 @@ public class AccumuloStore extends Store {
 
     protected void addUserToConfiguration(final Configuration conf) throws AccumuloSecurityException {
         LOGGER.info("Updating configuration with user of {}", getProperties().getUser());
-        InputConfigurator.setConnectorInfo(AccumuloInputFormat.class,
+        LegacySupport.InputConfigurator.setConnectorInfo(AccumuloInputFormat.class,
                 conf,
                 getProperties().getUser(),
                 new PasswordToken(getProperties().getPassword()));
     }
 
     protected void addZookeeperToConfiguration(final Configuration conf) {
-        InputConfigurator.setZooKeeperInstance(AccumuloInputFormat.class,
+        LegacySupport.InputConfigurator.setZooKeeperInstance(AccumuloInputFormat.class,
                 conf,
-                new ClientConfiguration()
+                ClientConfiguration.create()
                         .withInstance(getProperties().getInstance())
                         .withZkHosts(getProperties().getZookeepers()));
     }

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/operation/hdfs/handler/job/partitioner/GafferRangePartitioner.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/operation/hdfs/handler/job/partitioner/GafferRangePartitioner.java
@@ -16,7 +16,6 @@
 package uk.gov.gchq.gaffer.accumulostore.operation.hdfs.handler.job.partitioner;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.apache.accumulo.core.client.mapreduce.lib.impl.DistributedCacheHelper;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -91,7 +90,7 @@ public class GafferRangePartitioner extends Partitioner<Text, Writable> implemen
     private synchronized Text[] getCutPoints() throws IOException {
         if (null == cutPointArray) {
             final String cutFileName = conf.get(CUTFILE_KEY);
-            final Path[] cf = DistributedCacheHelper.getLocalCacheFiles(conf);
+            final Path[] cf = Job.getInstance(conf).getLocalCacheFiles();
             if (null != cf) {
                 for (final Path path : cf) {
                     if (path.toUri().getPath().endsWith(cutFileName.substring(cutFileName.lastIndexOf('/')))) {
@@ -142,7 +141,7 @@ public class GafferRangePartitioner extends Partitioner<Text, Writable> implemen
      */
     public static void setSplitFile(final Job job, final String file) {
         final URI uri = new Path(file).toUri();
-        DistributedCacheHelper.addCacheFile(uri, job.getConfiguration());
+        job.addCacheFile(uri);
         job.getConfiguration().set(CUTFILE_KEY, uri.getPath());
     }
 

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/operation/hdfs/handler/job/partitioner/GafferRangePartitioner.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/operation/hdfs/handler/job/partitioner/GafferRangePartitioner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Crown Copyright
+ * Copyright 2017-2022 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.accumulostore.operation.hdfs.handler.job.partitioner;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/IngestUtils.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/IngestUtils.java
@@ -20,7 +20,6 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.client.mock.MockConnector;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -81,12 +80,6 @@ public final class IngestUtils {
         }
         // This should have returned at most maxSplits splits, but this is not implemented properly in MockInstance.
         if (splits.size() > maxSplits) {
-            if (conn instanceof MockConnector) {
-                LOGGER.info("Manually reducing the number of splits to {} due to MockInstance not implementing"
-                        + " listSplits(table, maxSplits) properly", maxSplits);
-            } else {
-                LOGGER.info("Manually reducing the number of splits to {} (number of splits was {})", maxSplits, splits.size());
-            }
             final Collection<Text> filteredSplits = new TreeSet<>();
             final int outputEveryNth = splits.size() / maxSplits;
             LOGGER.info("Outputting every {}-th split from {} total", outputEveryNth, splits.size());

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/IngestUtils.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/IngestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Crown Copyright
+ * Copyright 2016-2022 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.accumulostore.utils;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/LegacySupport.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/LegacySupport.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.gchq.gaffer.accumulostore.utils;
 
 import org.apache.accumulo.core.client.ClientConfiguration;

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/LegacySupport.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/LegacySupport.java
@@ -1,0 +1,309 @@
+package uk.gov.gchq.gaffer.accumulostore.utils;
+
+import org.apache.accumulo.core.client.ClientConfiguration;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
+import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.file.FileOperations;
+import org.apache.accumulo.core.file.FileSKVIterator;
+import org.apache.accumulo.core.file.FileSKVWriter;
+import org.apache.accumulo.core.file.blockfile.impl.CachableBlockFile;
+import org.apache.accumulo.core.file.rfile.RFile;
+import org.apache.accumulo.core.file.rfile.bcfile.BCFile;
+import org.apache.accumulo.core.file.rfile.bcfile.Compression;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.util.Pair;
+import org.apache.accumulo.core.util.ratelimit.NullRateLimiter;
+import org.apache.accumulo.core.util.ratelimit.RateLimiter;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A utility class to provide static methods which map to a single
+ * import. This is to mitigate Accumulo code and package name changes
+ * between versions 1.x and 2.x of Accumulo. These changes would
+ * otherwise require duplication of any modules which imported
+ * Accumulo packages which had changed names or required code changes
+ * to remain compatible with both versions of Accumulo.
+ */
+public class LegacySupport {
+    private static String accumuloVersion;
+    private static Class<?> inputConfiguratorClazz;
+    private static Class<?> noCryptoServiceClazz;
+    private static Class<?> cryptoServiceClazz;
+    private static Class<?> cachableBuilderClazz;
+    private static Class<?> fileOperationsReaderBuilderClazz;
+    private static Class<?> fileOperationsWriterBuilderClazz;
+    private static Class<?> fsdataoutputstreamclazz;
+    private static Class<?> siteConfigurationClazz;
+    private static Class<?> needsFileClazz;
+    private static Class<?> needsFileOrOuputStreamClazz;
+    private static Class<?> needsTableConfigurationClazz;
+    private static Class<?> openWriterOperationBuilderClazz;
+    private static Class<?> openReaderOperationBuilderClazz;
+    private static Class<?> cachableBlockFileWriterClazz;
+    private static Class<?> blockFileWriterClazz;
+    private static Class<?> blockFileReaderClazz;
+    private static Class<?> blockCacheClazz;
+
+    static {
+        try {
+            inputConfiguratorClazz = Class.forName("org.apache.accumulo.core.clientImpl.mapreduce.lib.InputConfigurator");
+            noCryptoServiceClazz = Class.forName("org.apache.accumulo.core.cryptoImpl.NoCryptoService");
+            cryptoServiceClazz = Class.forName("org.apache.accumulo.core.spi.crypto.CryptoService");
+            cachableBuilderClazz = Class.forName("org.apache.accumulo.core.file.blockfile.impl.CachableBlockFile$CachableBuilder");
+            fileOperationsReaderBuilderClazz = Class.forName("org.apache.accumulo.core.file.FileOperations$ReaderBuilder");
+            fileOperationsWriterBuilderClazz = Class.forName("org.apache.accumulo.core.file.FileOperations$WriterBuilder");
+            fsdataoutputstreamclazz = Class.forName("org.apache.hadoop.fs.FSDataOutputStream");
+            accumuloVersion = "2";
+        } catch (final ClassNotFoundException e) {
+            // Fall back to using Accumulo 1 classes
+            accumuloVersion = "1";
+        }
+        if (accumuloVersion == "1") {
+            try {
+                inputConfiguratorClazz = Class.forName("org.apache.accumulo.core.client.mapreduce.lib.impl.InputConfigurator");
+                siteConfigurationClazz = Class.forName("org.apache.accumulo.core.conf.SiteConfiguration");
+                needsFileClazz = Class.forName("org.apache.accumulo.core.file.FileOperations$NeedsFile");
+                needsFileOrOuputStreamClazz = Class.forName("org.apache.accumulo.core.file.FileOperations$NeedsFileOrOuputStream");
+                needsTableConfigurationClazz = Class.forName("org.apache.accumulo.core.file.FileOperations$NeedsTableConfiguration");
+                openWriterOperationBuilderClazz = Class.forName("org.apache.accumulo.core.file.FileOperations$OpenWriterOperationBuilder");
+                openReaderOperationBuilderClazz = Class.forName("org.apache.accumulo.core.file.FileOperations$OpenReaderOperationBuilder");
+                cachableBlockFileWriterClazz = Class.forName("org.apache.accumulo.core.file.blockfile.impl.CachableBlockFile$Writer");
+                blockFileWriterClazz = Class.forName("org.apache.accumulo.core.file.blockfile.BlockFileWriter");
+                blockFileReaderClazz = Class.forName("org.apache.accumulo.core.file.blockfile.BlockFileReader");
+                blockCacheClazz = Class.forName("org.apache.accumulo.core.file.blockfile.cache.BlockCache");
+            } catch (final ClassNotFoundException e) {
+                throw new RuntimeException("Failed initialing Accumulo support classes. Ensure Accumulo version is supported", e);
+            }
+        }
+    }
+    public static class InputConfigurator {
+        public static void setScanAuthorizations(final Class<?> implementingClass, final Configuration conf, final Authorizations auths) {
+            try {
+                Method setScanAuthorizations = inputConfiguratorClazz.getMethod("setScanAuthorizations", Class.class, Configuration.class, Authorizations.class);
+                setScanAuthorizations.invoke(null, implementingClass, conf, auths);
+            } catch (final Exception e) {
+                throw new RuntimeException("Failed initialing Accumulo class. Ensure Accumulo version is supported", e);
+            }
+        }
+
+        public static void setInputTableName(final Class<AccumuloInputFormat> accumuloInputFormatClass, final Configuration conf, final String tableName) {
+            try {
+                Method setInputTableName = inputConfiguratorClazz.getMethod("setInputTableName", Class.class, Configuration.class, String.class);
+                setInputTableName.invoke(null, accumuloInputFormatClass, conf, tableName);
+            } catch (final Exception e) {
+                throw new RuntimeException("Failed initialing Accumulo class. Ensure Accumulo version is supported", e);
+            }
+        }
+
+        public static void fetchColumns(final Class<AccumuloInputFormat> accumuloInputFormatClass, final Configuration conf,
+                                        final Collection<Pair<Text, Text>> columnFamilyColumnQualifierPairs) {
+            try {
+                Method fetchColumns = inputConfiguratorClazz.getMethod("fetchColumns", Class.class, Configuration.class, Collection.class);
+                fetchColumns.invoke(null, accumuloInputFormatClass, conf, columnFamilyColumnQualifierPairs);
+            } catch (final Exception e) {
+                throw new RuntimeException("Failed initialing Accumulo class. Ensure Accumulo version is supported", e);
+            }
+        }
+
+        public static void addIterator(final Class<AccumuloInputFormat> accumuloInputFormatClass, final Configuration conf, final IteratorSetting elementPreFilter) {
+            try {
+                Method addIterator = inputConfiguratorClazz.getMethod("addIterator", Class.class, Configuration.class, IteratorSetting.class);
+                addIterator.invoke(null, accumuloInputFormatClass, conf, elementPreFilter);
+            } catch (final Exception e) {
+                throw new RuntimeException("Failed initialing Accumulo class. Ensure Accumulo version is supported", e);
+            }
+        }
+
+        public static void setConnectorInfo(final Class<AccumuloInputFormat> accumuloInputFormatClass, final Configuration conf, final String user, final AuthenticationToken token) {
+            try {
+                Method setConnectorInfo = inputConfiguratorClazz.getMethod("setConnectorInfo", Class.class, Configuration.class, String.class, AuthenticationToken.class);
+                setConnectorInfo.invoke(null, accumuloInputFormatClass, conf, user, token);
+            } catch (final Exception e) {
+                throw new RuntimeException("Failed initialing Accumulo class. Ensure Accumulo version is supported", e);
+            }
+        }
+
+        public static void setZooKeeperInstance(final Class<AccumuloInputFormat> accumuloInputFormatClass, final Configuration conf, final ClientConfiguration withZkHosts) {
+            try {
+                Method setZooKeeperInstance = inputConfiguratorClazz.getMethod("setZooKeeperInstance", Class.class, Configuration.class, ClientConfiguration.class);
+                setZooKeeperInstance.invoke(null, accumuloInputFormatClass, conf, withZkHosts);
+            } catch (final Exception e) {
+                throw new RuntimeException("Failed initialing Accumulo class. Ensure Accumulo version is supported", e);
+            }
+        }
+
+        public static void setBatchScan(final Class<AccumuloInputFormat> accumuloInputFormatClass, final Configuration conf, final boolean enableFeature) {
+            try {
+                Method setBatchScan = inputConfiguratorClazz.getMethod("setBatchScan", Class.class, Configuration.class, boolean.class);
+                setBatchScan.invoke(null, accumuloInputFormatClass, conf, enableFeature);
+            } catch (final Exception e) {
+                throw new RuntimeException("Failed initialing Accumulo class. Ensure Accumulo version is supported", e);
+            }
+        }
+
+        public static void setRanges(final Class<AccumuloInputFormat> accumuloInputFormatClass, final Configuration conf, final Collection<Range> ranges) {
+            try {
+                Method setRanges = inputConfiguratorClazz.getMethod("setRanges", Class.class, Configuration.class, Collection.class);
+                setRanges.invoke(null, accumuloInputFormatClass, conf, ranges);
+            } catch (final Exception e) {
+                throw new RuntimeException("Failed initialing Accumulo class. Ensure Accumulo version is supported", e);
+            }
+        }
+
+        public static List<IteratorSetting> getIterators(final Class<AccumuloInputFormat> accumuloInputFormatClass, final Configuration conf) {
+            try {
+                Method getIterators = inputConfiguratorClazz.getMethod("getIterators", Class.class, Configuration.class);
+                return (List<IteratorSetting>) getIterators.invoke(null, accumuloInputFormatClass, conf);
+            } catch (final Exception e) {
+                throw new RuntimeException("Failed initialing Accumulo class. Ensure Accumulo version is supported", e);
+            }
+        }
+
+        public static Set<Pair<Text, Text>> getFetchedColumns(final Class<AccumuloInputFormat> accumuloInputFormatClass, final Configuration conf) {
+            try {
+                Method getFetchedColumns = inputConfiguratorClazz.getMethod("getFetchedColumns", Class.class, Configuration.class);
+                return (Set<Pair<Text, Text>>) getFetchedColumns.invoke(null, accumuloInputFormatClass, conf);
+            } catch (final Exception e) {
+                throw new RuntimeException("Failed initialing Accumulo class. Ensure Accumulo version is supported", e);
+            }
+        }
+    }
+
+    public static class BackwardsCompatibleReaderBuilder {
+        public static FileSKVIterator create(final String filename, final FileSystem fs, final Configuration fsConf,
+                                             final AccumuloConfiguration tableConfiguration, final boolean seekBeginning) {
+            final Method forFile, withTableConfiguration, seekToBeginning, builderBuild;
+            Object builder = FileOperations.getInstance().newReaderBuilder();
+            try {
+                if (accumuloVersion == "2") {
+                    forFile = fileOperationsReaderBuilderClazz.getMethod("forFile", String.class, FileSystem.class, Configuration.class, cryptoServiceClazz);
+                    withTableConfiguration = fileOperationsReaderBuilderClazz.getMethod("withTableConfiguration", AccumuloConfiguration.class);
+                    seekToBeginning = fileOperationsReaderBuilderClazz.getMethod("seekToBeginning", boolean.class);
+                    builderBuild = fileOperationsReaderBuilderClazz.getMethod("build");
+                    builder = forFile.invoke(builder, filename, fs, fsConf, noCryptoServiceClazz.getConstructor().newInstance());
+                } else {
+                    forFile = needsFileClazz.getMethod("forFile", String.class, FileSystem.class, Configuration.class);
+                    withTableConfiguration = needsTableConfigurationClazz.getMethod("withTableConfiguration", AccumuloConfiguration.class);
+                    seekToBeginning = openReaderOperationBuilderClazz.getMethod("seekToBeginning", boolean.class);
+                    builderBuild = openReaderOperationBuilderClazz.getMethod("build");
+                    builder = forFile.invoke(builder, filename, fs, fsConf);
+                }
+                builder = seekToBeginning.invoke(builder, seekBeginning);
+                builder = withTableConfiguration.invoke(builder, tableConfiguration);
+                return (FileSKVIterator) builderBuild.invoke(builder);
+            } catch (final Exception e) {
+                throw new RuntimeException("Failed initialing Accumulo class. Ensure Accumulo version is supported", e);
+            }
+        }
+    }
+
+    public static class BackwardsCompatibleWriterBuilder {
+        public static FileSKVWriter create(final String filename, final FileSystem fs, final Configuration fsConf,
+                                           final AccumuloConfiguration tableConfiguration) {
+            final Method forFile, withTableConfiguration, builderBuild;
+            Object builder = FileOperations.getInstance().newWriterBuilder();
+            try {
+                if (accumuloVersion == "2") {
+                    forFile = fileOperationsWriterBuilderClazz.getMethod("forFile", String.class, FileSystem.class, Configuration.class, cryptoServiceClazz);
+                    withTableConfiguration = fileOperationsWriterBuilderClazz.getMethod("withTableConfiguration", AccumuloConfiguration.class);
+                    builderBuild = fileOperationsWriterBuilderClazz.getMethod("build");
+                    builder = forFile.invoke(builder, filename, fs, fsConf, noCryptoServiceClazz.getConstructor().newInstance());
+                } else {
+                    forFile = needsFileOrOuputStreamClazz.getMethod("forFile", String.class, FileSystem.class, Configuration.class);
+                    withTableConfiguration = needsTableConfigurationClazz.getMethod("withTableConfiguration", AccumuloConfiguration.class);
+                    builderBuild = openWriterOperationBuilderClazz.getMethod("build");
+                    builder = forFile.invoke(builder, filename, fs, fsConf);
+                }
+                builder = withTableConfiguration.invoke(builder, tableConfiguration);
+                return (FileSKVWriter) builderBuild.invoke(builder);
+            } catch (final Exception e) {
+                throw new RuntimeException("Failed initialing Accumulo class. Ensure Accumulo version is supported", e);
+            }
+        }
+    }
+
+    public static class BackwardsCompatibleCachableBlockFileReader {
+        public static RFile.Reader create(final FileSystem fs, final Path path, final Configuration fsConf) {
+            final RFile.Reader reader;
+            try {
+                if (accumuloVersion == "2") {
+                    Object builder = cachableBuilderClazz.getConstructor().newInstance();
+                    Method fsPathMethod = cachableBuilderClazz.getMethod("fsPath", FileSystem.class, Path.class);
+                    Method confMethod = cachableBuilderClazz.getMethod("conf", Configuration.class);
+                    Method cryptoServiceMethod = cachableBuilderClazz.getMethod("cryptoService", cryptoServiceClazz);
+                    fsPathMethod.invoke(builder, fs, path);
+                    confMethod.invoke(builder, fsConf);
+                    cryptoServiceMethod.invoke(builder, noCryptoServiceClazz.getConstructor().newInstance());
+                    reader = RFile.Reader.class.getConstructor(cachableBuilderClazz).newInstance(builder);
+                } else {
+                    AccumuloConfiguration accumuloConfiguration = (AccumuloConfiguration) siteConfigurationClazz.getMethod("getInstance").invoke(null);
+                    Constructor cachableBlockFileReaderConstructor = CachableBlockFile.Reader.class.getConstructor(FileSystem.class, Path.class, Configuration.class, blockCacheClazz,
+                            blockCacheClazz, AccumuloConfiguration.class);
+                    Object cacheableReader = cachableBlockFileReaderConstructor.newInstance(
+                            fs,
+                            path,
+                            fsConf,
+                            null,
+                            null,
+                            accumuloConfiguration
+                    );
+                    reader = RFile.Reader.class.getConstructor(blockFileReaderClazz).newInstance(cacheableReader);
+                }
+                return reader;
+            } catch (final Exception e) {
+                throw new RuntimeException("Failed initialing Accumulo class. Ensure Accumulo version is supported", e);
+            }
+        }
+    }
+
+    public static class BackwardsCompatibleRFileWriter {
+        public static RFile.Writer create(final String file, final Configuration fsConf, final int blocksize) {
+            final RFile.Writer writer;
+            final Constructor bcFileWriterConstructor, cachableBlockFileWriterConstructor, rFileWriterConstructor;
+            try {
+                if (accumuloVersion == "2") {
+                    bcFileWriterConstructor = BCFile.Writer.class.getConstructor(fsdataoutputstreamclazz, RateLimiter.class, String.class,
+                            Configuration.class, cryptoServiceClazz);
+                    Object bcFileWriter = bcFileWriterConstructor.newInstance(
+                            FileSystem.get(fsConf).create(new Path(file)),
+                            NullRateLimiter.INSTANCE,
+                            Compression.COMPRESSION_NONE,
+                            fsConf,
+                            noCryptoServiceClazz.getConstructor().newInstance()
+                    );
+                    rFileWriterConstructor = RFile.Writer.class.getConstructor(BCFile.Writer.class, int.class);
+                    writer = (RFile.Writer) rFileWriterConstructor.newInstance(bcFileWriter, blocksize);
+                } else {
+                    cachableBlockFileWriterConstructor = cachableBlockFileWriterClazz.getConstructor(FileSystem.class, Path.class, String.class, RateLimiter.class,
+                            Configuration.class, AccumuloConfiguration.class);
+                    AccumuloConfiguration accumuloConfiguration = (AccumuloConfiguration) AccumuloConfiguration.class.getMethod("getDefaultConfiguration").invoke(null);
+                    Object cachableBlockFileWriter = cachableBlockFileWriterConstructor.newInstance(
+                            FileSystem.get(fsConf),
+                            new Path(file),
+                            Compression.COMPRESSION_NONE,
+                            null,
+                            fsConf,
+                            accumuloConfiguration
+                    );
+                    rFileWriterConstructor = RFile.Writer.class.getConstructor(blockFileWriterClazz, int.class);
+                    writer = (RFile.Writer) rFileWriterConstructor.newInstance(cachableBlockFileWriter, blocksize);
+                }
+                return writer;
+            } catch (final Exception e) {
+                throw new RuntimeException("Failed initialing Accumulo class. Ensure Accumulo version is supported", e);
+            }
+        }
+    }
+}

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/performance/BloomFilterIT.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/performance/BloomFilterIT.java
@@ -16,8 +16,8 @@
 
 package uk.gov.gchq.gaffer.accumulostore.integration.performance;
 
-import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
+import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
@@ -26,7 +26,6 @@ import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVIterator;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.file.rfile.RFile;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +43,7 @@ import uk.gov.gchq.gaffer.accumulostore.key.core.impl.classic.ClassicAccumuloEle
 import uk.gov.gchq.gaffer.accumulostore.key.core.impl.classic.ClassicRangeFactory;
 import uk.gov.gchq.gaffer.accumulostore.key.exception.RangeFactoryException;
 import uk.gov.gchq.gaffer.accumulostore.utils.AccumuloPropertyNames;
+import uk.gov.gchq.gaffer.accumulostore.utils.LegacySupport;
 import uk.gov.gchq.gaffer.commonutil.CommonTestConstants;
 import uk.gov.gchq.gaffer.commonutil.TestGroups;
 import uk.gov.gchq.gaffer.commonutil.pair.Pair;
@@ -148,8 +148,7 @@ public class BloomFilterIT {
         final Value value2 = elementConverter.getValueFromProperties(TestGroups.EDGE, property);
 
         // Create Accumulo configuration
-        final ConfigurationCopy accumuloConf = new ConfigurationCopy(AccumuloConfiguration
-                .getDefaultConfiguration());
+        final ConfigurationCopy accumuloConf = new ConfigurationCopy(DefaultConfiguration.getInstance());
         accumuloConf.set(Property.TABLE_BLOOM_ENABLED, "true");
         accumuloConf.set(Property.TABLE_BLOOM_KEY_FUNCTOR, CoreKeyBloomFunctor.class
                 .getName());
@@ -158,7 +157,7 @@ public class BloomFilterIT {
         accumuloConf.set(Property.TSERV_BLOOM_LOAD_MAXCONCURRENT, "1");
 
         // Create Hadoop configuration
-        final Configuration conf = CachedConfiguration.getInstance();
+        final Configuration conf = new Configuration();
         final FileSystem fs = FileSystem.get(conf);
 
         // Open file
@@ -171,11 +170,7 @@ public class BloomFilterIT {
         }
 
         // Writer
-        final FileSKVWriter writer = FileOperations.getInstance()
-                .newWriterBuilder()
-                .forFile(filename, fs, conf)
-                .withTableConfiguration(accumuloConf)
-                .build();
+        final FileSKVWriter writer = LegacySupport.BackwardsCompatibleWriterBuilder.create(filename, fs, conf, accumuloConf);
 
         try {
             // Write data to file
@@ -194,12 +189,7 @@ public class BloomFilterIT {
         }
 
         // Reader
-        final FileSKVIterator reader = FileOperations.getInstance()
-                .newReaderBuilder()
-                .forFile(filename, fs, conf)
-                .withTableConfiguration(accumuloConf)
-                .seekToBeginning(false)
-                .build();
+        final FileSKVIterator reader = LegacySupport.BackwardsCompatibleReaderBuilder.create(filename, fs, conf, accumuloConf, false);
 
         try {
             // Calculate random look up rate - run it 3 times and take best

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/performance/BloomFilterIT.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/performance/BloomFilterIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 Crown Copyright
+ * Copyright 2016-2022 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/utils/LegacySupportTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/utils/LegacySupportTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.gchq.gaffer.accumulostore.utils;
 
 import org.apache.accumulo.core.client.ClientConfiguration;

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/utils/LegacySupportTest.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/utils/LegacySupportTest.java
@@ -1,0 +1,218 @@
+package uk.gov.gchq.gaffer.accumulostore.utils;
+
+import org.apache.accumulo.core.client.ClientConfiguration;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.conf.ConfigurationCopy;
+import org.apache.accumulo.core.conf.DefaultConfiguration;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.util.Pair;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import uk.gov.gchq.gaffer.accumulostore.utils.LegacySupport.InputConfigurator;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * These tests simply check that the reflection in the legacy support
+ * utility class is able to create and invoke Accumulo methods.
+ */
+public class LegacySupportTest {
+
+    @TempDir
+    static File tempDir;
+
+    @Test
+    public void shouldReflectForSetScanAuthorizations() {
+        // With
+        Configuration conf = new Configuration();
+        Authorizations authorisations = new Authorizations();
+
+        // Then
+        assertDoesNotThrow(() -> { InputConfigurator.setScanAuthorizations(AccumuloInputFormat.class, conf, authorisations); });
+    }
+
+    @Test
+    public void shouldReflectForSetInputTableName() {
+        // With
+        Configuration conf = new Configuration();
+        String tableName = "test";
+
+        // Then
+        assertDoesNotThrow(() -> { InputConfigurator.setInputTableName(AccumuloInputFormat.class, conf, tableName); });
+    }
+
+    @Test
+    public void shouldReflectForFetchColumns() {
+        // With
+        Configuration conf = new Configuration();
+        Collection<Pair<Text, Text>> columnFamilyColumnQualifierPairs = Arrays.asList(new org.apache.accumulo.core.util.Pair<>(new Text("null"), new Text("null")));
+
+        // Then
+        assertDoesNotThrow(() -> { InputConfigurator.fetchColumns(AccumuloInputFormat.class, conf, columnFamilyColumnQualifierPairs); });
+    }
+
+    @Test
+    public void shouldReflectForAddIterator() {
+        // With
+        Configuration conf = new Configuration();
+        String tableName = "test";
+        IteratorSetting setting = new IteratorSetting(1, "", "");
+
+        // Then
+        assertDoesNotThrow(() -> { InputConfigurator.addIterator(AccumuloInputFormat.class, conf, setting); });
+    }
+
+    @Test
+    public void shouldReflectForSetConnectorInfo() {
+        // With
+        Configuration conf = new Configuration();
+        String user = "testUser";
+        PasswordToken pass = new PasswordToken();
+
+        // Then
+        assertDoesNotThrow(() -> { InputConfigurator.setConnectorInfo(AccumuloInputFormat.class, conf, user, pass); });
+    }
+
+    @Test
+    public void shouldReflectForSetZooKeeperInstance() {
+        // With
+        Configuration conf = new Configuration();
+        ClientConfiguration withZkHosts = ClientConfiguration.create();
+
+        // Then
+        assertDoesNotThrow(() -> { InputConfigurator.setZooKeeperInstance(AccumuloInputFormat.class, conf, withZkHosts); });
+    }
+
+    @Test
+    public void shouldReflectForSetBatchScan() {
+        // With
+        Configuration conf = new Configuration();
+
+        // Then
+        assertDoesNotThrow(() -> { InputConfigurator.setBatchScan(AccumuloInputFormat.class, conf, false); });
+    }
+
+    @Test
+    public void shouldReflectForSetRanges() {
+        // With
+        Configuration conf = new Configuration();
+        final List<Range> ranges = new ArrayList<>();
+
+        // Then
+        assertDoesNotThrow(() -> { InputConfigurator.setRanges(AccumuloInputFormat.class, conf, ranges); });
+    }
+
+    @Test
+    public void shouldReflectForGetIterators() {
+        // With
+        Configuration conf = new Configuration();
+
+        // Then
+        assertDoesNotThrow(() -> { InputConfigurator.getIterators(AccumuloInputFormat.class, conf); });
+    }
+
+    @Test
+    public void shouldReflectForGetFetchedColumns() {
+        // With
+        Configuration conf = new Configuration();
+
+        // Then
+        assertDoesNotThrow(() -> { InputConfigurator.getFetchedColumns(AccumuloInputFormat.class, conf); });
+    }
+
+    @Test
+    public void shouldReflectForBackwardsCompatibleReaderBuilder() throws IOException {
+        // With
+        Configuration conf = new Configuration();
+        FileSystem fs = FileSystem.get(conf);
+        AccumuloConfiguration accumuloConf = new ConfigurationCopy(DefaultConfiguration.getInstance());
+        final String filenameTemp = tempDir.getAbsolutePath();
+        final String filename = filenameTemp + "/file.rf";
+        final File file = new File(filename);
+        file.createNewFile();
+        String thrown = null;
+
+        // When
+        try {
+            LegacySupport.BackwardsCompatibleReaderBuilder.create(filename, fs, conf, accumuloConf, false);
+        } catch (Throwable th) {
+            thrown = ExceptionUtils.getStackTrace(th);
+        }
+
+        // Then
+        // TODO: Use AsserJ to dump stack trace and be clearer etc.
+        // Note we only want to check that the classes are instantiated correctly via reflection, this exception confirms the object was created OK
+        assertTrue(thrown.contains("java.io.EOFException: Cannot seek to a negative offset"));
+    }
+
+    @Test
+    public void shouldReflectForBackwardsCompatibleWriterBuilder() throws IOException {
+        // With
+        final Configuration conf = new Configuration();
+        final FileSystem fs = FileSystem.get(conf);
+        final AccumuloConfiguration accumuloConf = new ConfigurationCopy(DefaultConfiguration.getInstance());
+        final String filenameTemp = tempDir.getAbsolutePath();
+        final String filename = filenameTemp + "/file.rf";
+        final File file = new File(filename);
+        if (file.exists()) {
+            file.delete();
+        }
+
+        // Then
+        assertDoesNotThrow(() -> { LegacySupport.BackwardsCompatibleWriterBuilder.create(filename, fs, conf, accumuloConf); });
+        }
+
+    @Test
+    public void shouldReflectForBackwardsCompatibleCachableBlockFileReader() throws IOException {
+        // With
+        final Configuration conf = new Configuration();
+        final FileSystem fs = FileSystem.get(conf);
+        final String filenameTemp = tempDir.getAbsolutePath();
+        final String filename = filenameTemp + "/file.rf";
+        final File file = new File(filename);
+        file.createNewFile();
+        final Path path = new Path(filename);
+        String thrown = null;
+
+        // When
+        try {
+            LegacySupport.BackwardsCompatibleCachableBlockFileReader.create(fs, path, conf);
+        } catch (Throwable th) {
+            thrown = ExceptionUtils.getStackTrace(th);
+        }
+
+        // Then
+        // TODO: Use AsserJ to dump stack trace and be clearer etc.
+        // Note we only want to check that the classes are instantiated correctly via reflection, this exception confirms the object was created OK
+        assertTrue(thrown.contains("java.io.EOFException: Cannot seek to a negative offset"));
+    }
+
+    @Test
+    public void shouldReflectForBackwardsCompatibleRFileWriter() throws IOException {
+        // With
+        final Configuration conf = new Configuration();
+        final String filenameTemp = tempDir.getAbsolutePath();
+        final String filename = filenameTemp + "/file.rf";
+
+        // Then
+        assertDoesNotThrow(() -> { LegacySupport.BackwardsCompatibleRFileWriter.create(filename, conf, 1000); });
+    }
+}


### PR DESCRIPTION
This make Gaffer compatible with Accumulo 2 and retains support for Accumulo 1.

Uses a utility class to dynamically import Accumulo classes which are incompatible between versions 1 & 2, plus handles creation of certain objects associated with these classes. Gaffer can be built for Accumulo 1 and Hadoop 2 using a 'classic' profile which swaps dependency versions. Other minor POM changes were required to ensure compatibility for existing libraries.