### PR TITLE
Gh-2837: Endpoint for getting the Gaffer version

### DIFF
--- a/rest-api/common-rest/pom.xml
+++ b/rest-api/common-rest/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023 Crown Copyright
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>rest-api</artifactId>

--- a/rest-api/common-rest/pom.xml
+++ b/rest-api/common-rest/pom.xml
@@ -35,4 +35,14 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <resources>
+      <!-- Filter resources to expand variables -->
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+
 </project>

--- a/rest-api/common-rest/pom.xml
+++ b/rest-api/common-rest/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2023 Crown Copyright
+  ~ Copyright 2020-2023 Crown Copyright
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/rest-api/common-rest/src/main/resources/version.properties
+++ b/rest-api/common-rest/src/main/resources/version.properties
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-gaffer.version=2.0.1-SNAPSHOT
-koryphe.version=2.5.2
+gaffer.version=${project.version}
+koryphe.version=${koryphe.version}

--- a/rest-api/core-rest/pom.xml
+++ b/rest-api/core-rest/pom.xml
@@ -182,5 +182,11 @@
                 </configuration>
             </plugin>
         </plugins>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
     </build>
 </project>

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/application/ApplicationConfigV2.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/application/ApplicationConfigV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Crown Copyright
+ * Copyright 2016-2023 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import uk.gov.gchq.gaffer.rest.service.v2.JobServiceV2;
 import uk.gov.gchq.gaffer.rest.service.v2.OperationServiceV2;
 import uk.gov.gchq.gaffer.rest.service.v2.PropertiesServiceV2;
 import uk.gov.gchq.gaffer.rest.service.v2.StatusServiceV2;
+import uk.gov.gchq.gaffer.rest.service.v2.VersionServiceV2;
 import uk.gov.gchq.gaffer.rest.service.v2.example.ExampleBinder;
 import uk.gov.gchq.gaffer.rest.service.v2.example.ExamplesServiceV2;
 
@@ -72,6 +73,7 @@ public class ApplicationConfigV2 extends ApplicationConfig {
         resources.add(JobServiceV2.class);
         resources.add(ExamplesServiceV2.class);
         resources.add(PropertiesServiceV2.class);
+        resources.add(VersionServiceV2.class);
     }
 
 }

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/VersionServiceV2.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/VersionServiceV2.java
@@ -16,16 +16,17 @@
 
 package uk.gov.gchq.gaffer.rest.service.v2;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.ResponseHeader;
+
 import uk.gov.gchq.gaffer.rest.SystemProperty;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
 
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/VersionServiceV2.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/VersionServiceV2.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.rest.service.v2;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.ResponseHeader;
+import uk.gov.gchq.gaffer.rest.SystemProperty;
+
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+import static uk.gov.gchq.gaffer.rest.ServiceConstants.GAFFER_MEDIA_TYPE;
+import static uk.gov.gchq.gaffer.rest.ServiceConstants.GAFFER_MEDIA_TYPE_HEADER;
+import static uk.gov.gchq.gaffer.rest.ServiceConstants.GAFFER_MEDIA_TYPE_HEADER_DESCRIPTION;
+import static uk.gov.gchq.gaffer.rest.ServiceConstants.OK;
+
+@Path("/graph/version")
+@Api(value = "/version")
+public class VersionServiceV2 {
+
+    @GET
+    @ApiOperation(
+        value = "Returns the version of the gaffer graph",
+        notes = "A simple way to check the version of the gaffer graph.",
+        response = String.class,
+        produces = TEXT_PLAIN,
+            responseHeaders = {
+                @ResponseHeader(name = GAFFER_MEDIA_TYPE_HEADER, description = GAFFER_MEDIA_TYPE_HEADER_DESCRIPTION)
+            })
+    @ApiResponses(value = {@ApiResponse(code = 200, message = OK)})
+    public Response getGafferVersion() {
+        // Return the preloaded version string from the common-rest library
+        return Response.ok(SystemProperty.GAFFER_VERSION_DEFAULT)
+                .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
+                .build();
+    }
+
+}

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/VersionServiceV2Test.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/VersionServiceV2Test.java
@@ -26,6 +26,10 @@ import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
 class VersionServiceV2Test extends JerseyTest {
 
     @Override
@@ -34,7 +38,12 @@ class VersionServiceV2Test extends JerseyTest {
     }
 
     @Test
-    void sendRequestAndCheckForValidVersion() {
+    void sendRequestAndCheckForValidVersion() throws IOException {
+        // Read the version properties file test resource to compare the endpoint returned one to
+        InputStream fileStream = VersionServiceV2Test.class.getClassLoader().getResourceAsStream("version.properties");
+        Properties versionProps = new Properties();
+        versionProps.load(fileStream);
+
         // Send response to the endpoint
         Response response = target("/graph/version").request().get();
 
@@ -42,9 +51,11 @@ class VersionServiceV2Test extends JerseyTest {
         assertThat(response.getStatus()).isEqualTo(200);
         assertThat(response.getEntity().toString()).isNotNull();
 
-        // Test the version is correct
+        // Test the version is correct format and matches the test resource
         String responseString = response.readEntity(String.class);
-        assertThat(responseString).matches("(?!\\.)(\\d+(\\.\\d+)+)(?:[-.][A-Z]+)?(?![\\d.])$");
+        assertThat(responseString)
+            .matches("(?!\\.)(\\d+(\\.\\d+)+)(?:[-.][A-Z]+)?(?![\\d.])$")
+            .isEqualTo(versionProps.getProperty("gaffer.version"));
     }
 
 

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/VersionServiceV2Test.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/VersionServiceV2Test.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.rest.service.v2;
+
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class VersionServiceV2Test extends JerseyTest {
+
+    @Override
+    public Application configure() {
+        return new ResourceConfig(VersionServiceV2.class);
+    }
+
+    @Test
+    void sendRequestAndCheckForValidVersion() {
+        // Send response to the endpoint
+        Response response = target("/graph/version").request().get();
+
+        // Validate the response
+        assertEquals(200, response.getStatus(), "Should return OK status 200");
+        assertNotNull(response.getEntity().toString(), "Should return a version string");
+
+        // Test the version is correct
+        String responseString = response.readEntity(String.class);
+        assertTrue(
+            responseString.matches("(?!\\.)(\\d+(\\.\\d+)+)(?:[-.][A-Z]+)?(?![\\d.])$"),
+            "The response from the endpoint is not a valid version string, output: " + responseString);
+    }
+
+
+}

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/VersionServiceV2Test.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/VersionServiceV2Test.java
@@ -16,16 +16,17 @@
 
 package uk.gov.gchq.gaffer.rest.service.v2;
 
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+
+import org.junit.jupiter.api.Test;
+
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
 
-import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class VersionServiceV2Test extends JerseyTest {
 

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/VersionServiceV2Test.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/VersionServiceV2Test.java
@@ -24,9 +24,7 @@ import org.junit.jupiter.api.Test;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class VersionServiceV2Test extends JerseyTest {
 
@@ -41,14 +39,12 @@ class VersionServiceV2Test extends JerseyTest {
         Response response = target("/graph/version").request().get();
 
         // Validate the response
-        assertEquals(200, response.getStatus(), "Should return OK status 200");
-        assertNotNull(response.getEntity().toString(), "Should return a version string");
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getEntity().toString()).isNotNull();
 
         // Test the version is correct
         String responseString = response.readEntity(String.class);
-        assertTrue(
-            responseString.matches("(?!\\.)(\\d+(\\.\\d+)+)(?:[-.][A-Z]+)?(?![\\d.])$"),
-            "The response from the endpoint is not a valid version string, output: " + responseString);
+        assertThat(responseString).matches("(?!\\.)(\\d+(\\.\\d+)+)(?:[-.][A-Z]+)?(?![\\d.])$");
     }
 
 

--- a/rest-api/core-rest/src/test/resources/version.properties
+++ b/rest-api/core-rest/src/test/resources/version.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2023 Crown Copyright
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+gaffer.version=${project.version}
+koryphe.version=${koryphe.version}

--- a/rest-api/spring-rest/pom.xml
+++ b/rest-api/spring-rest/pom.xml
@@ -167,6 +167,12 @@
                 </executions>
             </plugin>
         </plugins>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
     </build>
     <profiles>
         <profile>

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/VersionController.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/VersionController.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.rest.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.bind.annotation.RestController;
+
+import uk.gov.gchq.gaffer.rest.SystemProperty;
+
+import org.springframework.web.bind.annotation.GetMapping;
+
+@RestController
+public class VersionController {
+
+    @GetMapping(path = "/graph/version")
+    @Operation(summary = "Retrieves the version of the Gaffer Graph")
+    public String getGafferVersion() {
+        // Return the preloaded version string from the common-rest library
+        return SystemProperty.GAFFER_VERSION_DEFAULT;
+    }
+}

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/VersionController.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/VersionController.java
@@ -19,11 +19,10 @@ package uk.gov.gchq.gaffer.rest.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import uk.gov.gchq.gaffer.rest.SystemProperty;
-
-import org.springframework.web.bind.annotation.GetMapping;
 
 import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/VersionController.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/VersionController.java
@@ -23,9 +23,15 @@ import uk.gov.gchq.gaffer.rest.SystemProperty;
 
 import org.springframework.web.bind.annotation.GetMapping;
 
+
 @RestController
 public class VersionController {
 
+    /**
+     * Rest endpoint for getting the Gaffer version of the graph.
+     *
+     * @return Version of the graph
+     */
     @GetMapping(path = "/graph/version")
     @Operation(summary = "Retrieves the version of the Gaffer Graph")
     public String getGafferVersion() {

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/VersionController.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/VersionController.java
@@ -17,13 +17,17 @@
 package uk.gov.gchq.gaffer.rest.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.springframework.web.bind.annotation.RestController;
 
 import uk.gov.gchq.gaffer.rest.SystemProperty;
 
 import org.springframework.web.bind.annotation.GetMapping;
 
+import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 
+@Tag(name = "version")
 @RestController
 public class VersionController {
 
@@ -32,7 +36,7 @@ public class VersionController {
      *
      * @return Version of the graph
      */
-    @GetMapping(path = "/graph/version")
+    @GetMapping(path = "/graph/version", produces = TEXT_PLAIN_VALUE)
     @Operation(summary = "Retrieves the version of the Gaffer Graph")
     public String getGafferVersion() {
         // Return the preloaded version string from the common-rest library

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/VersionControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/VersionControllerTest.java
@@ -26,7 +26,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 
 @ExtendWith(SpringExtension.class)
@@ -46,9 +46,6 @@ class VersionControllerTest {
 
         // Validate the returned string matches a valid version regex
         String resultString = result.getResponse().getContentAsString();
-        assertTrue(
-            resultString.matches("(?!\\.)(\\d+(\\.\\d+)+)(?:[-.][A-Z]+)?(?![\\d.])$"),
-            "The response from the endpoint is not a valid version string, output: " + resultString);
-
+        assertThat(resultString).matches("(?!\\.)(\\d+(\\.\\d+)+)(?:[-.][A-Z]+)?(?![\\d.])$");
     }
 }

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/VersionControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/VersionControllerTest.java
@@ -27,6 +27,7 @@ import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(value = VersionController.class)
@@ -38,11 +39,14 @@ class VersionControllerTest {
     @Test
     void sendRequestAndCheckForValidVersion() throws Exception {
         // Perform mock request to the endpoint
-        RequestBuilder requestBuilder = MockMvcRequestBuilders.get("/graph/version");
+        RequestBuilder requestBuilder = MockMvcRequestBuilders
+            .get("/graph/version")
+            .accept(TEXT_PLAIN_VALUE);
         MvcResult result = mockMvc.perform(requestBuilder).andReturn();
 
         // Validate the returned string matches a valid version regex
         String resultString = result.getResponse().getContentAsString();
+        //System.out.println(result.getResponse().toString());
         assertTrue(
             resultString.matches("(?!\\.)(\\d+(\\.\\d+)+)(?:[-.][A-Z]+)?(?![\\d.])$"),
             "The response from the endpoint is not a valid version string, output: " + resultString);

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/VersionControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/VersionControllerTest.java
@@ -44,6 +44,9 @@ class VersionControllerTest {
             .accept(TEXT_PLAIN_VALUE);
         MvcResult result = mockMvc.perform(requestBuilder).andReturn();
 
+        // Ensure OK response
+        assertThat(result.getResponse().getStatus()).isEqualTo(200);
+
         // Validate the returned string matches a valid version regex
         String resultString = result.getResponse().getContentAsString();
         assertThat(resultString).matches("(?!\\.)(\\d+(\\.\\d+)+)(?:[-.][A-Z]+)?(?![\\d.])$");

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/VersionControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/VersionControllerTest.java
@@ -29,6 +29,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 
+import java.io.InputStream;
+import java.util.Properties;
+
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(value = VersionController.class)
 class VersionControllerTest {
@@ -38,6 +41,11 @@ class VersionControllerTest {
 
     @Test
     void sendRequestAndCheckForValidVersion() throws Exception {
+        // Read the version properties file test resource to compare the endpoint returned one to
+        InputStream fileStream = VersionControllerTest.class.getClassLoader().getResourceAsStream("version.properties");
+        Properties versionProps = new Properties();
+        versionProps.load(fileStream);
+
         // Perform mock request to the endpoint
         RequestBuilder requestBuilder = MockMvcRequestBuilders
             .get("/graph/version")
@@ -47,8 +55,10 @@ class VersionControllerTest {
         // Ensure OK response
         assertThat(result.getResponse().getStatus()).isEqualTo(200);
 
-        // Validate the returned string matches a valid version regex
+        // Validate the returned string matches a valid version regex and test resource
         String resultString = result.getResponse().getContentAsString();
-        assertThat(resultString).matches("(?!\\.)(\\d+(\\.\\d+)+)(?:[-.][A-Z]+)?(?![\\d.])$");
+        assertThat(resultString)
+            .matches("(?!\\.)(\\d+(\\.\\d+)+)(?:[-.][A-Z]+)?(?![\\d.])$")
+            .isEqualTo(versionProps.getProperty("gaffer.version"));
     }
 }

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/VersionControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/VersionControllerTest.java
@@ -16,8 +16,6 @@
 
 package uk.gov.gchq.gaffer.rest.controller;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +25,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(value = VersionController.class)

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/VersionControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/VersionControllerTest.java
@@ -16,7 +16,6 @@
 
 package uk.gov.gchq.gaffer.rest.controller;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/VersionControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/VersionControllerTest.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.rest.controller;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -36,15 +37,13 @@ class VersionControllerTest {
     private MockMvc mockMvc;
 
     @Test
-    void retrieveAndCheckForValidVersion() throws Exception {
-        // Create mock request to the endpoint
+    void sendRequestAndCheckForValidVersion() throws Exception {
+        // Perform mock request to the endpoint
         RequestBuilder requestBuilder = MockMvcRequestBuilders.get("/graph/version");
-
-        // Run the request
         MvcResult result = mockMvc.perform(requestBuilder).andReturn();
-        String resultString = result.getResponse().getContentAsString();
 
         // Validate the returned string matches a valid version regex
+        String resultString = result.getResponse().getContentAsString();
         assertTrue(
             resultString.matches("(?!\\.)(\\d+(\\.\\d+)+)(?:[-.][A-Z]+)?(?![\\d.])$"),
             "The response from the endpoint is not a valid version string, output: " + resultString);

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/VersionControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/VersionControllerTest.java
@@ -46,7 +46,6 @@ class VersionControllerTest {
 
         // Validate the returned string matches a valid version regex
         String resultString = result.getResponse().getContentAsString();
-        //System.out.println(result.getResponse().toString());
         assertTrue(
             resultString.matches("(?!\\.)(\\d+(\\.\\d+)+)(?:[-.][A-Z]+)?(?![\\d.])$"),
             "The response from the endpoint is not a valid version string, output: " + resultString);

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/VersionControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/VersionControllerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.rest.controller;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.RequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(value = VersionController.class)
+class VersionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void retrieveAndCheckForValidVersion() throws Exception {
+        // Create mock request to the endpoint
+        RequestBuilder requestBuilder = MockMvcRequestBuilders.get("/graph/version");
+
+        // Run the request
+        MvcResult result = mockMvc.perform(requestBuilder).andReturn();
+        String resultString = result.getResponse().getContentAsString();
+
+        // Validate the returned string matches a valid version regex
+        assertTrue(
+            resultString.matches("(?!\\.)(\\d+(\\.\\d+)+)(?:[-.][A-Z]+)?(?![\\d.])$"),
+            "The response from the endpoint is not a valid version string, output: " + resultString);
+
+    }
+}

--- a/rest-api/spring-rest/src/test/resources/version.properties
+++ b/rest-api/spring-rest/src/test/resources/version.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2023 Crown Copyright
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+gaffer.version=${project.version}
+koryphe.version=${koryphe.version}


### PR DESCRIPTION
Adds a simple endpoint to both the spring and core (jersey) API that returns the Gaffer version string contained in the `common-rest` library. The version is automatically kept in line with the maven version used for the project by simply expanding that variable into a properties file at build time that is embedded in the JAR and read back at runtime.

Unit tests provided for both that mock a request to the endpoint and validate the response, but also performed a sanity manual test to ensure the endpoint appears in the swagger UI and has relevant information/parameters.

# Related issue

- Resolve #2837