### PR TITLE
Gh-2944: Ensure CancelScheduledJobHandler is added only when Jobs are enabled.

### DIFF
--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/Store.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/Store.java
@@ -1009,6 +1009,7 @@ public abstract class Store {
             addOperationHandler(GetJobDetails.class, new GetJobDetailsHandler());
             addOperationHandler(GetAllJobDetails.class, new GetAllJobDetailsHandler());
             addOperationHandler(GetJobResults.class, new GetJobResultsHandler());
+            addOperationHandler(CancelScheduledJob.class, new CancelScheduledJobHandler());
         }
 
         // Output
@@ -1065,7 +1066,6 @@ public abstract class Store {
         addOperationHandler(ToSingletonList.class, new ToSingletonListHandler());
         addOperationHandler(Reduce.class, new ReduceHandler());
         addOperationHandler(Join.class, new JoinHandler());
-        addOperationHandler(CancelScheduledJob.class, new CancelScheduledJobHandler());
 
         // Context variables
         addOperationHandler(SetVariable.class, new SetVariableHandler());

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/StoreTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/StoreTest.java
@@ -651,7 +651,6 @@ public class StoreTest {
                         ToSingletonList.class,
                         ForEach.class,
                         Reduce.class,
-                        CancelScheduledJob.class,
 
                         // Function
                         Filter.class,


### PR DESCRIPTION
Previously, the CancelScheduledJobHandler would throw an OperationException with the message 'JobTracker not enabled' if used when Jobs were not enabled. This issue arose because the handler was being added even when Jobs were not enabled. To resolve this, changes were made to ensure that the CancelScheduledJobHandler is only added when Jobs are enabled. This ensures that the handler functions correctly and prevents the unnecessary exception from being thrown.