### PR TITLE
Gh-2838: Create endpoint to get store type

### DIFF
--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2.java
@@ -187,6 +187,13 @@ public class GraphConfigurationServiceV2 implements IGraphConfigurationServiceV2
     }
 
     @Override
+    public Response getStoreType() {
+        return Response.ok(graphFactory.getGraph().getStoreProperties().getStoreClass())
+                .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
+                .build();
+    }
+
+    @Override
     public Response getStoreTraits() {
         try {
             return Response.ok(graphFactory.getGraph().execute(new GetTraits.Builder().currentTraits(false).build(), userFactory.createContext()))

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/IGraphConfigurationServiceV2.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/IGraphConfigurationServiceV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Crown Copyright
+ * Copyright 2016-2023 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/IGraphConfigurationServiceV2.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/IGraphConfigurationServiceV2.java
@@ -153,6 +153,20 @@ public interface IGraphConfigurationServiceV2 {
     Response getObjectGenerators();
 
     @GET
+    @Path("/storeType")
+    @Produces(TEXT_PLAIN)
+    @ApiOperation(value = "Gets the store type",
+            notes = "Returns the store type",
+            response = String.class,
+            produces = TEXT_PLAIN,
+            responseHeaders = {
+                    @ResponseHeader(name = GAFFER_MEDIA_TYPE_HEADER, description = GAFFER_MEDIA_TYPE_HEADER_DESCRIPTION)
+            })
+    @ApiResponses(value = {@ApiResponse(code = 200, message = OK),
+            @ApiResponse(code = 500, message = INTERNAL_SERVER_ERROR)})
+    Response getStoreType();
+
+    @GET
     @Path("/storeTraits")
     @ApiOperation(value = "Gets all supported store traits",
             notes = "Returns a list of traits that the current store can support, " +

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2Test.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2Test.java
@@ -242,7 +242,7 @@ public class GraphConfigurationServiceV2Test {
             assertTrue(e.getMessage().contains("Class name was not recognised:"));
         }
     }
-    
+
     @Test
     public void shouldReturnStoreType() {
         // When

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2Test.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/GraphConfigurationServiceV2Test.java
@@ -30,6 +30,7 @@ import uk.gov.gchq.gaffer.exception.SerialisationException;
 import uk.gov.gchq.gaffer.graph.Graph;
 import uk.gov.gchq.gaffer.graph.GraphConfig;
 import uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser;
+import uk.gov.gchq.gaffer.mapstore.MapStoreProperties;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.OperationException;
 import uk.gov.gchq.gaffer.operation.impl.GetWalks;
@@ -106,7 +107,7 @@ public class GraphConfigurationServiceV2Test {
                 .build());
         lenient().doReturn(traits).when(graph).execute(any(GetTraits.class), any(Context.class));
 
-        final StoreProperties props = new StoreProperties();
+        final StoreProperties props = new MapStoreProperties();
         lenient().when(store.getProperties()).thenReturn(props);
 
         final Set<Class<? extends Operation>> operations = new HashSet<>();
@@ -240,6 +241,17 @@ public class GraphConfigurationServiceV2Test {
             assertNotNull(e.getMessage());
             assertTrue(e.getMessage().contains("Class name was not recognised:"));
         }
+    }
+    
+    @Test
+    public void shouldReturnStoreType() {
+        // When
+        final int status = service.getStoreType().getStatus();
+        final String storeType = service.getStoreType().getEntity().toString();
+
+        // Then
+        assertEquals(200, status);
+        assertEquals("uk.gov.gchq.gaffer.mapstore.MapStore", storeType);
     }
 
     @Test

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/GraphConfigurationController.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/GraphConfigurationController.java
@@ -141,7 +141,7 @@ public class GraphConfigurationController implements IGraphConfigurationControll
     public String getStoreType() {
         return graphFactory.getGraph().getStoreProperties().getStoreClass();
     }
-    
+
     @Override
     public Set<StoreTrait> getStoreTraits() {
         try {

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/GraphConfigurationController.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/GraphConfigurationController.java
@@ -27,7 +27,6 @@ import uk.gov.gchq.gaffer.core.exception.GafferRuntimeException;
 import uk.gov.gchq.gaffer.data.generator.ElementGenerator;
 import uk.gov.gchq.gaffer.data.generator.ObjectGenerator;
 import uk.gov.gchq.gaffer.operation.OperationException;
-import uk.gov.gchq.gaffer.rest.SystemProperty;
 import uk.gov.gchq.gaffer.rest.factory.GraphFactory;
 import uk.gov.gchq.gaffer.serialisation.util.JsonSerialisationUtil;
 import uk.gov.gchq.gaffer.store.Context;

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/GraphConfigurationController.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/GraphConfigurationController.java
@@ -27,6 +27,7 @@ import uk.gov.gchq.gaffer.core.exception.GafferRuntimeException;
 import uk.gov.gchq.gaffer.data.generator.ElementGenerator;
 import uk.gov.gchq.gaffer.data.generator.ObjectGenerator;
 import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.rest.SystemProperty;
 import uk.gov.gchq.gaffer.rest.factory.GraphFactory;
 import uk.gov.gchq.gaffer.serialisation.util.JsonSerialisationUtil;
 import uk.gov.gchq.gaffer.store.Context;
@@ -136,6 +137,11 @@ public class GraphConfigurationController implements IGraphConfigurationControll
         return JsonSerialisationUtil.getSerialisedFieldClasses(className);
     }
 
+    @Override
+    public String getStoreType() {
+        return graphFactory.getGraph().getStoreProperties().getStoreClass();
+    }
+    
     @Override
     public Set<StoreTrait> getStoreTraits() {
         try {

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/IGraphConfigurationController.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/IGraphConfigurationController.java
@@ -18,6 +18,8 @@ package uk.gov.gchq.gaffer.rest.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.apache.hadoop.yarn.webapp.hamlet.Hamlet.TEXTAREA;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import uk.gov.gchq.gaffer.store.StoreTrait;
@@ -123,6 +125,16 @@ public interface IGraphConfigurationController {
             summary = "Gets the serialised fields and their classes for a given class"
     )
     Map<String, String> getSerialisedFieldClasses(final String className);
+
+       @RequestMapping(
+            path = "/storeType",
+            method = GET,
+            produces = TEXT_PLAIN_VALUE
+    )
+    @Operation(
+            summary = "Gets the store type"
+    )
+    String getStoreType(); 
 
     @RequestMapping(
             path = "/storeTraits",

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/IGraphConfigurationController.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/IGraphConfigurationController.java
@@ -133,7 +133,7 @@ public interface IGraphConfigurationController {
     @Operation(
             summary = "Gets the store type"
     )
-    String getStoreType(); 
+    String getStoreType();
 
     @RequestMapping(
             path = "/storeTraits",

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/IGraphConfigurationController.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/IGraphConfigurationController.java
@@ -19,7 +19,6 @@ package uk.gov.gchq.gaffer.rest.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import org.apache.hadoop.yarn.webapp.hamlet.Hamlet.TEXTAREA;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import uk.gov.gchq.gaffer.store.StoreTrait;
@@ -126,7 +125,7 @@ public interface IGraphConfigurationController {
     )
     Map<String, String> getSerialisedFieldClasses(final String className);
 
-       @RequestMapping(
+    @RequestMapping(
             path = "/storeType",
             method = GET,
             produces = TEXT_PLAIN_VALUE

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/GraphConfigurationControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/GraphConfigurationControllerTest.java
@@ -257,6 +257,24 @@ public class GraphConfigurationControllerTest {
     }
 
     @Test
+    public void shouldReturnStoreType() {
+        // Given
+        when(graphFactory.getGraph()).thenReturn(new Graph.Builder()
+            .config(new GraphConfig("id"))
+            .addSchema(new Schema())
+            .storeProperties(new MapStoreProperties())
+            .build());
+
+        // When
+        GraphConfigurationController controller = new GraphConfigurationController(graphFactory);
+
+        final String storeType = controller.getStoreType();
+
+        // Then
+        assertThat(storeType).isEqualTo("uk.gov.gchq.gaffer.mapstore.MapStore");
+    }
+
+    @Test
     public void shouldGetStoreTraits() throws OperationException {
         // Given
         Store store = mock(Store.class);


### PR DESCRIPTION
Adds a simple endpoint to spring-rest and core-rest which returns the store that is used in your Gaffer graph. 

# Related issue

- Resolve #2838