### PR TITLE
Gh-2836: New operation names endpoint

### DIFF
--- a/rest-api/common-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/AbstractOperationService.java
+++ b/rest-api/common-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/AbstractOperationService.java
@@ -53,17 +53,22 @@ public abstract class AbstractOperationService {
 
     protected abstract GraphFactory getGraphFactory();
 
-    public Set<Class <? extends Operation>> getSupportedOperations() {
-        return getGraphFactory().getGraph().getSupportedOperations();
-    }
-
-    public Set<String> getAllOperationsNames() {
-        Set<Class<? extends Operation>> operationClasses = new HashSet(ReflectionUtil.getSubTypes(Operation.class));
-        return operationClasses.stream().sorted(Comparator.comparing(Class::getSimpleName)).map(Class::getName).collect(Collectors.toCollection(LinkedHashSet::new));
+    public Set<Class<? extends Operation>> getSupportedOperations(final boolean includeUnsupported) {
+        Set<Class<? extends Operation>> operationsClasses;
+        if (includeUnsupported) {
+            operationsClasses = sortOperations(new HashSet(ReflectionUtil.getSubTypes(Operation.class)));
+        } else {
+            operationsClasses = sortOperations(getGraphFactory().getGraph().getSupportedOperations());
+        }
+        return operationsClasses;
     }
 
     public Set<OperationDetail> getSupportedOperationDetails() {
         return getSupportedOperationDetails(false);
+    }
+
+    private Set<Class<? extends Operation>> sortOperations(final Set<Class<? extends Operation>> operationClassesSet) {
+        return operationClassesSet.stream().sorted(Comparator.comparing(Class::getSimpleName)).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     public Set<OperationDetail> getSupportedOperationDetails(final boolean includeUnsupported) {
@@ -71,7 +76,7 @@ public abstract class AbstractOperationService {
         if (includeUnsupported) {
             operationClasses = new HashSet(ReflectionUtil.getSubTypes(Operation.class));
         } else {
-            operationClasses = getSupportedOperations();
+            operationClasses = getSupportedOperations(false);
         }
         Set<OperationDetail> operationDetails = new HashSet<>();
 

--- a/rest-api/common-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/AbstractOperationService.java
+++ b/rest-api/common-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/AbstractOperationService.java
@@ -33,8 +33,11 @@ import uk.gov.gchq.gaffer.store.Context;
 import uk.gov.gchq.koryphe.serialisation.json.SimpleClassNameIdResolver;
 import uk.gov.gchq.koryphe.util.ReflectionUtil;
 
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * An abstract OperationsService which allows for implementations to inject dependencies
@@ -52,6 +55,11 @@ public abstract class AbstractOperationService {
 
     public Set<Class <? extends Operation>> getSupportedOperations() {
         return getGraphFactory().getGraph().getSupportedOperations();
+    }
+
+    public Set<String> getAllOperationsNames() {
+        Set<Class<? extends Operation>> operationClasses = new HashSet(ReflectionUtil.getSubTypes(Operation.class));
+        return operationClasses.stream().sorted(Comparator.comparing(Class::getSimpleName)).map(Class::getName).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     public Set<OperationDetail> getSupportedOperationDetails() {

--- a/rest-api/common-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/AbstractOperationService.java
+++ b/rest-api/common-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/AbstractOperationService.java
@@ -37,6 +37,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 /**
@@ -63,12 +64,12 @@ public abstract class AbstractOperationService {
         return operationsClasses;
     }
 
-    public Set<OperationDetail> getSupportedOperationDetails() {
-        return getSupportedOperationDetails(false);
-    }
-
     private Set<Class<? extends Operation>> sortOperations(final Set<Class<? extends Operation>> operationClassesSet) {
         return operationClassesSet.stream().sorted(Comparator.comparing(Class::getSimpleName)).collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    public Set<OperationDetail> getSupportedOperationDetails() {
+        return getSupportedOperationDetails(false);
     }
 
     public Set<OperationDetail> getSupportedOperationDetails(final boolean includeUnsupported) {

--- a/rest-api/common-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/AbstractOperationService.java
+++ b/rest-api/common-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/AbstractOperationService.java
@@ -65,7 +65,7 @@ public abstract class AbstractOperationService {
     }
 
     private Set<Class<? extends Operation>> sortOperations(final Set<Class<? extends Operation>> operationClassesSet) {
-        return operationClassesSet.stream().sorted(Comparator.comparing(Class::getSimpleName)).collect(Collectors.toCollection(LinkedHashSet::new));
+        return operationClassesSet.stream().sorted(Comparator.comparing(Class::getName)).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     public Set<OperationDetail> getSupportedOperationDetails() {

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/IOperationController.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/IOperationController.java
@@ -40,7 +40,7 @@ public interface IOperationController {
             produces = APPLICATION_JSON_VALUE
     )
     @io.swagger.v3.oas.annotations.Operation(
-            summary = "Retrieves a list of supported operations"
+            summary = "Retrieves a sorted list of supported operations"
     )
     Set<Class<? extends Operation>> getOperations();
 
@@ -50,9 +50,9 @@ public interface IOperationController {
             produces = APPLICATION_JSON_VALUE
     )
     @io.swagger.v3.oas.annotations.Operation(
-            summary = "Retrieves a sorted list of all operations names"
+            summary = "Retrieves a sorted list of all operations"
     )
-    Set<String> getOperationsName();
+    Set<Class<? extends Operation>> getAllOperations();
 
     @RequestMapping(
             method = GET,

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/IOperationController.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/IOperationController.java
@@ -46,6 +46,16 @@ public interface IOperationController {
 
     @RequestMapping(
             method = GET,
+            path = "/all",
+            produces = APPLICATION_JSON_VALUE
+    )
+    @io.swagger.v3.oas.annotations.Operation(
+            summary = "Retrieves a sorted list of all operations names"
+    )
+    Set<String> getOperationsName();
+
+    @RequestMapping(
+            method = GET,
             path = "/details",
             produces = APPLICATION_JSON_VALUE
     )

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/OperationController.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/OperationController.java
@@ -64,12 +64,12 @@ public class OperationController extends AbstractOperationService implements IOp
 
     @Override
     public Set<Class<? extends Operation>> getOperations() {
-        return getSupportedOperations();
+        return getSupportedOperations(false);
     }
 
     @Override
-    public Set<String> getOperationsName() {
-        return getAllOperationsNames();
+    public Set<Class<? extends Operation>> getAllOperations() {
+        return getSupportedOperations(true);
     }
 
     @Override
@@ -96,7 +96,7 @@ public class OperationController extends AbstractOperationService implements IOp
             throw new GafferRuntimeException("Class: " + className + " was not found on the classpath.", e, Status.NOT_FOUND);
         } catch (final ClassCastException e) {
             throw new GafferRuntimeException(className + " does not extend Operation", e, Status.BAD_REQUEST);
-        } catch (final  IllegalAccessException | InstantiationException e) {
+        } catch (final IllegalAccessException | InstantiationException e) {
             throw new GafferRuntimeException("Unable to instantiate " + className, e);
         }
     }

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/OperationController.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/OperationController.java
@@ -68,6 +68,11 @@ public class OperationController extends AbstractOperationService implements IOp
     }
 
     @Override
+    public Set<String> getOperationsName() {
+        return getAllOperationsNames();
+    }
+
+    @Override
     public Set<OperationDetail> getAllOperationDetails() {
         return getSupportedOperationDetails();
     }

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/OperationControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/OperationControllerTest.java
@@ -104,7 +104,7 @@ public class OperationControllerTest {
 
         // Then
         Set<Class<? extends Operation>> operationClasses = graphFactory.getGraph().getSupportedOperations();
-        Set<Class<? extends Operation>> expectedOperations = operationClasses.stream().sorted(Comparator.comparing(Class::getSimpleName)).collect(Collectors.toCollection(LinkedHashSet::new));
+        Set<Class<? extends Operation>> expectedOperations = operationClasses.stream().sorted(Comparator.comparing(Class::getName)).collect(Collectors.toCollection(LinkedHashSet::new));
 
         assertThat(supportedOperations).containsExactlyElementsOf(expectedOperations);
         assertThat(supportedOperations).isNotEmpty();
@@ -117,7 +117,7 @@ public class OperationControllerTest {
 
         // Then
         Set<Class<? extends Operation>> operationClasses = new HashSet(ReflectionUtil.getSubTypes(Operation.class));
-        Set<Class<? extends Operation>> expectedOperations = operationClasses.stream().sorted(Comparator.comparing(Class::getSimpleName)).collect(Collectors.toCollection(LinkedHashSet::new));
+        Set<Class<? extends Operation>> expectedOperations = operationClasses.stream().sorted(Comparator.comparing(Class::getName)).collect(Collectors.toCollection(LinkedHashSet::new));
 
         assertThat(allOperations).containsExactlyElementsOf(expectedOperations);
         assertThat(allOperations).isNotEmpty();

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/OperationControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/OperationControllerTest.java
@@ -49,10 +49,7 @@ import uk.gov.gchq.koryphe.util.ReflectionUtil;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -91,6 +88,19 @@ public class OperationControllerTest {
                 .build();
 
         when(graphFactory.getGraph()).thenReturn(graph);
+    }
+
+    @Test
+    public void shouldReturnAllOperationNamesInSortedOrder() {
+        // Given / When
+        final Set<String> allOperationNames = operationController.getAllOperationsNames();
+
+        // Then
+        Set<Class<? extends Operation>> operationClasses = new HashSet(ReflectionUtil.getSubTypes(Operation.class));
+        Set<String> expectedOperationNames = operationClasses.stream().sorted(Comparator.comparing(Class::getSimpleName)).map(Class::getName).collect(Collectors.toCollection(LinkedHashSet::new));
+
+        assertThat(allOperationNames).containsExactlyElementsOf(expectedOperationNames);
+        assertThat(allOperationNames).isNotEmpty();
     }
 
     @SuppressWarnings({"unchecked"})

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/OperationControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/OperationControllerTest.java
@@ -49,7 +49,13 @@ import uk.gov.gchq.koryphe.util.ReflectionUtil;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/OperationControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/OperationControllerTest.java
@@ -91,16 +91,30 @@ public class OperationControllerTest {
     }
 
     @Test
-    public void shouldReturnAllOperationNamesInSortedOrder() {
+    public void shouldReturnAllSupportedOperationsInSortedOrder() {
         // Given / When
-        final Set<String> allOperationNames = operationController.getAllOperationsNames();
+        when(store.getSupportedOperations()).thenReturn(Sets.newHashSet(GetElements.class, AddElements.class));
+        final Set<Class<? extends Operation>> supportedOperations = operationController.getSupportedOperations(false);
+
+        // Then
+        Set<Class<? extends Operation>> operationClasses = graphFactory.getGraph().getSupportedOperations();
+        Set<Class<? extends Operation>> expectedOperations = operationClasses.stream().sorted(Comparator.comparing(Class::getSimpleName)).collect(Collectors.toCollection(LinkedHashSet::new));
+
+        assertThat(supportedOperations).containsExactlyElementsOf(expectedOperations);
+        assertThat(supportedOperations).isNotEmpty();
+    }
+
+    @Test
+    public void shouldReturnAllOperationsInSortedOrder() {
+        // Given / When
+        final Set<Class<? extends Operation>> allOperations = operationController.getSupportedOperations(true);
 
         // Then
         Set<Class<? extends Operation>> operationClasses = new HashSet(ReflectionUtil.getSubTypes(Operation.class));
-        Set<String> expectedOperationNames = operationClasses.stream().sorted(Comparator.comparing(Class::getSimpleName)).map(Class::getName).collect(Collectors.toCollection(LinkedHashSet::new));
+        Set<Class<? extends Operation>> expectedOperations = operationClasses.stream().sorted(Comparator.comparing(Class::getSimpleName)).collect(Collectors.toCollection(LinkedHashSet::new));
 
-        assertThat(allOperationNames).containsExactlyElementsOf(expectedOperationNames);
-        assertThat(allOperationNames).isNotEmpty();
+        assertThat(allOperations).containsExactlyElementsOf(expectedOperations);
+        assertThat(allOperations).isNotEmpty();
     }
 
     @SuppressWarnings({"unchecked"})


### PR DESCRIPTION
New "/graph/operations/all" endpoint for retrieving sorted operation names. 