### PR TITLE
Gh-2968: Spring REST has multiple occurrences of org.json.JSONObject on the class path

### DIFF
--- a/rest-api/spring-rest/pom.xml
+++ b/rest-api/spring-rest/pom.xml
@@ -171,6 +171,9 @@
     <profiles>
         <profile>
             <id>demo</id>
+            <properties>
+               <maven.test.skip>true</maven.test.skip>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -184,6 +187,14 @@
                                 -Dgaffer.schemas=${project.build.outputDirectory}/schemas
                             </jvmArguments>
                         </configuration>
+                        <executions>
+                            <execution>
+                                <id>run</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/rest-api/spring-rest/pom.xml
+++ b/rest-api/spring-rest/pom.xml
@@ -118,6 +118,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- Introduces duplicate org.json.JSONObject on the class path -->
+                <exclusion>
+                    <groupId>com.vaadin.external.google</groupId>
+                    <artifactId>android-json</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Already defined in parent POM but required for surefire to discover tests -->
         <dependency>

--- a/rest-api/spring-rest/pom.xml
+++ b/rest-api/spring-rest/pom.xml
@@ -119,7 +119,7 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
             <exclusions>
-                <!-- Introduces duplicate org.json.JSONObject on the class path -->
+                <!-- Removed because it introduces duplicate org.json.JSONObject on the class path -->
                 <exclusion>
                     <groupId>com.vaadin.external.google</groupId>
                     <artifactId>android-json</artifactId>


### PR DESCRIPTION
Also improves the demo profile to run the demo whenever the profile is used. Otherwise you need to call `mvn spring-boot:run -Pdemo -pl :spring-rest` to get the demo working. Can now just run `mvn clean install -Pdemo -pl :spring-rest` to get the same result.