### PR TITLE
Gh-2997: Fix NullPointerException in MiniAccumuloStore

### DIFF
--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/MiniAccumuloStore.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/MiniAccumuloStore.java
@@ -149,17 +149,16 @@ public class MiniAccumuloStore extends AccumuloStore {
         MiniAccumuloConfig config = new MiniAccumuloConfig(getAccumuloDirectory(), rootUserPassword);
 
         String zookeeperStr = getProperties().getZookeepers();
+        int zookeeperPort = DEFAULT_ZOOKEEPER_PORT;
+
         if (zookeeperStr != null) {
-            String [] zookeepers = zookeeperStr.split(":");
+            String[] zookeepers = zookeeperStr.split(":");
             if (zookeepers.length == 2) {
-                config.setZooKeeperPort(Integer.parseInt(zookeepers[1]));
-            } else {
-                config.setZooKeeperPort(DEFAULT_ZOOKEEPER_PORT);
+                zookeeperPort = Integer.parseInt(zookeepers[1]);
             }
-        } else {
-            config.setZooKeeperPort(DEFAULT_ZOOKEEPER_PORT);
         }
 
+        config.setZooKeeperPort(zookeeperPort);
         config.setInstanceName(getProperties().getInstance());
 
         CLUSTER_INSTANCES.put(getProperties().getInstance(), new MiniAccumuloCluster(config));

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/MiniAccumuloStore.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/MiniAccumuloStore.java
@@ -148,9 +148,14 @@ public class MiniAccumuloStore extends AccumuloStore {
 
         MiniAccumuloConfig config = new MiniAccumuloConfig(getAccumuloDirectory(), rootUserPassword);
 
-        String[] zookeepers = getProperties().getZookeepers().split(":");
-        if (zookeepers.length == 2) {
-            config.setZooKeeperPort(Integer.parseInt(zookeepers[1]));
+        String zookeeperStr = getProperties().getZookeepers();
+        if (zookeeperStr != null) {
+            String [] zookeepers = zookeeperStr.split(":");
+            if (zookeepers.length == 2) {
+                config.setZooKeeperPort(Integer.parseInt(zookeepers[1]));
+            } else {
+                config.setZooKeeperPort(DEFAULT_ZOOKEEPER_PORT);
+            }
         } else {
             config.setZooKeeperPort(DEFAULT_ZOOKEEPER_PORT);
         }


### PR DESCRIPTION
Details: Added null check for getZookeepers() to prevent NullPointerException when the accumulo.zookeepers property is not defined in the store.properties file. In case of a null return from getZookeepers(), the default Zookeeper port is now set.