### PR TITLE
Gh-2948: Upgrade JUnit and related dependencies and plugins

### DIFF
--- a/example/road-traffic/road-traffic-rest/pom.xml
+++ b/example/road-traffic/road-traffic-rest/pom.xml
@@ -200,7 +200,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${failsafe.version}</version>
                         <executions>
                             <execution>
                                 <id>system-test</id>

--- a/example/road-traffic/road-traffic-rest/pom.xml
+++ b/example/road-traffic/road-traffic-rest/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016-2022 Crown Copyright
+  ~ Copyright 2016-2023 Crown Copyright
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <junit.version>5.9.3</junit.version>
         <junit-suite.version>1.9.3</junit-suite.version>
         <assertj.version>3.24.2</assertj.version>
-        <mockito.version>4.6.1</mockito.version>
+        <mockito.version>4.11.0</mockito.version>
         <failsafe.version>3.0.0-M7</failsafe.version>
         <slf4j.api.version>1.7.36</slf4j.api.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,9 +50,9 @@
         <java.version>1.8</java.version>
 
         <!-- Dependency version properties -->
-        <junit.version>5.9.0</junit.version>
-        <junit-suite.version>1.9.0</junit-suite.version>
-        <assertj.version>3.23.1</assertj.version>
+        <junit.version>5.9.3</junit.version>
+        <junit-suite.version>1.9.3</junit-suite.version>
+        <assertj.version>3.24.2</assertj.version>
         <mockito.version>4.6.1</mockito.version>
         <failsafe.version>3.0.0-M7</failsafe.version>
         <slf4j.api.version>1.7.36</slf4j.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <install.plugin.version>3.0.0-M1</install.plugin.version>
         <resources.plugin.version>3.2.0</resources.plugin.version>
         <clean.plugin.version>3.2.0</clean.plugin.version>
-        <jacoco.plugin.version>0.8.7</jacoco.plugin.version>
+        <jacoco.plugin.version>0.8.10</jacoco.plugin.version>
         <jar.plugin.version>3.2.2</jar.plugin.version>
         <javadoc.plugin.version>3.5.0</javadoc.plugin.version>
         <nexus.plugin.version>1.6.8</nexus.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@
         <junit-suite.version>1.9.3</junit-suite.version>
         <assertj.version>3.24.2</assertj.version>
         <mockito.version>4.11.0</mockito.version>
-        <failsafe.version>3.0.0-M7</failsafe.version>
         <slf4j.api.version>1.7.36</slf4j.api.version>
 
         <scala.minor.version>2.11</scala.minor.version>
@@ -117,7 +116,8 @@
         <scm.plugin.version>3.1.0</scm.plugin.version>
         <shade.plugin.version>3.2.4</shade.plugin.version>
         <source.plugin.version>3.2.1</source.plugin.version>
-        <surefire.plugin.version>3.0.0-M5</surefire.plugin.version>
+        <surefire.plugin.version>3.1.2</surefire.plugin.version>
+        <failsafe.plugin.version>3.1.2</failsafe.plugin.version>
         <cargo.plugin.version>1.9.10</cargo.plugin.version>
         <enforcer.plugin.version>3.1.0</enforcer.plugin.version>
         <site.plugin.version>3.12.1</site.plugin.version>
@@ -919,7 +919,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${failsafe.version}</version>
+                <version>${failsafe.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>integration-test</id>
@@ -1347,7 +1347,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${surefire.plugin.version}</version>
                         <configuration>
                             <forkCount>0</forkCount>
                         </configuration>
@@ -1500,7 +1499,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${surefire.plugin.version}</version>
                         <configuration>
                             <argLine>${surefireArgLine}</argLine>
                         </configuration>
@@ -1508,7 +1506,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${failsafe.version}</version>
                         <configuration>
                             <argLine>${failsafeArgLine}</argLine>
                         </configuration>


### PR DESCRIPTION
The versions of JUnit and JUnit Suites need to be kept in sync when upgrading their versions.

# Related Issue

- Resolve #2948