### PR TITLE
gh-2880 RemoveGraph errors when graphId does not exist

### DIFF
--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreCache.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreCache.java
@@ -20,6 +20,7 @@ import uk.gov.gchq.gaffer.cache.Cache;
 import uk.gov.gchq.gaffer.cache.ICache;
 import uk.gov.gchq.gaffer.cache.exception.CacheOperationException;
 import uk.gov.gchq.gaffer.commonutil.pair.Pair;
+import uk.gov.gchq.gaffer.core.exception.GafferRuntimeException;
 import uk.gov.gchq.gaffer.exception.SerialisationException;
 import uk.gov.gchq.gaffer.graph.Graph;
 import uk.gov.gchq.gaffer.graph.GraphSerialisable;
@@ -96,7 +97,7 @@ public class FederatedStoreCache extends Cache<String, Pair<GraphSerialisable, F
      *
      * @param graphId the ID of the {@link Graph} to retrieve
      * @return the {@link GraphSerialisable} related to the specified ID
-     * @exception CacheOperationException exception
+     * @throws CacheOperationException exception
      */
     public GraphSerialisable getGraphFromCache(final String graphId) throws CacheOperationException {
         return cacheTransient.getGraphFromCache(graphId);
@@ -125,7 +126,7 @@ public class FederatedStoreCache extends Cache<String, Pair<GraphSerialisable, F
             final byte[] accessFromCache = cacheTransient.getAccessFromCache(graphId);
             return (isNull(accessFromCache)) ? null : JSONSerialiser.deserialise(accessFromCache, FederatedAccess.class);
         } catch (final Exception e) {
-            throw new RuntimeException(e);
+            throw new GafferRuntimeException(String.format("Error Getting Access from Cache for graphId:%s", graphId), e);
         }
     }
 

--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreCacheTransient.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/FederatedStoreCacheTransient.java
@@ -114,6 +114,7 @@ public class FederatedStoreCacheTransient extends Cache<String, Pair<GraphSerial
     }
 
     public byte[] getAccessFromCache(final String graphId) throws CacheOperationException {
-        return getFromCache(graphId).getSecond();
+        final Pair<GraphSerialisable, byte[]> fromCache = getFromCache(graphId);
+        return isNull(fromCache) ? null : fromCache.getSecond();
     }
 }

--- a/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/operation/handler/impl/FederatedRemoveGraphHandlerTest.java
+++ b/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/operation/handler/impl/FederatedRemoveGraphHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 Crown Copyright
+ * Copyright 2017-2023 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static uk.gov.gchq.gaffer.user.StoreUser.testUser;
 
 public class FederatedRemoveGraphHandlerTest {
@@ -100,7 +101,7 @@ public class FederatedRemoveGraphHandlerTest {
 
         assertEquals(1, store.getGraphs(testUser, null, new RemoveGraph()).size());
 
-        new FederatedRemoveGraphHandler().doOperation(
+        final Boolean removed = new FederatedRemoveGraphHandler().doOperation(
                 new RemoveGraph.Builder()
                         .graphId(EXPECTED_GRAPH_ID)
                         .build(),
@@ -110,6 +111,30 @@ public class FederatedRemoveGraphHandlerTest {
         Collection<GraphSerialisable> graphs = store.getGraphs(testUser, null, new RemoveGraph());
 
         assertThat(graphs).hasSize(1);
+        assertFalse(removed);
+    }
+
+    @Test
+    public void shouldReturnFalseWhenNoGraphWasRemoved() throws Exception {
+        FederatedStore store = new FederatedStore();
+        final FederatedStoreProperties federatedStoreProperties = new FederatedStoreProperties();
+        federatedStoreProperties.setCacheServiceClass(CACHE_SERVICE_CLASS_STRING);
+
+        store.initialise(FEDERATEDSTORE_GRAPH_ID, null, federatedStoreProperties);
+
+        assertEquals(0, store.getGraphs(testUser, null, new RemoveGraph()).size());
+
+        final Boolean removed = new FederatedRemoveGraphHandler().doOperation(
+                new RemoveGraph.Builder()
+                        .graphId(EXPECTED_GRAPH_ID)
+                        .build(),
+                new Context(testUser),
+                store);
+
+        Collection<GraphSerialisable> graphs = store.getGraphs(testUser, null, new RemoveGraph());
+
+        assertThat(graphs).hasSize(0);
+        assertFalse(removed);
 
     }
 


### PR DESCRIPTION
# Related Issue

- Resolve #2880