### PR TITLE
Gh-2997: Prevented a NullPointerException being thrown.

### DIFF
--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/MiniAccumuloStore.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/MiniAccumuloStore.java
@@ -148,11 +148,15 @@ public class MiniAccumuloStore extends AccumuloStore {
 
         MiniAccumuloConfig config = new MiniAccumuloConfig(getAccumuloDirectory(), rootUserPassword);
 
-        String[] zookeepers = getProperties().getZookeepers().split(":");
-        if (zookeepers.length == 2) {
-            config.setZooKeeperPort(Integer.parseInt(zookeepers[1]));
-        } else {
+        if (getProperties().getZookeepers() == null) {
             config.setZooKeeperPort(DEFAULT_ZOOKEEPER_PORT);
+        } else {
+            String[] zookeepers = getProperties().getZookeepers().split(":");
+            if (zookeepers.length == 2) {
+                config.setZooKeeperPort(Integer.parseInt(zookeepers[1]));
+            } else {
+                config.setZooKeeperPort(DEFAULT_ZOOKEEPER_PORT);
+            }
         }
 
         config.setInstanceName(getProperties().getInstance());

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/MiniAccumuloStore.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/MiniAccumuloStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Crown Copyright
+ * Copyright 2023 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/MiniAccumuloStore.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/MiniAccumuloStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Crown Copyright
+ * Copyright 2020-2023 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/MiniAccumuloStore.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/MiniAccumuloStore.java
@@ -148,15 +148,12 @@ public class MiniAccumuloStore extends AccumuloStore {
 
         MiniAccumuloConfig config = new MiniAccumuloConfig(getAccumuloDirectory(), rootUserPassword);
 
-        if (getProperties().getZookeepers() == null) {
-            config.setZooKeeperPort(DEFAULT_ZOOKEEPER_PORT);
+        String zookeepers = getProperties().getZookeepers();
+        String[] zooKeepersArray = zookeepers != null ? zookeepers.split(":") : null;
+        if (zooKeepersArray != null && zooKeepersArray.length == 2) {
+            config.setZooKeeperPort(Integer.parseInt(zooKeepersArray[1]));
         } else {
-            String[] zookeepers = getProperties().getZookeepers().split(":");
-            if (zookeepers.length == 2) {
-                config.setZooKeeperPort(Integer.parseInt(zookeepers[1]));
-            } else {
-                config.setZooKeeperPort(DEFAULT_ZOOKEEPER_PORT);
-            }
+            config.setZooKeeperPort(DEFAULT_ZOOKEEPER_PORT);
         }
 
         config.setInstanceName(getProperties().getInstance());


### PR DESCRIPTION
This commit refactors the code to address the scenario where the zookeepers property is null. The modified code now checks if the zookeepers property is null, and if so, it sets the ZooKeeperPort to the default value. This change ensures that a NullPointerException is avoided when accessing the zookeepers property and provides a more robust behavior in the case of a missing or null value.