### PR TITLE
Gh-2766: Removed userRequestingDefaultGraphsOverride

### DIFF
--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/FederatedStore.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/FederatedStore.java
@@ -587,14 +587,8 @@ public class FederatedStore extends Store {
     }
 
     private List<GraphSerialisable> getDefaultGraphs(final User user, final IFederationOperation operation) {
-
-        boolean isAdminRequestingOverridingDefaultGraphs =
-                operation.isUserRequestingAdminUsage()
-                        && (operation instanceof FederatedOperation)
-                        && ((FederatedOperation) operation).isUserRequestingDefaultGraphsOverride();
-
-        if (isNull(storeConfiguredGraphIds) || isAdminRequestingOverridingDefaultGraphs) {
-            return graphStorage.get(user, null, (/*TODO FS examine isAdminRequestingOverridingDefaultGraphs vs ->*/operation.isUserRequestingAdminUsage() ? getProperties().getAdminAuth() : null));
+        if (isNull(storeConfiguredGraphIds)) {
+            return graphStorage.get(user, null, (operation.isUserRequestingAdminUsage() ? getProperties().getAdminAuth() : null));
         } else {
             //This operation has already been processes once, by this store.
             String keyForProcessedFedStoreId = getKeyForProcessedFedStoreId();

--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/FederatedOperation.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/FederatedOperation.java
@@ -70,7 +70,6 @@ public class FederatedOperation<INPUT, OUTPUT> implements IFederationOperation, 
     private boolean skipFailedFederatedExecution = DEFAULT_SKIP_FAILED_FEDERATED_EXECUTION;
     private Map<String, String> options;
     private boolean userRequestingAdminUsage;
-    private boolean userRequestingDefaultGraphsOverride;
 
     @Override
     @JsonProperty("graphIds")
@@ -120,20 +119,6 @@ public class FederatedOperation<INPUT, OUTPUT> implements IFederationOperation, 
     @Override
     public FederatedOperation<INPUT, OUTPUT> setUserRequestingAdminUsage(final boolean adminRequest) {
         userRequestingAdminUsage = adminRequest;
-        return this;
-    }
-
-    public boolean isUserRequestingDefaultGraphsOverride() {
-        return userRequestingDefaultGraphsOverride;
-    }
-
-    @JsonGetter("userRequestingDefaultGraphsOverride")
-    public Boolean _isUserRequestingDefaultGraphsOverride() {
-        return userRequestingDefaultGraphsOverride ? true : null;
-    }
-
-    public FederatedOperation<INPUT, OUTPUT> isUserRequestingDefaultGraphsOverride(final boolean userRequestingDefaultGraphsOverride) {
-        this.userRequestingDefaultGraphsOverride = userRequestingDefaultGraphsOverride;
         return this;
     }
 
@@ -217,7 +202,6 @@ public class FederatedOperation<INPUT, OUTPUT> implements IFederationOperation, 
                 .mergeFunction(mergeFunction)
                 .graphIds(graphIds)
                 .setUserRequestingAdminUsage(userRequestingAdminUsage)
-                .isUserRequestingDefaultGraphsOverride(userRequestingDefaultGraphsOverride)
                 .skipFailedFederatedExecution(skipFailedFederatedExecution)
                 .options(options);
     }
@@ -246,8 +230,7 @@ public class FederatedOperation<INPUT, OUTPUT> implements IFederationOperation, 
                     .append(this.mergeFunction, that.mergeFunction)
                     .append(this.skipFailedFederatedExecution, that.skipFailedFederatedExecution)
                     .append(this.options, that.options)
-                    .append(this.userRequestingAdminUsage, that.userRequestingAdminUsage)
-                    .append(this.userRequestingDefaultGraphsOverride, that.userRequestingDefaultGraphsOverride);
+                    .append(this.userRequestingAdminUsage, that.userRequestingAdminUsage);
 
             if (equalsBuilder.isEquals()) {
                 try {
@@ -275,7 +258,6 @@ public class FederatedOperation<INPUT, OUTPUT> implements IFederationOperation, 
                 .append(skipFailedFederatedExecution)
                 .append(options)
                 .append(userRequestingAdminUsage)
-                .append(userRequestingDefaultGraphsOverride)
                 .build();
     }
 


### PR DESCRIPTION
`userRequestingDefaultGraphsOverride` removed as `graphIds` can be used instead.

# Related Issue

- Resolve #2766