### PR TITLE
Gh-2891: Aggregate First and Last properties consistently in Accumulo

### DIFF
--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/AbstractCoreKeyAccumuloElementConverter.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/AbstractCoreKeyAccumuloElementConverter.java
@@ -353,7 +353,7 @@ public abstract class AbstractCoreKeyAccumuloElementConverter implements Accumul
 
     @Override
     public long buildTimestamp(final String group, final Properties properties) {
-        Long timestamp = null;
+        Long timestamp;
         if (timestampProperty != null) {
             timestamp = (Long) properties.get(timestampProperty);
             return timestamp;
@@ -375,7 +375,6 @@ public abstract class AbstractCoreKeyAccumuloElementConverter implements Accumul
         } else {
             timestamp = LongUtil.getTimeBasedRandom();
         }
-        
 
         return timestamp;
     }

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/AbstractCoreKeyAccumuloElementConverter.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/AbstractCoreKeyAccumuloElementConverter.java
@@ -387,12 +387,11 @@ public abstract class AbstractCoreKeyAccumuloElementConverter implements Accumul
 
     @Override
     public long buildTimestamp(final String group, final Properties properties) {
-        Long timestamp = LongUtil.getTimeBasedRandom();
+        Long timestamp;
 
         // Allow override via property
         if (timestampProperty != null) {
-            timestamp = (Long) properties.get(timestampProperty);
-            return timestamp;
+            return (Long) properties.get(timestampProperty);
         }
 
         // Check if aggregating to see what timestamp we should apply
@@ -402,7 +401,10 @@ public abstract class AbstractCoreKeyAccumuloElementConverter implements Accumul
             if (timeSensitiveAggregatedGroups.contains(group)) {
                 timestamp = System.currentTimeMillis();
             }
+        } else {
+            timestamp = LongUtil.getTimeBasedRandom();
         }
+
         return timestamp;
     }
 

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/AbstractCoreKeyAccumuloElementConverter.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/AbstractCoreKeyAccumuloElementConverter.java
@@ -47,7 +47,6 @@ import uk.gov.gchq.gaffer.store.schema.TypeDefinition;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/AbstractCoreKeyAccumuloElementConverter.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/AbstractCoreKeyAccumuloElementConverter.java
@@ -396,10 +396,11 @@ public abstract class AbstractCoreKeyAccumuloElementConverter implements Accumul
 
         // Check if aggregating to see what timestamp we should apply
         if (aggregatedGroups.contains(group)) {
-            timestamp = AccumuloStoreConstants.DEFAULT_TIMESTAMP;
             // If any types used by the element aggregate using a time sensitive function, add a timestamp
             if (timeSensitiveAggregatedGroups.contains(group)) {
                 timestamp = System.currentTimeMillis();
+            } else {
+                timestamp = AccumuloStoreConstants.DEFAULT_TIMESTAMP;
             }
         } else {
             timestamp = LongUtil.getTimeBasedRandom();

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/AbstractCoreKeyAccumuloElementConverter.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/AbstractCoreKeyAccumuloElementConverter.java
@@ -366,7 +366,7 @@ public abstract class AbstractCoreKeyAccumuloElementConverter implements Accumul
                 schema.getElement(group).getPropertyTypeDefs().spliterator(), true);
 
             // If any types used by the element aggregate using a time sensitive function, add a timestamp
-            if (typeStream.anyMatch(td -> Arrays.asList(AccumuloStoreConstants.TIME_SENSITIVE_AGGREGATORS)
+            if (typeStream.anyMatch(td -> AccumuloStoreConstants.TIME_SENSITIVE_AGGREGATORS
                     .contains(td.getAggregateFunction().getClass().getSimpleName()))) {
                 // Add timestamp
                 timestamp = System.currentTimeMillis();

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/AbstractCoreKeyAccumuloElementConverter.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/AbstractCoreKeyAccumuloElementConverter.java
@@ -280,15 +280,12 @@ public abstract class AbstractCoreKeyAccumuloElementConverter implements Accumul
         for (final String group : aggregatedGroups) {
             // Check all type definitions for the group
             Stream<TypeDefinition> typeStream = StreamSupport.stream(
-                schema.getElement(group).getPropertyTypeDefs().spliterator(), true);
+                schema.getElement(group).getPropertyTypeDefs().spliterator(), false);
+
             // Check if a time sensitive function is used anywhere
-            boolean timeSensitiveGroup = typeStream.anyMatch(td -> {
-                if (td.getAggregateFunction() == null) {
-                    return false;
-                }
-                return AccumuloStoreConstants.TIME_SENSITIVE_AGGREGATORS.contains(
-                    td.getAggregateFunction().getClass().getSimpleName());
-            });
+            boolean timeSensitiveGroup = typeStream.anyMatch(td ->
+                td.getAggregateFunction() != null &&
+                AccumuloStoreConstants.TIME_SENSITIVE_AGGREGATORS.contains(td.getAggregateFunction().getClass().getName()));
 
             if (timeSensitiveGroup) {
                 timeSensitiveAggregatedGroups.add(group);

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/AbstractCoreKeyAccumuloElementConverter.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/AbstractCoreKeyAccumuloElementConverter.java
@@ -47,6 +47,7 @@ import uk.gov.gchq.gaffer.store.schema.TypeDefinition;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
@@ -365,8 +366,8 @@ public abstract class AbstractCoreKeyAccumuloElementConverter implements Accumul
                 schema.getElement(group).getPropertyTypeDefs().spliterator(), true);
 
             // If any types used by the element aggregate using a time sensitive function, add a timestamp
-            if (typeStream.anyMatch(td -> AccumuloStoreConstants.TIME_SENSITIVE_AGGREGATORS.contains(
-                    td.getAggregateFunction().getClass().getSimpleName()))) {
+            if (typeStream.anyMatch(td -> Arrays.asList(AccumuloStoreConstants.TIME_SENSITIVE_AGGREGATORS)
+                    .contains(td.getAggregateFunction().getClass().getSimpleName()))) {
                 // Add timestamp
                 timestamp = System.currentTimeMillis();
             } else {

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/AbstractCoreKeyAccumuloElementConverter.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/key/core/AbstractCoreKeyAccumuloElementConverter.java
@@ -285,7 +285,7 @@ public abstract class AbstractCoreKeyAccumuloElementConverter implements Accumul
             // Check if a time sensitive function is used anywhere
             boolean timeSensitiveGroup = typeStream.anyMatch(td ->
                 td.getAggregateFunction() != null &&
-                AccumuloStoreConstants.TIME_SENSITIVE_AGGREGATORS.contains(td.getAggregateFunction().getClass().getName()));
+                AccumuloStoreConstants.TIME_SENSITIVE_AGGREGATORS.contains(td.getAggregateFunction().getClass()));
 
             if (timeSensitiveGroup) {
                 timeSensitiveAggregatedGroups.add(group);

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/AccumuloStoreConstants.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/AccumuloStoreConstants.java
@@ -16,12 +16,12 @@
 
 package uk.gov.gchq.gaffer.accumulostore.utils;
 
+import uk.gov.gchq.koryphe.impl.binaryoperator.First;
+import uk.gov.gchq.koryphe.impl.binaryoperator.Last;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import uk.gov.gchq.koryphe.impl.binaryoperator.First;
-import uk.gov.gchq.koryphe.impl.binaryoperator.Last;
 
 public final class AccumuloStoreConstants {
     //Iterator names

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/AccumuloStoreConstants.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/AccumuloStoreConstants.java
@@ -55,8 +55,8 @@ public final class AccumuloStoreConstants {
     // Time sensitive aggregation functions where an actual timestamp must applied to the key
     public static final List<String> TIME_SENSITIVE_AGGREGATORS = Collections.unmodifiableList(
         Arrays.asList(
-            First.class.getSimpleName(),
-            Last.class.getSimpleName()));
+            First.class.getName(),
+            Last.class.getName()));
 
     // Iterator options
     public static final String VIEW = "View";

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/AccumuloStoreConstants.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/AccumuloStoreConstants.java
@@ -16,11 +16,11 @@
 
 package uk.gov.gchq.gaffer.accumulostore.utils;
 
-import java.util.Arrays;
-import java.util.List;
-
 import uk.gov.gchq.koryphe.impl.binaryoperator.First;
 import uk.gov.gchq.koryphe.impl.binaryoperator.Last;
+
+import java.util.Arrays;
+import java.util.List;
 
 public final class AccumuloStoreConstants {
     //Iterator names

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/AccumuloStoreConstants.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/AccumuloStoreConstants.java
@@ -52,9 +52,10 @@ public final class AccumuloStoreConstants {
     public static final long DEFAULT_TIMESTAMP = 1L;
 
     // Time sensitive aggregation functions where an actual timestamp must applied to the key
-    public static final List<String> TIME_SENSITIVE_AGGREGATORS = Arrays.asList(
+    public static final String[] TIME_SENSITIVE_AGGREGATORS = {
         First.class.getSimpleName(),
-        Last.class.getSimpleName());
+        Last.class.getSimpleName()
+    };
 
     // Iterator options
     public static final String VIEW = "View";

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/AccumuloStoreConstants.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/AccumuloStoreConstants.java
@@ -19,9 +19,6 @@ package uk.gov.gchq.gaffer.accumulostore.utils;
 import uk.gov.gchq.koryphe.impl.binaryoperator.First;
 import uk.gov.gchq.koryphe.impl.binaryoperator.Last;
 
-import java.util.Arrays;
-import java.util.List;
-
 public final class AccumuloStoreConstants {
     //Iterator names
     public static final String VALIDATOR_ITERATOR_NAME = "Validator";

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/AccumuloStoreConstants.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/AccumuloStoreConstants.java
@@ -16,6 +16,10 @@
 
 package uk.gov.gchq.gaffer.accumulostore.utils;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import uk.gov.gchq.koryphe.impl.binaryoperator.First;
 import uk.gov.gchq.koryphe.impl.binaryoperator.Last;
 
@@ -49,10 +53,10 @@ public final class AccumuloStoreConstants {
     public static final long DEFAULT_TIMESTAMP = 1L;
 
     // Time sensitive aggregation functions where an actual timestamp must applied to the key
-    public static final String[] TIME_SENSITIVE_AGGREGATORS = {
-        First.class.getSimpleName(),
-        Last.class.getSimpleName()
-    };
+    public static final List<String> TIME_SENSITIVE_AGGREGATORS = Collections.unmodifiableList(
+        Arrays.asList(
+            First.class.getSimpleName(),
+            Last.class.getSimpleName()));
 
     // Iterator options
     public static final String VIEW = "View";

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/AccumuloStoreConstants.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/AccumuloStoreConstants.java
@@ -52,11 +52,11 @@ public final class AccumuloStoreConstants {
      */
     public static final long DEFAULT_TIMESTAMP = 1L;
 
-    // Time sensitive aggregation functions where an actual timestamp must applied to the key
-    public static final List<String> TIME_SENSITIVE_AGGREGATORS = Collections.unmodifiableList(
-        Arrays.asList(
-            First.class.getName(),
-            Last.class.getName()));
+    /**
+     * Time sensitive aggregation functions where an actual timestamp must be applied to the key.
+     */
+    public static final List<Class<?>> TIME_SENSITIVE_AGGREGATORS = Collections.unmodifiableList(
+        Arrays.asList(First.class, Last.class));
 
     // Iterator options
     public static final String VIEW = "View";

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/AccumuloStoreConstants.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/utils/AccumuloStoreConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Crown Copyright
+ * Copyright 2016-2023 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,12 @@
  */
 
 package uk.gov.gchq.gaffer.accumulostore.utils;
+
+import java.util.Arrays;
+import java.util.List;
+
+import uk.gov.gchq.koryphe.impl.binaryoperator.First;
+import uk.gov.gchq.koryphe.impl.binaryoperator.Last;
 
 public final class AccumuloStoreConstants {
     //Iterator names
@@ -44,6 +50,11 @@ public final class AccumuloStoreConstants {
      * The default timestamp value to use if it has not been populated.
      */
     public static final long DEFAULT_TIMESTAMP = 1L;
+
+    // Time sensitive aggregation functions where an actual timestamp must applied to the key
+    public static final List<String> TIME_SENSITIVE_AGGREGATORS = Arrays.asList(
+        First.class.getSimpleName(),
+        Last.class.getSimpleName());
 
     // Iterator options
     public static final String VIEW = "View";

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/FirstLastIT.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/FirstLastIT.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.accumulostore.integration;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.admin.CompactionConfig;
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.gaffer.accumulostore.AccumuloProperties;
+import uk.gov.gchq.gaffer.accumulostore.AccumuloStore;
+import uk.gov.gchq.gaffer.commonutil.StreamUtil;
+import uk.gov.gchq.gaffer.data.element.Entity;
+import uk.gov.gchq.gaffer.graph.Graph;
+import uk.gov.gchq.gaffer.integration.StandaloneIT;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
+import uk.gov.gchq.gaffer.operation.impl.get.GetAllElements;
+import uk.gov.gchq.gaffer.store.StoreException;
+import uk.gov.gchq.gaffer.store.StoreProperties;
+import uk.gov.gchq.gaffer.store.schema.Schema;
+import uk.gov.gchq.gaffer.store.schema.SchemaEntityDefinition;
+import uk.gov.gchq.gaffer.store.schema.TypeDefinition;
+import uk.gov.gchq.koryphe.impl.binaryoperator.First;
+import uk.gov.gchq.koryphe.impl.binaryoperator.Last;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.gchq.gaffer.commonutil.TestGroups.ENTITY;
+import static uk.gov.gchq.gaffer.commonutil.TestPropertyNames.PROP_1;
+import static uk.gov.gchq.gaffer.commonutil.TestPropertyNames.PROP_2;
+import static uk.gov.gchq.gaffer.store.TestTypes.ID_STRING;
+import static uk.gov.gchq.gaffer.store.TestTypes.PROP_INTEGER;
+import static uk.gov.gchq.gaffer.store.TestTypes.PROP_INTEGER_2;
+import static uk.gov.gchq.gaffer.store.TestTypes.STRING_TYPE;
+
+public class FirstLastIT extends StandaloneIT {
+    private static final String GRAPH_ID = "graphId";
+    private static final String VERTEX = "vertex";
+    private static final AccumuloProperties PROPERTIES = AccumuloProperties.loadStoreProperties(StreamUtil.storeProps(AccumuloStoreITs.class));
+
+    @Test
+    public void shouldReturnCorrectResultsAfterCompaction() throws OperationException, InterruptedException, StoreException, TableNotFoundException, AccumuloException, AccumuloSecurityException {
+        final Graph graph = createGraph();
+        final AccumuloStore accumuloStore = new AccumuloStore();
+        accumuloStore.initialise("graphId", createSchema(), createStoreProperties());
+
+        graph.execute(new AddElements.Builder().input(getEntity(10)).build(), getUser());
+        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(10, 10));
+
+        graph.execute(new AddElements.Builder().input(getEntity(1)).build(), getUser());
+        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(1, 10));
+
+        compact(accumuloStore);
+    
+        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(1, 10));
+    }
+
+    @Test
+    public void shouldReturnCorrectResultsAfterFlush() throws OperationException, InterruptedException, StoreException, TableNotFoundException, AccumuloException, AccumuloSecurityException {
+        final Graph graph = createGraph();
+        final AccumuloStore accumuloStore = new AccumuloStore();
+        accumuloStore.initialise("graphId", createSchema(), createStoreProperties());
+
+        graph.execute(new AddElements.Builder().input(getEntity(10)).build(), getUser());
+        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(10, 10));
+
+        graph.execute(new AddElements.Builder().input(getEntity(1)).build(), getUser());
+        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(1, 10));
+
+        flush(accumuloStore);
+    
+        // This fails, returning getEntity(1, 1)
+        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(1, 10));
+    }
+
+    private void compact(final AccumuloStore accumuloStore) throws StoreException, AccumuloSecurityException, TableNotFoundException, AccumuloException, InterruptedException {
+        accumuloStore.getConnection()
+                .tableOperations()
+                .compact(GRAPH_ID, new CompactionConfig());
+        Thread.sleep(5000L);
+    }
+
+    private void flush(final AccumuloStore accumuloStore) throws StoreException, AccumuloSecurityException, TableNotFoundException, AccumuloException, InterruptedException {
+        accumuloStore.getConnection()
+                .tableOperations()
+                .flush(GRAPH_ID);
+        Thread.sleep(5000L);
+    }
+
+    private Entity getEntity(final int propertyValue) {
+        return getEntity(propertyValue, propertyValue);
+    }
+
+    private Entity getEntity(final int firstValue, final int lastValue) {
+        return new Entity.Builder()
+                .group(ENTITY)
+                .vertex(VERTEX)
+                .property(PROP_1, firstValue)
+                .property(PROP_2, lastValue)
+                .build();
+    }
+
+    @Override
+    protected Schema createSchema() {
+        return new Schema.Builder()
+                .entity(ENTITY, new SchemaEntityDefinition.Builder()
+                        .vertex(ID_STRING)
+                        .property(PROP_1, PROP_INTEGER)
+                        .property(PROP_2, PROP_INTEGER)
+                        .build())
+                .type(ID_STRING, STRING_TYPE)
+                .type(PROP_INTEGER, new TypeDefinition.Builder()
+                        .clazz(Integer.class)
+                        .aggregateFunction(new First())
+                        .build())
+                .type(PROP_INTEGER_2, new TypeDefinition.Builder()
+                        .clazz(Integer.class)
+                        .aggregateFunction(new Last())
+                        .build())
+                .build();
+    }
+
+    @Override
+    public StoreProperties createStoreProperties() {
+        return PROPERTIES;
+    }
+
+}

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/FirstLastIT.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/FirstLastIT.java
@@ -20,10 +20,10 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
-
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
 import uk.gov.gchq.gaffer.accumulostore.AccumuloProperties;
 import uk.gov.gchq.gaffer.accumulostore.AccumuloStore;
 import uk.gov.gchq.gaffer.commonutil.StreamUtil;
@@ -99,7 +99,7 @@ class FirstLastIT extends StandaloneIT {
         for (int i = 7; i <= 100; i++) {
             graph.execute(new AddElements.Builder().input(getEntity(i)).build(), getUser());
         }
-        
+
          // Check before and after compaction
         assertThat(graph.execute(getOperation, getUser())).containsExactly(getEntity(100, 1));
         compact(accumuloStore);

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/FirstLastIT.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/FirstLastIT.java
@@ -66,7 +66,8 @@ public class FirstLastIT extends StandaloneIT {
         assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(1, 10));
 
         compact(accumuloStore);
-    
+
+        // This fails, returning getEntity(1, 1)
         assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(1, 10));
     }
 
@@ -83,7 +84,7 @@ public class FirstLastIT extends StandaloneIT {
         assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(1, 10));
 
         flush(accumuloStore);
-    
+
         // This fails, returning getEntity(1, 1)
         assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(1, 10));
     }

--- a/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/FirstLastIT.java
+++ b/store-implementation/accumulo-store/src/test/java/uk/gov/gchq/gaffer/accumulostore/integration/FirstLastIT.java
@@ -59,16 +59,17 @@ public class FirstLastIT extends StandaloneIT {
         final AccumuloStore accumuloStore = new AccumuloStore();
         accumuloStore.initialise("graphId", createSchema(), createStoreProperties());
 
-        graph.execute(new AddElements.Builder().input(getEntity(10)).build(), getUser());
-        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(10, 10));
-
         graph.execute(new AddElements.Builder().input(getEntity(1)).build(), getUser());
-        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(1, 10));
+        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(1, 1));
+
+        graph.execute(new AddElements.Builder().input(getEntity(2)).build(), getUser());
+        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(2, 1));
 
         compact(accumuloStore);
+        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(2, 1));
 
-        // This fails, returning getEntity(1, 1)
-        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(1, 10));
+        graph.execute(new AddElements.Builder().input(getEntity(3)).build(), getUser());
+        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(3, 1));
     }
 
     @Test
@@ -77,16 +78,17 @@ public class FirstLastIT extends StandaloneIT {
         final AccumuloStore accumuloStore = new AccumuloStore();
         accumuloStore.initialise("graphId", createSchema(), createStoreProperties());
 
-        graph.execute(new AddElements.Builder().input(getEntity(10)).build(), getUser());
-        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(10, 10));
-
         graph.execute(new AddElements.Builder().input(getEntity(1)).build(), getUser());
-        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(1, 10));
+        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(1, 1));
+
+        graph.execute(new AddElements.Builder().input(getEntity(2)).build(), getUser());
+        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(2, 1));
 
         flush(accumuloStore);
+        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(2, 1));
 
-        // This fails, returning getEntity(1, 1)
-        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(1, 10));
+        graph.execute(new AddElements.Builder().input(getEntity(3)).build(), getUser());
+        assertThat(graph.execute(new GetAllElements(), getUser())).containsExactly(getEntity(3, 1));
     }
 
     private void compact(final AccumuloStore accumuloStore) throws StoreException, AccumuloSecurityException, TableNotFoundException, AccumuloException, InterruptedException {
@@ -122,7 +124,7 @@ public class FirstLastIT extends StandaloneIT {
                 .entity(ENTITY, new SchemaEntityDefinition.Builder()
                         .vertex(ID_STRING)
                         .property(PROP_1, PROP_INTEGER)
-                        .property(PROP_2, PROP_INTEGER)
+                        .property(PROP_2, PROP_INTEGER_2)
                         .build())
                 .type(ID_STRING, STRING_TYPE)
                 .type(PROP_INTEGER, new TypeDefinition.Builder()


### PR DESCRIPTION
Following some investigation the bug appears to be due to the Accumulo timestamp.
 
Looking at the Accumulo docs it is stated that if you insert a key with same rowID, column and timestamp then the behaviour is non-deterministic, this is what was happening when aggregating as the timestamp is being hardcoded to a default value and rowID and column would be the same ([see](https://accumulo.apache.org/1.8/accumulo_user_manual.html#_versioning_iterators_and_timestamps))

The solution here will apply a timestamp to elements that are aggregated via time sensitive aggregation functions such as, First and Last. This should fix the original issue and ensure no unnecessary timestamps are added to data that doesn't need them.

Integration test has been added to ensure this is fixed.

# Related issue

- Resolve #2891