### PR TITLE
Gh-2767: Add FederatedStore schema overlap tests

### DIFF
--- a/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreSchemaOverlapTest.java
+++ b/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreSchemaOverlapTest.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright 2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package uk.gov.gchq.gaffer.federatedstore;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.gaffer.accumulostore.AccumuloProperties;
+import uk.gov.gchq.gaffer.federatedstore.operation.AddGraph;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.serialisation.implementation.MultiSerialiser;
+import uk.gov.gchq.gaffer.serialisation.implementation.StringSerialiser;
+import uk.gov.gchq.gaffer.serialisation.implementation.ordered.OrderedIntegerSerialiser;
+import uk.gov.gchq.gaffer.store.Context;
+import uk.gov.gchq.gaffer.store.operation.GetSchema;
+import uk.gov.gchq.gaffer.store.schema.Schema;
+import uk.gov.gchq.gaffer.store.schema.SchemaEdgeDefinition;
+import uk.gov.gchq.gaffer.store.schema.TypeDefinition;
+import uk.gov.gchq.gaffer.user.User;
+import uk.gov.gchq.koryphe.impl.binaryoperator.Last;
+import uk.gov.gchq.koryphe.impl.binaryoperator.Sum;
+import uk.gov.gchq.koryphe.impl.predicate.IsLessThan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.ACCUMULO_STORE_SINGLE_USE_PROPERTIES;
+import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.GRAPH_ID_A;
+import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.GRAPH_ID_B;
+import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.GRAPH_ID_TEST_FEDERATED_STORE;
+import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.GROUP_BASIC_EDGE;
+import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.INTEGER;
+import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.PROPERTY_1;
+import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.STRING;
+import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.contextTestUser;
+import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.loadAccumuloStoreProperties;
+import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.resetForFederatedTests;
+import static uk.gov.gchq.gaffer.store.TestTypes.DIRECTED_EITHER;
+import static uk.gov.gchq.gaffer.store.TestTypes.DIRECTED_TRUE;
+import static uk.gov.gchq.gaffer.store.TestTypes.STRING_TYPE;
+import static uk.gov.gchq.gaffer.store.TestTypes.VISIBILITY;
+import static uk.gov.gchq.gaffer.user.StoreUser.testUser;
+
+public class FederatedStoreSchemaOverlapTest {
+    public static final AccumuloProperties STORE_PROPERTIES = loadAccumuloStoreProperties(ACCUMULO_STORE_SINGLE_USE_PROPERTIES);
+
+    private static final TypeDefinition INTEGER_TYPE = new TypeDefinition.Builder()
+            .clazz(Integer.class)
+            .serialiser(new OrderedIntegerSerialiser())
+            .aggregateFunction(new Sum())
+            .validateFunctions(new IsLessThan(10))
+            .build();
+
+    private static final SchemaEdgeDefinition EDGE_DEFINITION = new SchemaEdgeDefinition.Builder()
+            .source(STRING)
+            .destination(STRING)
+            .description(GRAPH_ID_A)
+            .directed(DIRECTED_EITHER)
+            .groupBy(PROPERTY_1)
+            .property(PROPERTY_1, INTEGER)
+            .property(VISIBILITY, STRING)
+            .build();
+
+    private static final Schema GRAPH_A_SCHEMA = new Schema.Builder()
+            .edge(GROUP_BASIC_EDGE, EDGE_DEFINITION)
+            .visibilityProperty(VISIBILITY)
+            .vertexSerialiser(new StringSerialiser())
+            .type(STRING, STRING_TYPE)
+            .type(INTEGER, INTEGER_TYPE)
+            .type(DIRECTED_EITHER, Boolean.class)
+            .type(DIRECTED_TRUE, Boolean.class)
+            .build();
+
+    public User testUser;
+    public Context testContext;
+    private FederatedStore federatedStore;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        resetForFederatedTests();
+
+        federatedStore = new FederatedStore();
+        federatedStore.initialise(GRAPH_ID_TEST_FEDERATED_STORE, null, new FederatedStoreProperties());
+
+        testUser = testUser();
+        testContext = contextTestUser();
+    }
+
+    @Test
+    public void shouldMergeSameSchema() throws OperationException {
+        // Given
+        addGraphWith(GRAPH_ID_A, GRAPH_A_SCHEMA);
+        addGraphWith(GRAPH_ID_B, GRAPH_A_SCHEMA);
+
+        // When
+        final Schema schema = federatedStore.execute(new GetSchema.Builder().build(), testContext);
+
+        // Then
+        assertThat(schema.validate().isValid())
+                .withFailMessage(schema.validate().getErrorString())
+                .isTrue();
+        assertThat(schema).isEqualTo(GRAPH_A_SCHEMA);
+    }
+
+    @Test
+    public void shouldSetVertexSerialiserToNullWhenConflictingSchemasMerge() throws OperationException {
+        // Given
+        addGraphWith(GRAPH_ID_A, GRAPH_A_SCHEMA);
+        final Schema graphBSchema = new Schema.Builder()
+                .merge(GRAPH_A_SCHEMA)
+                .vertexSerialiser(new MultiSerialiser())
+                .build();
+        addGraphWith(GRAPH_ID_B, graphBSchema);
+
+        // When
+        final Schema schema = federatedStore.execute(new GetSchema.Builder().build(), testContext);
+
+        // Then
+        assertThat(schema.validate().isValid())
+                .withFailMessage(schema.validate().getErrorString())
+                .isTrue();
+        assertThat(schema.getVertexSerialiser()).isNull();
+        assertThat(schema.toString())
+                .isNotEqualTo(GRAPH_A_SCHEMA.toString())
+                .isNotEqualTo(graphBSchema.toString());
+    }
+
+    @Test
+    public void shouldOverwriteVisibilityPropertyWhenConflictingSchemasMerge() throws OperationException {
+        // Given
+        addGraphWith(GRAPH_ID_A, GRAPH_A_SCHEMA);
+        final Schema graphBSchema = new Schema.Builder()
+                .merge(GRAPH_A_SCHEMA)
+                .visibilityProperty(PROPERTY_1)
+                .build();
+        addGraphWith(GRAPH_ID_B, graphBSchema);
+
+        // When
+        final Schema schema = federatedStore.execute(new GetSchema.Builder().build(), testContext);
+
+        // Then
+        assertThat(schema.validate().isValid())
+                .withFailMessage(schema.validate().getErrorString())
+                .isTrue();
+        assertThat(schema.getVisibilityProperty()).isEqualTo(PROPERTY_1);
+        assertThat(schema.toString())
+                .isNotEqualTo(GRAPH_A_SCHEMA.toString())
+                .isEqualTo(graphBSchema.toString());
+    }
+
+    @Test
+    public void shouldOverwriteTypeDefinitionWhenConflictingSchemasMerge() throws OperationException {
+        // Given
+        addGraphWith(GRAPH_ID_A, GRAPH_A_SCHEMA);
+        final Schema graphBSchema = new Schema.Builder()
+                .merge(GRAPH_A_SCHEMA)
+                .type(INTEGER, STRING_TYPE)
+                .build();
+        addGraphWith(GRAPH_ID_B, graphBSchema);
+
+        // When
+        final Schema schema = federatedStore.execute(new GetSchema.Builder().build(), testContext);
+
+        // Then
+        assertThat(schema.validate().isValid())
+                .withFailMessage(schema.validate().getErrorString())
+                .isTrue();
+        assertThat(schema.getType(INTEGER)).isEqualTo(STRING_TYPE);
+        assertThat(schema.toString())
+                .isNotEqualTo(GRAPH_A_SCHEMA.toString())
+                .isEqualTo(graphBSchema.toString());
+    }
+
+    @Test
+    public void shouldRetainGroupSourceTypeWhenConflictingSchemasMerge() throws OperationException {
+        // Given
+        addGraphWith(GRAPH_ID_A, GRAPH_A_SCHEMA);
+        final Schema graphBSchema = new Schema.Builder()
+                .merge(GRAPH_A_SCHEMA)
+                .edge(GROUP_BASIC_EDGE, new SchemaEdgeDefinition.Builder()
+                        .merge(EDGE_DEFINITION)
+                        .source(INTEGER)
+                        .build())
+                .build();
+        addGraphWith(GRAPH_ID_B, graphBSchema);
+
+        // When
+        final Schema schema = federatedStore.execute(new GetSchema.Builder().build(), testContext);
+
+        // Then
+        assertThat(schema.validate().isValid())
+                .withFailMessage(schema.validate().getErrorString())
+                .isTrue();
+        assertThat(schema.getEdge(GROUP_BASIC_EDGE).getSource()).isEqualTo(STRING);
+        assertThat(schema.toString())
+                .isEqualTo(GRAPH_A_SCHEMA.toString())
+                .isNotEqualTo(graphBSchema.toString());
+    }
+
+    @Test
+    public void shouldRetainGroupDestinationTypeWhenConflictingSchemasMerge() throws OperationException {
+        // Given
+        addGraphWith(GRAPH_ID_A, GRAPH_A_SCHEMA);
+        final Schema graphBSchema = new Schema.Builder()
+                .merge(GRAPH_A_SCHEMA)
+                .edge(GROUP_BASIC_EDGE, new SchemaEdgeDefinition.Builder()
+                        .merge(EDGE_DEFINITION)
+                        .destination(INTEGER)
+                        .build())
+                .build();
+        addGraphWith(GRAPH_ID_B, graphBSchema);
+
+        // When
+        final Schema schema = federatedStore.execute(new GetSchema.Builder().build(), testContext);
+
+        // Then
+        assertThat(schema.validate().isValid())
+                .withFailMessage(schema.validate().getErrorString())
+                .isTrue();
+        assertThat(schema.getEdge(GROUP_BASIC_EDGE).getDestination()).isEqualTo(STRING);
+        assertThat(schema.toString())
+                .isEqualTo(GRAPH_A_SCHEMA.toString())
+                .isNotEqualTo(graphBSchema.toString());
+    }
+
+    @Test
+    public void shouldRetainGroupDescriptionWhenConflictingSchemasMerge() throws OperationException {
+        // Given
+        addGraphWith(GRAPH_ID_A, GRAPH_A_SCHEMA);
+        final Schema graphBSchema = new Schema.Builder()
+                .merge(GRAPH_A_SCHEMA)
+                .edge(GROUP_BASIC_EDGE, new SchemaEdgeDefinition.Builder()
+                        .merge(EDGE_DEFINITION)
+                        .description(GRAPH_ID_B)
+                        .build())
+                .build();
+        addGraphWith(GRAPH_ID_B, graphBSchema);
+
+        // When
+        final Schema schema = federatedStore.execute(new GetSchema.Builder().build(), testContext);
+
+        // Then
+        assertThat(schema.validate().isValid())
+                .withFailMessage(schema.validate().getErrorString())
+                .isTrue();
+        assertThat(schema.getEdge(GROUP_BASIC_EDGE).getDescription()).isEqualTo(GRAPH_ID_A);
+        assertThat(schema.toString())
+                .isEqualTo(GRAPH_A_SCHEMA.toString())
+                .isNotEqualTo(graphBSchema.toString());
+    }
+
+    @Test
+    public void shouldRetainGroupDirectedTypeWhenConflictingSchemasMerge() throws OperationException {
+        // Given
+        addGraphWith(GRAPH_ID_A, GRAPH_A_SCHEMA);
+        final Schema graphBSchema = new Schema.Builder()
+                .merge(GRAPH_A_SCHEMA)
+                .edge(GROUP_BASIC_EDGE, new SchemaEdgeDefinition.Builder()
+                        .merge(EDGE_DEFINITION)
+                        .directed(DIRECTED_TRUE)
+                        .build())
+                .build();
+        addGraphWith(GRAPH_ID_B, graphBSchema);
+
+        // When
+        final Schema schema = federatedStore.execute(new GetSchema.Builder().build(), testContext);
+
+        // Then
+        assertThat(schema.validate().isValid())
+                .withFailMessage(schema.validate().getErrorString())
+                .isTrue();
+        assertThat(schema.getEdge(GROUP_BASIC_EDGE).getDirected()).isEqualTo(DIRECTED_EITHER);
+        assertThat(schema.toString())
+                .isEqualTo(GRAPH_A_SCHEMA.toString())
+                .isNotEqualTo(graphBSchema.toString());
+    }
+
+    @Test
+    public void shouldRetainGroupGroupByWhenConflictingSchemasMerge() throws OperationException {
+        // Given
+        addGraphWith(GRAPH_ID_A, GRAPH_A_SCHEMA);
+        final Schema graphBSchema = new Schema.Builder()
+                .merge(GRAPH_A_SCHEMA)
+                .edge(GROUP_BASIC_EDGE, new SchemaEdgeDefinition.Builder()
+                        .merge(EDGE_DEFINITION)
+                        .groupBy(VISIBILITY)
+                        .build())
+                .build();
+        addGraphWith(GRAPH_ID_B, graphBSchema);
+
+        // When
+        final Schema schema = federatedStore.execute(new GetSchema.Builder().build(), testContext);
+
+        // Then
+        assertThat(schema.validate().isValid())
+                .withFailMessage(schema.validate().getErrorString())
+                .isTrue();
+        assertThat(schema.getEdge(GROUP_BASIC_EDGE).getGroupBy()).containsExactly(PROPERTY_1);
+        assertThat(schema.toString())
+                .isEqualTo(GRAPH_A_SCHEMA.toString())
+                .isNotEqualTo(graphBSchema.toString());
+    }
+
+    @Test
+    public void shouldOverwriteTypeDefinitionAggregationFunctionWhenConflictingSchemasMerge() throws OperationException {
+        // Given
+        addGraphWith(GRAPH_ID_A, GRAPH_A_SCHEMA);
+        final Schema graphBSchema = new Schema.Builder()
+                .merge(GRAPH_A_SCHEMA)
+                .type(INTEGER, new TypeDefinition.Builder()
+                        .clazz(Integer.class)
+                        .serialiser(new OrderedIntegerSerialiser())
+                        .aggregateFunction(new Last())
+                        .validateFunctions(new IsLessThan(10))
+                        .build())
+                .build();
+        addGraphWith(GRAPH_ID_B, graphBSchema);
+
+        // When
+        final Schema schema = federatedStore.execute(new GetSchema.Builder().build(), testContext);
+
+        // Then
+        assertThat(schema.validate().isValid())
+                .withFailMessage(schema.validate().getErrorString())
+                .isTrue();
+        assertThat(schema.getEdge(GROUP_BASIC_EDGE).getPropertyTypeDef(PROPERTY_1).getAggregateFunction())
+                .isEqualTo(new Last());
+        assertThat(schema.toString())
+                .isNotEqualTo(GRAPH_A_SCHEMA.toString())
+                .isEqualTo(graphBSchema.toString());
+    }
+
+    @Test
+    public void shouldAppendTypeDefinitionValidationFunctionWhenConflictingSchemasMerge() throws OperationException {
+        // Given
+        addGraphWith(GRAPH_ID_A, GRAPH_A_SCHEMA);
+        final Schema graphBSchema = new Schema.Builder()
+                .merge(GRAPH_A_SCHEMA)
+                .type(INTEGER, new TypeDefinition.Builder()
+                        .clazz(Integer.class)
+                        .serialiser(new OrderedIntegerSerialiser())
+                        .aggregateFunction(new Sum())
+                        .validateFunctions(new IsLessThan(20))
+                        .build())
+                .build();
+        addGraphWith(GRAPH_ID_B, graphBSchema);
+
+        // When
+        final Schema schema = federatedStore.execute(new GetSchema.Builder().build(), testContext);
+
+        // Then
+        assertThat(schema.validate().isValid())
+                .withFailMessage(schema.validate().getErrorString())
+                .isTrue();
+        assertThat(schema.getEdge(GROUP_BASIC_EDGE).getPropertyTypeDef(PROPERTY_1).getValidateFunctions())
+                .containsExactlyInAnyOrder(new IsLessThan(10), new IsLessThan(20));
+        assertThat(schema.toString())
+                .isNotEqualTo(GRAPH_A_SCHEMA.toString())
+                .isNotEqualTo(graphBSchema.toString());
+    }
+
+    private void addGraphWith(final String graphId, final Schema schema) throws OperationException {
+        federatedStore.execute(new AddGraph.Builder()
+                .graphId(graphId)
+                .schema(schema)
+                .storeProperties(STORE_PROPERTIES.clone())
+                .build(), testContext);
+    }
+}

--- a/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreSchemaTest.java
+++ b/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreSchemaTest.java
@@ -53,6 +53,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.ACCUMULO_STORE_SINGLE_USE_PROPERTIES;
 import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.DEST_BASIC;
+import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.GRAPH_ID_A;
+import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.GRAPH_ID_B;
+import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.GRAPH_ID_C;
 import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.GRAPH_ID_TEST_FEDERATED_STORE;
 import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.GROUP_BASIC_EDGE;
 import static uk.gov.gchq.gaffer.federatedstore.FederatedStoreTestUtil.PROPERTY_1;
@@ -71,9 +74,6 @@ import static uk.gov.gchq.gaffer.store.TestTypes.DIRECTED_EITHER;
 import static uk.gov.gchq.gaffer.user.StoreUser.testUser;
 
 public class FederatedStoreSchemaTest {
-    public static final String GRAPH_ID_A = "a";
-    public static final String GRAPH_ID_B = "b";
-    public static final String GRAPH_ID_C = "c";
     public static final String DEST_2 = DEST_BASIC + 2;
     public static final AccumuloProperties STORE_PROPERTIES = loadAccumuloStoreProperties(ACCUMULO_STORE_SINGLE_USE_PROPERTIES);
     private static final Schema STRING_TYPE = new Schema.Builder()
@@ -258,7 +258,9 @@ public class FederatedStoreSchemaTest {
         final Schema schema = federatedStore.execute(new GetSchema.Builder().build(), testContext);
 
         // Then
-        assertThat(schema.validate().isValid()).withFailMessage(schema.validate().getErrorString()).isTrue();
+        assertThat(schema.validate().isValid())
+                .withFailMessage(schema.validate().getErrorString())
+                .isTrue();
     }
 
     @Test

--- a/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreTestUtil.java
+++ b/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreTestUtil.java
@@ -69,6 +69,7 @@ public final class FederatedStoreTestUtil {
 
     public static final String GRAPH_ID_A = "graphA";
     public static final String GRAPH_ID_B = "graphB";
+    public static final String GRAPH_ID_C = "graphC";
     public static final String FEDERATED_STORE_SINGLE_USE_PROPERTIES = "properties/singleUseFederatedStore.properties";
     public static final String SCHEMA_EDGE_BASIC_JSON = "/schema/basicEdgeSchema.json";
     public static final String SCHEMA_ENTITY_BASIC_JSON = "/schema/basicEntitySchema.json";


### PR DESCRIPTION
It could be argued that these tests should be added to `SchemaTest`, however, the reason I have put them here is that they should not only test schema merging but also any interactions that might have with the federated store.