### PR TITLE
Gh-2749: Hllp is not aggregated properly with TSV

### DIFF
--- a/core/type/src/main/java/uk/gov/gchq/gaffer/types/FreqMap.java
+++ b/core/type/src/main/java/uk/gov/gchq/gaffer/types/FreqMap.java
@@ -16,6 +16,7 @@
 package uk.gov.gchq.gaffer.types;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import uk.gov.gchq.koryphe.serialisation.json.JsonSimpleClassName;
 
@@ -26,6 +27,7 @@ import java.util.Map;
  * {@code FreqMap} extends {@link HashMap} with String keys and Long values, adding an upsert operation.
  */
 @JsonSimpleClassName
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
 public class FreqMap extends HashMap<String, Long> {
     private static final long serialVersionUID = -851105369975081220L;
 

--- a/core/type/src/main/java/uk/gov/gchq/gaffer/types/FreqMap.java
+++ b/core/type/src/main/java/uk/gov/gchq/gaffer/types/FreqMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Crown Copyright
+ * Copyright 2016-2022 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.types;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/core/type/src/main/java/uk/gov/gchq/gaffer/types/TypeSubTypeValue.java
+++ b/core/type/src/main/java/uk/gov/gchq/gaffer/types/TypeSubTypeValue.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.gaffer.types;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
@@ -30,6 +31,7 @@ import java.util.Comparator;
  * sub-types and associated values.
  */
 @JsonSimpleClassName
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class", defaultImpl = TypeSubTypeValue.class)
 public class TypeSubTypeValue implements Comparable<TypeSubTypeValue>, Serializable {
 
     private static Comparator<String> stringComparator = Comparator

--- a/core/type/src/main/java/uk/gov/gchq/gaffer/types/TypeSubTypeValue.java
+++ b/core/type/src/main/java/uk/gov/gchq/gaffer/types/TypeSubTypeValue.java
@@ -32,7 +32,7 @@ import java.util.Comparator;
  * sub-types and associated values.
  */
 @JsonSimpleClassName
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class", defaultImpl = TypeSubTypeValue.class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
 public class TypeSubTypeValue implements Comparable<TypeSubTypeValue>, Serializable {
 
     private static Comparator<String> stringComparator = Comparator

--- a/core/type/src/main/java/uk/gov/gchq/gaffer/types/TypeSubTypeValue.java
+++ b/core/type/src/main/java/uk/gov/gchq/gaffer/types/TypeSubTypeValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Crown Copyright
+ * Copyright 2016-2022 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.types;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;

--- a/core/type/src/main/java/uk/gov/gchq/gaffer/types/TypeValue.java
+++ b/core/type/src/main/java/uk/gov/gchq/gaffer/types/TypeValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Crown Copyright
+ * Copyright 2016-2022 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/type/src/main/java/uk/gov/gchq/gaffer/types/TypeValue.java
+++ b/core/type/src/main/java/uk/gov/gchq/gaffer/types/TypeValue.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.types;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
@@ -31,6 +32,7 @@ import java.util.Comparator;
  * values.
  */
 @JsonSimpleClassName
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
 public class TypeValue implements Comparable<TypeValue>, Serializable {
 
     private static Comparator<String> stringComparator = Comparator

--- a/library/sketches-library/src/main/java/uk/gov/gchq/gaffer/sketches/clearspring/cardinality/serialisation/json/HyperLogLogPlusJsonDeserialiser.java
+++ b/library/sketches-library/src/main/java/uk/gov/gchq/gaffer/sketches/clearspring/cardinality/serialisation/json/HyperLogLogPlusJsonDeserialiser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Crown Copyright
+ * Copyright 2016-2022 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/sketches-library/src/main/java/uk/gov/gchq/gaffer/sketches/clearspring/cardinality/serialisation/json/HyperLogLogPlusJsonDeserialiser.java
+++ b/library/sketches-library/src/main/java/uk/gov/gchq/gaffer/sketches/clearspring/cardinality/serialisation/json/HyperLogLogPlusJsonDeserialiser.java
@@ -21,108 +21,57 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.TextNode;
 
 import uk.gov.gchq.gaffer.exception.SerialisationException;
 import uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 
-import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
 /**
  * A {@code HyperLogLogPlusJsonDeserialiser} deserialises {@link HyperLogLogPlus}
- * objects. All objects including as {@link uk.gov.gchq.gaffer.types.TypeSubTypeValue}
- * are now properly supported. The only stipulation is that the {@code class}
- * must included in the fields of the {@code JSON} object. The object will not
- * be affected if it does not feature a {@code class} as this will be ignored
- * when the object is deserialised. NOTE: the {@code toString} method is
- * called by the {@link HyperLogLogPlus} so you need to ensure that this is
- * overridden by your object.
+ * objects. All objects including {@link uk.gov.gchq.gaffer.types.TypeValue},
+ * {@link uk.gov.gchq.gaffer.types.TypeSubTypeValue},
+ * {@link uk.gov.gchq.gaffer.types.CustomMap} and
+ * {@link uk.gov.gchq.gaffer.types.FreqMap} are now properly supported. The only
+ * stipulation is that the {@code class} must included in the fields of the
+ * {@code JSON} object. This can be done in {@code Java} by including the
+ * {@code class} {@code annotation}:
+ * <pre>
+ * <code>&#064;JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")</code>
+ * </pre>
+ * The object will not be affected if it does not feature a {@code class} as
+ * this will be ignored when the object is deserialised. Unfortunately,
+ * you cannot have arrays of values as {@code offers} is not permitted.
+ * <p>
+ * <b>
+ * NOTE: the {@code toString} method is called by the {@link HyperLogLogPlus}
+ * class when making the {@code offers} so you need to ensure that the
+ * {@code toString} method is overridden by your object.
+ * </b>
+ * </p>
  */
 public class HyperLogLogPlusJsonDeserialiser extends JsonDeserializer<HyperLogLogPlus> {
-    public static final int DEFAULT_P = 10;
-    public static final int DEFAULT_SP = 10;
+
     public static final String CLASS = "class";
-    public static final String OFFERS = "offers";
-    public static final String P = "p";
-    public static final String SP = "sp";
+
     public static final String HYPER_LOG_LOG_PLUS = "hyperLogLogPlus";
 
     @Override
     public HyperLogLogPlus deserialize(final JsonParser jsonParser, final DeserializationContext deserializationContext) throws IOException {
-        TreeNode treeNode = jsonParser.getCodec().readTree(jsonParser);
-        final TreeNode nestedHllp = treeNode.get(HYPER_LOG_LOG_PLUS);
+        try {
+            TreeNode treeNode = jsonParser.getCodec().readTree(jsonParser);
+            final TreeNode nestedHllp = treeNode.get(HYPER_LOG_LOG_PLUS);
 
-        if (nonNull(nestedHllp)) {
-            treeNode = nestedHllp;
-        }
-
-        final HyperLogLogPlus hllp;
-
-        final TextNode jsonNodes = (TextNode) treeNode.get(HyperLogLogPlusJsonConstants.HYPER_LOG_LOG_PLUS_SKETCH_BYTES_FIELD);
-        if (isNull(jsonNodes)) {
-            final IntNode pNode = (IntNode) treeNode.get(P);
-            final IntNode spNode = (IntNode) treeNode.get(SP);
-            final int p = nonNull(pNode) ? pNode.asInt(DEFAULT_P) : DEFAULT_P;
-            final int sp = nonNull(spNode) ? spNode.asInt(DEFAULT_SP) : DEFAULT_SP;
-            hllp = new HyperLogLogPlus(p, sp);
-        } else {
-            hllp = HyperLogLogPlus.Builder.build(jsonNodes.binaryValue());
-        }
-
-        final ArrayNode offers = (ArrayNode) treeNode.get(OFFERS);
-
-        if (nonNull(offers)) {
-            for (final JsonNode offer : offers) {
-                try {
-                    final Object object = getOffer(offer);
-                    if (object != null) {
-                        hllp.offer(object);
-                    }
-                } catch (final Exception e) {
-                    throw new SerialisationException("Error deserialising JSON object: " + e.getMessage(), e);
-                }
+            if (nonNull(nestedHllp)) {
+                treeNode = nestedHllp;
             }
-        }
 
-        return hllp;
-    }
-
-    private static Object getOffer(final JsonNode offer) throws Exception {
-        if (offer.hasNonNull(CLASS)) {
-            try {
-                return JSONSerialiser.deserialise(offer.toString(), Class.forName(offer.get(CLASS).asText()));
-            } catch (final ClassNotFoundException e) {
-                throw new IllegalArgumentException("Error converting the class [" + offer.get(CLASS).asText() + "] to a Java Object", e);
-            }
-        } else if (offer.fields().hasNext()) {
-            // has fields so must be a map
-            final Map<Object, Object> map = new HashMap<>();
-            final Iterator<Map.Entry<String, JsonNode>> iterator = offer.fields();
-            while (iterator.hasNext()) {
-                final Map.Entry<String, JsonNode> entry = iterator.next();
-                map.put(entry.getKey(), getOffer(entry.getValue()));
-            }
-            return map;
-        } else if (offer.isArray()) {
-            final List<Object> list = new ArrayList<>();
-            final Iterator<JsonNode> iterator = offer.elements();
-            while (iterator.hasNext()) {
-                list.add(getOffer(iterator.next()));
-            }
-            return list;
-        } else {
-            return offer.asText();
+            final HyperLogLogPlusWithOffers hyperLogLogPlusWithOffers = JSONSerialiser.deserialise(treeNode.toString(), HyperLogLogPlusWithOffers.class);
+            return hyperLogLogPlusWithOffers.getHyperLogLogPlus();
+        } catch (final Exception e) {
+            throw new SerialisationException("Error deserialising JSON object: " + e.getMessage(), e);
         }
     }
 }

--- a/library/sketches-library/src/main/java/uk/gov/gchq/gaffer/sketches/clearspring/cardinality/serialisation/json/HyperLogLogPlusJsonDeserialiser.java
+++ b/library/sketches-library/src/main/java/uk/gov/gchq/gaffer/sketches/clearspring/cardinality/serialisation/json/HyperLogLogPlusJsonDeserialiser.java
@@ -89,7 +89,7 @@ public class HyperLogLogPlusJsonDeserialiser extends JsonDeserializer<HyperLogLo
                     if (object != null) {
                         hllp.offer(object);
                     }
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     throw new SerialisationException("Error deserialising JSON object: " + e.getMessage(), e);
                 }
             }
@@ -102,7 +102,7 @@ public class HyperLogLogPlusJsonDeserialiser extends JsonDeserializer<HyperLogLo
         if (offer.hasNonNull(CLASS)) {
             try {
                 return JSONSerialiser.deserialise(offer.toString(), Class.forName(offer.get(CLASS).asText()));
-            } catch (ClassNotFoundException e) {
+            } catch (final ClassNotFoundException e) {
                 throw new IllegalArgumentException("Error converting the class [" + offer.get(CLASS).asText() + "] to a Java Object", e);
             }
         } else if (offer.fields().hasNext()) {

--- a/library/sketches-library/src/main/java/uk/gov/gchq/gaffer/sketches/clearspring/cardinality/serialisation/json/HyperLogLogPlusWithOffers.java
+++ b/library/sketches-library/src/main/java/uk/gov/gchq/gaffer/sketches/clearspring/cardinality/serialisation/json/HyperLogLogPlusWithOffers.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.sketches.clearspring.cardinality.serialisation.json;
+
+import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class HyperLogLogPlusWithOffers {
+
+    private int p = 10;
+
+    private int sp = 10;
+
+    private byte[] hyperLogLogPlusSketchBytes = null;
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
+    private List<?> offers = new ArrayList<>();
+
+    public int getP() {
+        return p;
+    }
+
+    public void setP(final int p) {
+        this.p = p;
+    }
+
+    public int getSp() {
+        return sp;
+    }
+
+    public void setSp(final int sp) {
+        this.sp = sp;
+    }
+
+    public byte[] getHyperLogLogPlusSketchBytes() {
+        return hyperLogLogPlusSketchBytes;
+    }
+
+    public void setHyperLogLogPlusSketchBytes(final byte[] hyperLogLogPlusSketchBytes) {
+        this.hyperLogLogPlusSketchBytes = hyperLogLogPlusSketchBytes;
+    }
+
+    public List<?> getOffers() {
+        return offers;
+    }
+
+    public void setOffers(final List<?> offers) {
+        this.offers = offers;
+    }
+
+    @JsonIgnore
+    public HyperLogLogPlus getHyperLogLogPlus() throws IOException {
+        final HyperLogLogPlus hyperLogLogPlus;
+        if (getHyperLogLogPlusSketchBytes() == null) {
+            hyperLogLogPlus = new HyperLogLogPlus(getP(), getSp());
+        } else {
+            hyperLogLogPlus = HyperLogLogPlus.Builder.build(hyperLogLogPlusSketchBytes);
+        }
+
+        for (final Object object : getOffers()) {
+            hyperLogLogPlus.offer(object);
+        }
+
+        return hyperLogLogPlus;
+    }
+}

--- a/library/sketches-library/src/test/java/uk/gov/gchq/gaffer/sketches/clearspring/cardinality/serialisation/json/HyperLogLogPlusJsonDeserialiserTest.java
+++ b/library/sketches-library/src/test/java/uk/gov/gchq/gaffer/sketches/clearspring/cardinality/serialisation/json/HyperLogLogPlusJsonDeserialiserTest.java
@@ -476,8 +476,12 @@ public class HyperLogLogPlusJsonDeserialiserTest {
 
         @Override
         public boolean equals(final Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
             final TestObject that = (TestObject) o;
             return new EqualsBuilder()
                     .append(getTestString(), that.getTestString())

--- a/library/sketches-library/src/test/java/uk/gov/gchq/gaffer/sketches/clearspring/cardinality/serialisation/json/HyperLogLogPlusJsonDeserialiserTest.java
+++ b/library/sketches-library/src/test/java/uk/gov/gchq/gaffer/sketches/clearspring/cardinality/serialisation/json/HyperLogLogPlusJsonDeserialiserTest.java
@@ -1,0 +1,501 @@
+/*
+ * Copyright 2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.sketches.clearspring.cardinality.serialisation.json;
+
+import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.gaffer.commonutil.ToStringBuilder;
+import uk.gov.gchq.gaffer.exception.SerialisationException;
+import uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser;
+import uk.gov.gchq.gaffer.sketches.serialisation.json.SketchesJsonModules;
+import uk.gov.gchq.gaffer.types.FreqMap;
+import uk.gov.gchq.gaffer.types.TypeSubTypeValue;
+import uk.gov.gchq.gaffer.types.TypeValue;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+public class HyperLogLogPlusJsonDeserialiserTest {
+
+    @BeforeEach
+    void before() {
+        System.setProperty(JSONSerialiser.JSON_SERIALISER_MODULES, SketchesJsonModules.class.getName());
+        JSONSerialiser.update();
+    }
+
+    @AfterEach
+    void after() {
+        System.clearProperty(JSONSerialiser.JSON_SERIALISER_MODULES);
+        JSONSerialiser.update();
+    }
+
+    @Test
+    void shouldFailDeserialisingHllpNull() throws SerialisationException {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> JSONSerialiser.deserialise((String) null, HyperLogLogPlus.class))
+                .withMessage("argument \"content\" is null");
+    }
+
+    @Test
+    void shouldFailDeserialisingHllpEmptyString() throws SerialisationException {
+        assertThatExceptionOfType(SerialisationException.class)
+                .isThrownBy(() -> JSONSerialiser.deserialise("  ", HyperLogLogPlus.class))
+                .withMessageContaining("No content to map due to end-of-input");
+    }
+
+    @Test
+    void shouldDeserialiseHllpAsEmptySketch() throws IOException {
+        // Given
+        final String json = "{}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+        assertThat(hllp.cardinality()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldFailDeserialisingHllpEmptyInvalidBytes() {
+        // Given
+        final String json = String.format("{\"%s\": \"fail\"}",
+                HyperLogLogPlusJsonConstants.HYPER_LOG_LOG_PLUS_SKETCH_BYTES_FIELD);
+
+        assertThatExceptionOfType(SerialisationException.class)
+                .isThrownBy(() -> JSONSerialiser.deserialise(json, HyperLogLogPlus.class))
+                .withMessageContaining("Unexpected IOException (of type java.io.EOFException): null");
+    }
+
+    @Test
+    void shouldDeserialiseHllpWithSAndSpValuesAndOfferStoredAsBytes() throws IOException {
+        // Given
+        final HyperLogLogPlus expected = new HyperLogLogPlus(5, 10);
+        expected.offer("test");
+
+        final Map<String, Object> stringMap = Collections.singletonMap(HyperLogLogPlusJsonConstants.HYPER_LOG_LOG_PLUS_SKETCH_BYTES_FIELD, expected.getBytes());
+
+        final String s = JSONSerialiser.getMapper().writeValueAsString(stringMap);
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(s, HyperLogLogPlus.class);
+
+        // Then
+        assertThat(hllp.getBytes()).isEqualTo(expected.getBytes());
+    }
+
+    @Test
+    void shouldDeserialiseHllpWithSAndSpValues() throws IOException {
+        // Given
+        final String json = "{\"p\": 5, \"sp\": 10}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+        assertThat(hllp.getBytes()).isEqualTo(new HyperLogLogPlus(5, 10).getBytes());
+    }
+
+    @Test
+    void shouldDeserialiseNestedHllpWithSAndSpValues() throws IOException {
+        // Given
+        final String json = "{\"hyperLogLogPlus\": {\"p\": 5, \"sp\": 10}}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+        assertThat(hllp.getBytes()).isEqualTo(new HyperLogLogPlus(5, 10).getBytes());
+    }
+
+    @Test
+    void shouldDeserialiseNestedHllpWithSAndSpValuesOffersEmpty() throws IOException {
+        // Given
+        final String json = "{\"hyperLogLogPlus\": {\"p\": 5, \"sp\": 10, \"offers\": []}}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+        assertThat(hllp.getBytes()).isEqualTo(new HyperLogLogPlus(5, 10).getBytes());
+    }
+
+    @Test
+    void shouldFailDeserialisingHllpWithOffersInvalidObject() throws IOException {
+        // Given
+        final String json = "{\"p\": 5, \"sp\": 5, " +
+                "\"offers\": [" +
+                "[{\"class\": \"fail\", \"fail\": \"fail\"}]" +
+                "]}";
+
+        // When
+        // Then
+        assertThatExceptionOfType(SerialisationException.class)
+                .isThrownBy(() -> JSONSerialiser.deserialise(json, HyperLogLogPlus.class))
+                .withMessageContaining("Error deserialising JSON object: Error converting the class [fail] to a Java Object");
+    }
+
+    @Test
+    void shouldDeserialiseHllpWithOffers() throws IOException {
+        // Given
+        final String json = "{\"p\": 5, \"sp\": 5, \"offers\": [\"value1\", \"value2\", \"value2\", \"value2\", \"value3\"]}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+        final HyperLogLogPlus expected = new HyperLogLogPlus(5, 5);
+        expected.offer("value1");
+        expected.offer("value2");
+        expected.offer("value2");
+        expected.offer("value2");
+        expected.offer("value3");
+        assertArrayEquals(expected.getBytes(), hllp.getBytes());
+    }
+
+    @Test
+    void shouldDeserialiseHllpWithOffersTypeSubTypeValue() throws IOException {
+        // Given
+        final String json = "{\"p\": 5, \"sp\": 5, " +
+                "\"offers\": [" +
+                "{\"class\": \"uk.gov.gchq.gaffer.types.TypeSubTypeValue\", \"type\": \"type1\", \"subType\": \"subType1\", \"value\": \"value1\"}, " +
+                "{\"class\": \"uk.gov.gchq.gaffer.types.TypeSubTypeValue\", \"type\": \"type2\", \"subType\": \"subType2\", \"value\": \"value2\"}, " +
+                "{\"class\": \"uk.gov.gchq.gaffer.types.TypeSubTypeValue\", \"type\": \"type3\", \"subType\": \"subType3\", \"value\": \"value3\"}" +
+                "]}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+        final HyperLogLogPlus expected = new HyperLogLogPlus(5, 5);
+        expected.offer(new TypeSubTypeValue("type1", "subType1", "value1"));
+        expected.offer(new TypeSubTypeValue("type2", "subType2", "value2"));
+        expected.offer(new TypeSubTypeValue("type3", "subType3", "value3"));
+        assertThat(hllp.getBytes()).isEqualTo(expected.getBytes());
+    }
+
+    @Test
+    void shouldDeserialiseHllpWithOffersTypeValue() throws IOException {
+        // Given
+        final String json = "{\"p\": 5, \"sp\": 5, " +
+                "\"offers\": [" +
+                "{\"class\": \"uk.gov.gchq.gaffer.types.TypeValue\", \"type\": \"type1\", \"value\": \"value1\"}, " +
+                "{\"class\": \"uk.gov.gchq.gaffer.types.TypeValue\", \"type\": \"type2\", \"value\": \"value2\"}, " +
+                "{\"class\": \"uk.gov.gchq.gaffer.types.TypeValue\", \"type\": \"type3\", \"value\": \"value3\"}" +
+                "]}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+        final HyperLogLogPlus expected = new HyperLogLogPlus(5, 5);
+        expected.offer(new TypeValue("type1", "value1"));
+        expected.offer(new TypeValue("type2", "value2"));
+        expected.offer(new TypeValue("type3", "value3"));
+        assertThat(hllp.getBytes()).isEqualTo(expected.getBytes());
+    }
+
+    @Test
+    void shouldDeserialiseHllpWithOffersTypeValueArray() throws IOException {
+        // Given
+        final String json = "{\"p\": 5, \"sp\": 5, " +
+                "\"offers\": [" +
+                "[{\"class\": \"uk.gov.gchq.gaffer.types.TypeValue\", \"type\": \"type\", \"value\": \"value\"}]" +
+                "]}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+        final HyperLogLogPlus expected = new HyperLogLogPlus(5, 5);
+        expected.offer(Collections.singletonList(new TypeValue("type", "value")));
+        assertThat(hllp.getBytes()).isEqualTo(expected.getBytes());
+    }
+
+    @Test
+    void shouldDeserialiseHllpWithOffersArrayOfTypeValueArray() throws IOException {
+        // Given
+        final String json = "{\"p\": 5, \"sp\": 5, " +
+                "\"offers\": [" +
+                "[[{\"class\": \"uk.gov.gchq.gaffer.types.TypeValue\", \"type\": \"type\", \"value\": \"value\"}]]" +
+                "]}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+        final HyperLogLogPlus expected = new HyperLogLogPlus(5, 5);
+        expected.offer(Collections.singletonList(Collections.singletonList(new TypeValue("type", "value"))));
+        assertThat(hllp.getBytes()).isEqualTo(expected.getBytes());
+    }
+
+    @Test
+    void shouldDeserialiseHllpWithOffersTypeFreqMap() throws IOException {
+        // Given
+        final String json = "{\"p\": 5, \"sp\": 5, " +
+                "\"offers\": [" +
+                "{\"a\": 1, \"b\": 1234567891011121314}" +
+                "]}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+        final FreqMap freqMap = new FreqMap();
+        freqMap.put("a", 1L);
+        freqMap.put("b", 1234567891011121314L);
+
+        final HyperLogLogPlus expected = new HyperLogLogPlus(5, 5);
+        expected.offer(freqMap);
+        assertThat(hllp.getBytes()).isEqualTo(expected.getBytes());
+    }
+
+    @Test
+    void shouldDeserialiseHllpWithOffersArray() throws IOException {
+        // Given
+        final String json = "{\"p\": 5, \"sp\": 5, " +
+                "\"offers\": [[1, 2, 3]]}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+        final HyperLogLogPlus expected = new HyperLogLogPlus(5, 5);
+        expected.offer(Arrays.asList(1, 2, 3));
+        assertThat(hllp.getBytes()).isEqualTo(expected.getBytes());
+    }
+
+    @Test
+    void shouldDeserialiseHllpWithOffersInteger() throws IOException {
+        // Given
+        final String json = "{\"p\": 5, \"sp\": 5, " +
+                "\"offers\": [1, 2, 3]}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+        final HyperLogLogPlus expected = new HyperLogLogPlus(5, 5);
+        expected.offer(1);
+        expected.offer(2);
+        expected.offer(3);
+        assertThat(hllp.getBytes()).isEqualTo(expected.getBytes());
+    }
+
+    @Test
+    void shouldDeserialiseHllpWithOffersString() throws IOException {
+        // Given
+        final String json = "{\"p\": 5, \"sp\": 5, " +
+                "\"offers\": [\"one\", \"two\", \"three\"]}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+        final HyperLogLogPlus expected = new HyperLogLogPlus(5, 5);
+        expected.offer("one");
+        expected.offer("two");
+        expected.offer("three");
+        assertThat(hllp.getBytes()).isEqualTo(expected.getBytes());
+    }
+
+    @Test
+    void shouldDeserialiseHllpWithOffersFloat() throws IOException {
+        // Given
+        final String json = "{\"p\": 5, \"sp\": 5, " +
+                "\"offers\": [1.2, 2.12345, 3.123456789]}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+        final HyperLogLogPlus expected = new HyperLogLogPlus(5, 5);
+        expected.offer(1.2F);
+        expected.offer(2.12345F);
+        expected.offer(3.123456789);
+        assertThat(hllp.getBytes()).isEqualTo(expected.getBytes());
+    }
+
+    @Test
+    void shouldDeserialiseHllpWithOffersLong() throws IOException {
+        // Given
+        final String json = "{\"p\": 5, \"sp\": 5, " +
+                "\"offers\": [1234567891011121314]}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+        final HyperLogLogPlus expected = new HyperLogLogPlus(5, 5);
+        expected.offer(1234567891011121314L);
+        assertThat(hllp.getBytes()).isEqualTo(expected.getBytes());
+    }
+
+    @Test
+    void shouldDeserialiseHllpWithOffersDouble() throws IOException {
+        // Given
+        final String json = "{\"p\": 5, \"sp\": 5, " +
+                "\"offers\": [1.2, 2.12345, 3.123456789]}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+        final HyperLogLogPlus expected = new HyperLogLogPlus(5, 5);
+        expected.offer(1.2D);
+        expected.offer(2.12345D);
+        expected.offer(3.123456789D);
+        assertThat(hllp.getBytes()).isEqualTo(expected.getBytes());
+    }
+
+    @Test
+    void shouldDeserialiseHllpWithOffersBoolean() throws IOException {
+        // Given
+        final String json = "{\"p\": 5, \"sp\": 5, " +
+                "\"offers\": [true, false]}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+        final HyperLogLogPlus expected = new HyperLogLogPlus(5, 5);
+        expected.offer(true);
+        expected.offer(false);
+        assertThat(hllp.getBytes()).isEqualTo(expected.getBytes());
+    }
+
+    @Test
+    void shouldDeserialiseHllpWithOffersTestObjectNoAnnotations() throws IOException {
+        // Given
+        final String json = "{\"p\": 5, \"sp\": 5, " +
+                "\"offers\": [{\"class\": \"" + TestObject.class.getName() + "\", \"testString\": \"test\"}]}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+
+        final HyperLogLogPlus expected = new HyperLogLogPlus(5, 5);
+        expected.offer(new TestObject("test"));
+        assertThat(hllp.getBytes()).isEqualTo(expected.getBytes());
+    }
+
+    @Disabled("Test doesn't store a class when serialising TypeSubTypeValue. Look into why")
+    @Test
+    void shouldDeserialiseHllpWithOffersTestJavaToJson() throws IOException {
+        // Given
+        final HashMap<String, Object> map = new HashMap<>();
+        map.put("p", 5);
+        map.put("sp", 5);
+        map.put("offers", new Object[] {new TypeSubTypeValue("type", "subType", "value")});
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(JSONSerialiser.serialise(map), HyperLogLogPlus.class);
+
+        // Then
+        final HyperLogLogPlus expected = new HyperLogLogPlus(5, 5);
+        expected.offer(new TypeSubTypeValue("type", "subType", "value"));
+        assertThat(hllp.getBytes()).isEqualTo(expected.getBytes());
+    }
+
+    @Test
+    void shouldDeserialiseHllpWithOffersAll() throws IOException {
+        // Given
+        final String json = "{\"p\": 5, \"sp\": 5, " +
+                "\"offers\": [" +
+                "1, " +
+                "\"string\",  " +
+                "true, " +
+                "1.12345, " +
+                "1.123456789, " +
+                "1234567891011121314, " +
+                "{\"class\": \"uk.gov.gchq.gaffer.types.TypeSubTypeValue\", \"type\": \"type\", \"subType\": \"subType\", \"value\": \"value\"}, " +
+                "{\"class\": \"uk.gov.gchq.gaffer.types.TypeValue\", \"type\": \"type\", \"value\": \"value\"}" +
+                "]}";
+
+        // When
+        final HyperLogLogPlus hllp = JSONSerialiser.deserialise(json, HyperLogLogPlus.class);
+
+        // Then
+        final HyperLogLogPlus expected = new HyperLogLogPlus(5, 5);
+        expected.offer(1);
+        expected.offer("string");
+        expected.offer(true);
+        expected.offer(1.12345F);
+        expected.offer(1.123456789D);
+        expected.offer(1234567891011121314L);
+        expected.offer(new TypeValue("type", "value"));
+        expected.offer(new TypeSubTypeValue("type", "subType", "value"));
+        assertThat(hllp.getBytes()).isEqualTo(expected.getBytes());
+    }
+
+    public static class TestObject {
+
+        private String testString = null;
+
+        public TestObject() {
+        }
+
+        public TestObject(final String testString) {
+            this.testString = testString;
+        }
+
+        public String getTestString() {
+            return testString;
+        }
+
+        public void setTestString(final String testString) {
+            this.testString = testString;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            final TestObject that = (TestObject) o;
+            return new EqualsBuilder()
+                    .append(getTestString(), that.getTestString())
+                    .isEquals();
+        }
+
+        @Override
+        public int hashCode() {
+            return new HashCodeBuilder(47, 85)
+                    .append(getTestString())
+                    .hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .append("testString", getTestString())
+                    .toString();
+        }
+    }
+}

--- a/library/sketches-library/src/test/java/uk/gov/gchq/gaffer/sketches/clearspring/cardinality/serialisation/json/HyperLogLogPlusJsonSerialisationTest.java
+++ b/library/sketches-library/src/test/java/uk/gov/gchq/gaffer/sketches/clearspring/cardinality/serialisation/json/HyperLogLogPlusJsonSerialisationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Crown Copyright
+ * Copyright 2016-2022 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import uk.gov.gchq.gaffer.sketches.serialisation.json.SketchesJsonModules;
 
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -70,67 +69,12 @@ public class HyperLogLogPlusJsonSerialisationTest {
     @Test
     public void testNullHyperLogLogPlusSketchIsSerialisedAsNullString() throws SerialisationException {
         // Given
-        final HyperLogLogPlus sketch = null;
 
         // When
-        final String sketchAsString = new String(JSONSerialiser.serialise(sketch));
+        final String sketchAsString = new String(JSONSerialiser.serialise(null));
 
         // Then - Serialisation framework will serialise nulls as 'null' string.
         assertEquals("null", sketchAsString);
-    }
-
-    @Test
-    public void testNullHyperLogLogSketchDeserialisedAsEmptySketch() throws IOException {
-        // Given
-        final String sketchAsString = "{}";
-
-        // When
-        HyperLogLogPlus hllp = JSONSerialiser.deserialise(sketchAsString, HyperLogLogPlus.class);
-
-        // Then
-        assertEquals(0, hllp.cardinality());
-    }
-
-    @Test
-    public void shouldDeserialiseNewHllpWithSAndSpValues() throws IOException {
-        // Given
-        final String sketchAsString = "{\"p\": 5, \"sp\": 10}";
-
-        // When
-        HyperLogLogPlus hllp = JSONSerialiser.deserialise(sketchAsString, HyperLogLogPlus.class);
-
-        // Then
-        assertArrayEquals(new HyperLogLogPlus(5, 10).getBytes(), hllp.getBytes());
-    }
-
-    @Test
-    public void shouldDeserialiseNewNestedHllpWithSAndSpValues() throws IOException {
-        // Given
-        final String sketchAsString = "{\"hyperLogLogPlus\": {\"p\": 5, \"sp\": 10}}";
-
-        // When
-        HyperLogLogPlus hllp = JSONSerialiser.deserialise(sketchAsString, HyperLogLogPlus.class);
-
-        // Then
-        assertArrayEquals(new HyperLogLogPlus(5, 10).getBytes(), hllp.getBytes());
-    }
-
-    @Test
-    public void shouldDeserialiseNewHllpWithOffers() throws IOException {
-        // Given
-        final String sketchAsString = "{\"p\": 5, \"sp\": 5, \"offers\": [\"value1\", \"value2\", \"value2\", \"value2\", \"value3\"]}";
-
-        // When
-        HyperLogLogPlus hllp = JSONSerialiser.deserialise(sketchAsString, HyperLogLogPlus.class);
-
-        // Then
-        HyperLogLogPlus expected = new HyperLogLogPlus(5, 5);
-        expected.offer("value1");
-        expected.offer("value2");
-        expected.offer("value2");
-        expected.offer("value2");
-        expected.offer("value3");
-        assertArrayEquals(expected.getBytes(), hllp.getBytes());
     }
 
     private void runTestWithSketch(final HyperLogLogPlus sketch) throws IOException {

--- a/library/sketches-library/src/test/java/uk/gov/gchq/gaffer/sketches/clearspring/cardinality/serialisation/json/HyperLogLogPlusJsonSerialisationTest.java
+++ b/library/sketches-library/src/test/java/uk/gov/gchq/gaffer/sketches/clearspring/cardinality/serialisation/json/HyperLogLogPlusJsonSerialisationTest.java
@@ -69,9 +69,10 @@ public class HyperLogLogPlusJsonSerialisationTest {
     @Test
     public void testNullHyperLogLogPlusSketchIsSerialisedAsNullString() throws SerialisationException {
         // Given
+        final HyperLogLogPlus sketch = null;
 
         // When
-        final String sketchAsString = new String(JSONSerialiser.serialise(null));
+        final String sketchAsString = new String(JSONSerialiser.serialise(sketch));
 
         // Then - Serialisation framework will serialise nulls as 'null' string.
         assertEquals("null", sketchAsString);


### PR DESCRIPTION
`HyperLogLogPlus` was attempting to add the text version of the `JsonNode` which returned an empty string for an object. Have now reworked so the `JsonNode` is now examined and if a `class` field is found attempts to instantiate the object and send this to the `HyperLogLogPlus`.

# Related Issue

- Resolve #2749