### PR TITLE
Gh-2845: Update class variable to use Map interface

### DIFF
--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/NamedOperation.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/named/operation/NamedOperation.java
@@ -63,7 +63,7 @@ public class NamedOperation<I_ITEM, O> implements
 
     @Required
     private String operationName;
-    private LinkedHashMap<String, Object> parameters;
+    private Map<String, Object> parameters;
     private Map<String, String> options;
 
     @Override


### PR DESCRIPTION
Resolves issue: #2845 

Updated class variable `parameter` to be of type `Map`.