### PR TITLE
Gh-2680: Fix repo priority in spark-library

### DIFF
--- a/library/spark/pom.xml
+++ b/library/spark/pom.xml
@@ -31,6 +31,14 @@
     </modules>
 
     <repositories>
+        <!-- Manually specify central repo to ensure it is the highest priority.
+         Otherwise, Maven trys to fetch everything from the spark repo which can
+         cause a wait for a timeout before trying central. This is because repos
+         in a POM are prioritised before the super POM where central is declared. -->
+        <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
         <repository>
             <id>Spark Packages</id>
             <url>https://repos.spark-packages.org/</url>

--- a/library/spark/pom.xml
+++ b/library/spark/pom.xml
@@ -14,6 +14,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/library/spark/pom.xml
+++ b/library/spark/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016-2020 Crown Copyright
+  ~ Copyright 2016-2023 Crown Copyright
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Related issue

- Resolve #2680