### PR TITLE
Gh-3056: Add testing to GafferPopElementGenerator

### DIFF
--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferEdgeGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferEdgeGeneratorTest.java
@@ -49,7 +49,7 @@ public class GafferEdgeGeneratorTest {
         assertThat(edge.getSource()).isEqualTo(source);
         assertThat(edge.getDestination()).isEqualTo(dest);
         assertThat(edge.isDirected()).isTrue();
-        assertThat(edge.getProperties().size()).isEqualTo(1);
+        assertThat(edge.getProperties()).hasSize(1);
         assertThat(edge.getProperty(TestPropertyNames.STRING)).isEqualTo(propValue);
     }
 

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferEdgeGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferEdgeGeneratorTest.java
@@ -24,8 +24,7 @@ import uk.gov.gchq.gaffer.data.element.Edge;
 import uk.gov.gchq.gaffer.tinkerpop.GafferPopEdge;
 import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class GafferEdgeGeneratorTest {
@@ -46,12 +45,12 @@ public class GafferEdgeGeneratorTest {
         final Edge edge = generator._apply(gafferPopEdge);
 
         // Then
-        assertEquals(TestGroups.EDGE, edge.getGroup());
-        assertEquals(source, edge.getSource());
-        assertEquals(dest, edge.getDestination());
-        assertTrue(edge.isDirected());
-        assertEquals(1, edge.getProperties().size());
-        assertEquals(propValue, edge.getProperty(TestPropertyNames.STRING));
+        assertThat(edge.getGroup()).isEqualTo(TestGroups.EDGE);
+        assertThat(edge.getSource()).isEqualTo(source);
+        assertThat(edge.getDestination()).isEqualTo(dest);
+        assertThat(edge.isDirected()).isTrue();
+        assertThat(edge.getProperties().size()).isEqualTo(1);
+        assertThat(edge.getProperty(TestPropertyNames.STRING)).isEqualTo(propValue);
     }
 
 }

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferEntityGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferEntityGeneratorTest.java
@@ -59,7 +59,7 @@ public class GafferEntityGeneratorTest {
         // Then
         assertThat(entity.getGroup()).isEqualTo(TestGroups.ENTITY);
         assertThat(entity.getVertex()).isEqualTo(vertex);
-        assertThat(entity.getProperties().size()).isEqualTo(1);
+        assertThat(entity.getProperties()).hasSize(1);
         assertThat(entity.getProperty(TestPropertyNames.STRING)).isEqualTo(propValue);
     }
 

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferEntityGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferEntityGeneratorTest.java
@@ -28,7 +28,7 @@ import uk.gov.gchq.gaffer.data.element.Entity;
 import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph;
 import uk.gov.gchq.gaffer.tinkerpop.GafferPopVertex;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -57,10 +57,10 @@ public class GafferEntityGeneratorTest {
         final Entity entity = generator._apply(gafferPopVertex);
 
         // Then
-        assertEquals(TestGroups.ENTITY, entity.getGroup());
-        assertEquals(vertex, entity.getVertex());
-        assertEquals(1, entity.getProperties().size());
-        assertEquals(propValue, entity.getProperty(TestPropertyNames.STRING));
+        assertThat(entity.getGroup()).isEqualTo(TestGroups.ENTITY);
+        assertThat(entity.getVertex()).isEqualTo(vertex);
+        assertThat(entity.getProperties().size()).isEqualTo(1);
+        assertThat(entity.getProperty(TestPropertyNames.STRING)).isEqualTo(propValue);
     }
 
 }

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
@@ -25,10 +25,7 @@ import uk.gov.gchq.gaffer.data.element.Edge;
 import uk.gov.gchq.gaffer.tinkerpop.GafferPopEdge;
 import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class GafferPopEdgeGeneratorTest {
@@ -50,13 +47,13 @@ public class GafferPopEdgeGeneratorTest {
         final GafferPopEdge gafferPopEdge = generator._apply(edge);
 
         // Then
-        assertEquals(TestGroups.EDGE, gafferPopEdge.label());
-        assertEquals(source, gafferPopEdge.outVertex().id());
-        assertEquals(dest, gafferPopEdge.inVertex().id());
-        assertEquals(propValue, gafferPopEdge.property(TestPropertyNames.STRING).value());
-        assertEquals(1, Lists.newArrayList(gafferPopEdge.properties()).size());
-        assertSame(graph, gafferPopEdge.graph());
-        assertTrue(gafferPopEdge.isReadOnly());
+        assertThat(gafferPopEdge.label()).isEqualTo(TestGroups.EDGE);
+        assertThat(gafferPopEdge.outVertex().id()).isEqualTo(source);
+        assertThat(gafferPopEdge.inVertex().id()).isEqualTo(dest);
+        assertThat(gafferPopEdge.property(TestPropertyNames.STRING).value()).isEqualTo(propValue);
+        assertThat(Lists.newArrayList(gafferPopEdge.properties()).size()).isEqualTo(1);
+        assertThat(gafferPopEdge.graph()).isSameAs(graph);
+        assertThat(gafferPopEdge.isReadOnly()).isTrue();
     }
 
     @Test
@@ -77,12 +74,12 @@ public class GafferPopEdgeGeneratorTest {
         final GafferPopEdge gafferPopEdge = generator._apply(edge);
 
         // Then
-        assertEquals(TestGroups.EDGE, gafferPopEdge.label());
-        assertEquals(source, gafferPopEdge.outVertex().id());
-        assertEquals(dest, gafferPopEdge.inVertex().id());
-        assertEquals(propValue, gafferPopEdge.property(TestPropertyNames.STRING).value());
-        assertEquals(1, Lists.newArrayList(gafferPopEdge.properties()).size());
-        assertSame(graph, gafferPopEdge.graph());
-        assertFalse(gafferPopEdge.isReadOnly());
+        assertThat(gafferPopEdge.label()).isEqualTo(TestGroups.EDGE);
+        assertThat(gafferPopEdge.outVertex().id()).isEqualTo(source);
+        assertThat(gafferPopEdge.inVertex().id()).isEqualTo(dest);
+        assertThat(gafferPopEdge.property(TestPropertyNames.STRING).value()).isEqualTo(propValue);
+        assertThat(Lists.newArrayList(gafferPopEdge.properties()).size()).isEqualTo(1);
+        assertThat(gafferPopEdge.graph()).isSameAs(graph);
+        assertThat(gafferPopEdge.isReadOnly()).isFalse();
     }
 }

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
@@ -55,7 +55,7 @@ public class GafferPopEdgeGeneratorTest {
         assertThat(gafferPopEdge.outVertex().id()).isEqualTo(source);
         assertThat(gafferPopEdge.inVertex().id()).isEqualTo(dest);
         assertThat(gafferPopEdge.property(TestPropertyNames.STRING).value()).isEqualTo(propValue);
-        assertThat(Lists.newArrayList(gafferPopEdge.properties())).hasSize(1);
+        assertThat(gafferPopEdge.properties()).toIterable().hasSize(1);
         assertThat(gafferPopEdge.graph()).isSameAs(graph);
         assertThat(gafferPopEdge.isReadOnly()).isTrue();
     }
@@ -82,7 +82,7 @@ public class GafferPopEdgeGeneratorTest {
         assertThat(gafferPopEdge.outVertex().id()).isEqualTo(source);
         assertThat(gafferPopEdge.inVertex().id()).isEqualTo(dest);
         assertThat(gafferPopEdge.property(TestPropertyNames.STRING).value()).isEqualTo(propValue);
-        assertThat(Lists.newArrayList(gafferPopEdge.properties())).hasSize(1);
+        assertThat(gafferPopEdge.properties()).toIterable().hasSize(1);
         assertThat(gafferPopEdge.graph()).isSameAs(graph);
         assertThat(gafferPopEdge.isReadOnly()).isFalse();
     }

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
@@ -16,8 +16,6 @@
 
 package uk.gov.gchq.gaffer.tinkerpop.generator;
 
-import com.google.common.collect.Lists;
-
 import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.commonutil.TestGroups;

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
@@ -18,7 +18,6 @@ package uk.gov.gchq.gaffer.tinkerpop.generator;
 
 import com.google.common.collect.Lists;
 
-import org.json.Property;
 import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.commonutil.TestGroups;
@@ -32,8 +31,6 @@ import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
-
-import java.util.ArrayList;
 
 public class GafferPopEdgeGeneratorTest {
     @Test

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
@@ -86,12 +86,11 @@ public class GafferPopEdgeGeneratorTest {
         assertThat(gafferPopEdge.isReadOnly()).isFalse();
     }
 
-    @Test 
+    @Test
     public void shouldThrowExceptionWhenPassedEntity() {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final Element element = new Entity.Builder().group(TestGroups.ENTITY).build();
-        
         final GafferPopEdgeGenerator generator = new GafferPopEdgeGenerator(graph, true);
 
         // Then

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
@@ -17,6 +17,8 @@
 package uk.gov.gchq.gaffer.tinkerpop.generator;
 
 import com.google.common.collect.Lists;
+
+import org.json.Property;
 import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.commonutil.TestGroups;
@@ -30,6 +32,8 @@ import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
 
 public class GafferPopEdgeGeneratorTest {
     @Test
@@ -54,7 +58,7 @@ public class GafferPopEdgeGeneratorTest {
         assertThat(gafferPopEdge.outVertex().id()).isEqualTo(source);
         assertThat(gafferPopEdge.inVertex().id()).isEqualTo(dest);
         assertThat(gafferPopEdge.property(TestPropertyNames.STRING).value()).isEqualTo(propValue);
-        assertThat(gafferPopEdge.properties()).asList().hasSize(1);
+        assertThat(Lists.newArrayList(gafferPopEdge.properties())).hasSize(1);
         assertThat(gafferPopEdge.graph()).isSameAs(graph);
         assertThat(gafferPopEdge.isReadOnly()).isTrue();
     }
@@ -81,7 +85,7 @@ public class GafferPopEdgeGeneratorTest {
         assertThat(gafferPopEdge.outVertex().id()).isEqualTo(source);
         assertThat(gafferPopEdge.inVertex().id()).isEqualTo(dest);
         assertThat(gafferPopEdge.property(TestPropertyNames.STRING).value()).isEqualTo(propValue);
-        assertThat(gafferPopEdge.properties()).asList().hasSize(1);
+        assertThat(Lists.newArrayList(gafferPopEdge.properties())).hasSize(1);
         assertThat(gafferPopEdge.graph()).isSameAs(graph);
         assertThat(gafferPopEdge.isReadOnly()).isFalse();
     }

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
@@ -54,7 +54,7 @@ public class GafferPopEdgeGeneratorTest {
         assertThat(gafferPopEdge.outVertex().id()).isEqualTo(source);
         assertThat(gafferPopEdge.inVertex().id()).isEqualTo(dest);
         assertThat(gafferPopEdge.property(TestPropertyNames.STRING).value()).isEqualTo(propValue);
-        assertThat(Lists.newArrayList(gafferPopEdge.properties()).size()).isEqualTo(1);
+        assertThat(gafferPopEdge.properties()).asList().hasSize(1);
         assertThat(gafferPopEdge.graph()).isSameAs(graph);
         assertThat(gafferPopEdge.isReadOnly()).isTrue();
     }
@@ -81,7 +81,7 @@ public class GafferPopEdgeGeneratorTest {
         assertThat(gafferPopEdge.outVertex().id()).isEqualTo(source);
         assertThat(gafferPopEdge.inVertex().id()).isEqualTo(dest);
         assertThat(gafferPopEdge.property(TestPropertyNames.STRING).value()).isEqualTo(propValue);
-        assertThat(Lists.newArrayList(gafferPopEdge.properties()).size()).isEqualTo(1);
+        assertThat(gafferPopEdge.properties()).asList().hasSize(1);
         assertThat(gafferPopEdge.graph()).isSameAs(graph);
         assertThat(gafferPopEdge.isReadOnly()).isFalse();
     }

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
@@ -22,10 +22,13 @@ import org.junit.jupiter.api.Test;
 import uk.gov.gchq.gaffer.commonutil.TestGroups;
 import uk.gov.gchq.gaffer.commonutil.TestPropertyNames;
 import uk.gov.gchq.gaffer.data.element.Edge;
+import uk.gov.gchq.gaffer.data.element.Element;
+import uk.gov.gchq.gaffer.data.element.Entity;
 import uk.gov.gchq.gaffer.tinkerpop.GafferPopEdge;
 import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 
 public class GafferPopEdgeGeneratorTest {
@@ -81,5 +84,18 @@ public class GafferPopEdgeGeneratorTest {
         assertThat(Lists.newArrayList(gafferPopEdge.properties()).size()).isEqualTo(1);
         assertThat(gafferPopEdge.graph()).isSameAs(graph);
         assertThat(gafferPopEdge.isReadOnly()).isFalse();
+    }
+
+    @Test 
+    public void shouldThrowExceptionWhenPassedEntity() {
+        // Given
+        final GafferPopGraph graph = mock(GafferPopGraph.class);
+        final Element element = new Entity.Builder().group(TestGroups.ENTITY).build();
+        
+        final GafferPopEdgeGenerator generator = new GafferPopEdgeGenerator(graph, true);
+
+        // Then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> generator._apply(element));
     }
 }

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopElementGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopElementGeneratorTest.java
@@ -35,13 +35,16 @@ public class GafferPopElementGeneratorTest {
 
     @Test
     public void shouldReturnAGafferPopVertex(){
+        // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
-
         final Element element = new Entity.Builder().group(TestGroups.ENTITY).build();
-
+        
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(graph, true);
+
+        // When
         final GafferPopElement gafferPopElement = generator._apply(element);
 
+        // Then
         assertThat(gafferPopElement).isInstanceOf(GafferPopVertex.class);
         assertThat(gafferPopElement.label()).isEqualTo(TestGroups.ENTITY);
         assertThat(gafferPopElement.graph()).isSameAs(graph);
@@ -49,12 +52,16 @@ public class GafferPopElementGeneratorTest {
 
     @Test
     public void shouldReturnAGafferPopEdge(){
+        // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final Element element = new Edge.Builder().group(TestGroups.EDGE).build();
 
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(graph, true);
+
+        // When
         final GafferPopElement gafferPopElement = generator._apply(element);
 
+        // Then
         assertThat(gafferPopElement).isInstanceOf(GafferPopEdge.class);
         assertThat(gafferPopElement.label()).isEqualTo(TestGroups.EDGE);
         assertThat(gafferPopElement.graph()).isSameAs(graph);
@@ -62,12 +69,13 @@ public class GafferPopElementGeneratorTest {
 
     @Test
     public void shouldThrowExceptionForInvalidElement(){
+        // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
+        final Element element = mock(Element.class);   
 
-        final Element element = mock(Element.class);
-        
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(graph, true);
 
+        // Then
         assertThatExceptionOfType(IllegalArgumentException.class)
             .isThrownBy(() -> generator._apply(element))
             .withMessageMatching("GafferPopElement has to be Edge or Entity");

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopElementGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopElementGeneratorTest.java
@@ -74,7 +74,6 @@ public class GafferPopElementGeneratorTest {
 
         // Then
         assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(() -> generator._apply(element))
-            .withMessageMatching("GafferPopElement has to be Edge or Entity");
+            .isThrownBy(() -> generator._apply(element));
     }
 }

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopElementGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopElementGeneratorTest.java
@@ -34,59 +34,38 @@ import uk.gov.gchq.gaffer.tinkerpop.GafferPopVertex;
 public class GafferPopElementGeneratorTest {
 
     @Test
-    public void shouldReturnGafferPopReadOnlyEntity(){
-        // Mock graph
+    public void shouldReturnAGafferPopVertex(){
         final GafferPopGraph graph = mock(GafferPopGraph.class);
 
-        // Mock element as an entity
         final Element element = new Entity.Builder().group(TestGroups.ENTITY).build();
 
-        // Mock a GafferPopVertex
-        final String id = GafferPopGraph.ID_LABEL;
-        final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, id, graph);
-
-        // Pass element to the generator
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(graph, true);
         final GafferPopElement gafferPopElement = generator._apply(element);
 
-        assertThat(gafferPopElement.label()).isEqualTo(vertex.label());
-        assertThat(gafferPopElement.isReadOnly()).isTrue();
+        assertThat(gafferPopElement).isInstanceOf(GafferPopVertex.class);
     }
 
     @Test
-    public void shouldReturnGafferPopReadOnlyEdge(){
-        // Mock graph
+    public void shouldReturnAGafferPopEdge(){
         final GafferPopGraph graph = mock(GafferPopGraph.class);
-
-        // Mock element as an edge
         final Element element = new Edge.Builder().group(TestGroups.EDGE).build();
 
-        // Mock a GafferPopEdge
-        final String source = "source";
-        final String dest = "dest";
-        final GafferPopVertex outVertex = new GafferPopVertex(GafferPopGraph.ID_LABEL, source, graph);
-        final GafferPopVertex inVertex = new GafferPopVertex(GafferPopGraph.ID_LABEL, dest, graph);
-        final GafferPopEdge edge = new GafferPopEdge(TestGroups.EDGE, outVertex, inVertex, graph);
-
-        // Pass element to the generator
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(graph, true);
         final GafferPopElement gafferPopElement = generator._apply(element);
 
-        assertThat(gafferPopElement.label()).isEqualTo(edge.label());
-        assertThat(gafferPopElement.isReadOnly()).isTrue();
+        assertThat(gafferPopElement).isInstanceOf(GafferPopEdge.class);
     }
 
     @Test
     public void shouldThrowExceptionForInvalidElement(){
         final GafferPopGraph graph = mock(GafferPopGraph.class);
 
-        // Mock invalid element
         final Element element = mock(Element.class);
         
-        // Pass element to the generator
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(graph, true);
 
-        //Check exception is thrown
-        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> generator._apply(element)).withMessageMatching("GafferPopElement has to be Edge or Entity");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> generator._apply(element))
+            .withMessageMatching("GafferPopElement has to be Edge or Entity");
     }
 }

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopElementGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopElementGeneratorTest.java
@@ -16,16 +16,15 @@
 
 package uk.gov.gchq.gaffer.tinkerpop.generator;
 
+import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 
-import org.junit.jupiter.api.Test;
-
 import uk.gov.gchq.gaffer.commonutil.TestGroups;
-import uk.gov.gchq.gaffer.data.element.Entity;
 import uk.gov.gchq.gaffer.data.element.Edge;
 import uk.gov.gchq.gaffer.data.element.Element;
+import uk.gov.gchq.gaffer.data.element.Entity;
 import uk.gov.gchq.gaffer.tinkerpop.GafferPopEdge;
 import uk.gov.gchq.gaffer.tinkerpop.GafferPopElement;
 import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph;
@@ -34,11 +33,10 @@ import uk.gov.gchq.gaffer.tinkerpop.GafferPopVertex;
 public class GafferPopElementGeneratorTest {
 
     @Test
-    public void shouldReturnAGafferPopVertex(){
+    public void shouldReturnAGafferPopVertex() {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final Element element = new Entity.Builder().group(TestGroups.ENTITY).build();
-        
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(graph, true);
 
         // When
@@ -51,7 +49,7 @@ public class GafferPopElementGeneratorTest {
     }
 
     @Test
-    public void shouldReturnAGafferPopEdge(){
+    public void shouldReturnAGafferPopEdge() {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final Element element = new Edge.Builder().group(TestGroups.EDGE).build();
@@ -68,11 +66,10 @@ public class GafferPopElementGeneratorTest {
     }
 
     @Test
-    public void shouldThrowExceptionForInvalidElement(){
+    public void shouldThrowExceptionForInvalidElement() {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final Element element = mock(Element.class);   
-
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(graph, true);
 
         // Then

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopElementGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopElementGeneratorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.tinkerpop.generator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.gaffer.commonutil.TestGroups;
+import uk.gov.gchq.gaffer.data.element.Entity;
+import uk.gov.gchq.gaffer.data.element.Edge;
+import uk.gov.gchq.gaffer.data.element.Element;
+import uk.gov.gchq.gaffer.tinkerpop.GafferPopEdge;
+import uk.gov.gchq.gaffer.tinkerpop.GafferPopElement;
+import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph;
+import uk.gov.gchq.gaffer.tinkerpop.GafferPopVertex;
+
+public class GafferPopElementGeneratorTest {
+
+    @Test
+    public void shouldReturnGafferPopReadOnlyEntity(){
+        // Mock graph
+        final GafferPopGraph graph = mock(GafferPopGraph.class);
+
+        // Mock element as an entity
+        final Element element = new Entity.Builder().group(TestGroups.ENTITY).build();
+
+        // Mock a GafferPopVertex
+        final String id = GafferPopGraph.ID_LABEL;
+        final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, id, graph);
+
+        // Pass element to the generator
+        final GafferPopElementGenerator generator = new GafferPopElementGenerator(graph, true);
+        final GafferPopElement gafferPopElement = generator._apply(element);
+
+        assertThat(gafferPopElement.label()).isEqualTo(vertex.label());
+        assertThat(gafferPopElement.isReadOnly()).isTrue();
+    }
+
+    @Test
+    public void shouldReturnGafferPopReadOnlyEdge(){
+        // Mock graph
+        final GafferPopGraph graph = mock(GafferPopGraph.class);
+
+        // Mock element as an edge
+        final Element element = new Edge.Builder().group(TestGroups.EDGE).build();
+
+        // Mock a GafferPopEdge
+        final String source = "source";
+        final String dest = "dest";
+        final GafferPopVertex outVertex = new GafferPopVertex(GafferPopGraph.ID_LABEL, source, graph);
+        final GafferPopVertex inVertex = new GafferPopVertex(GafferPopGraph.ID_LABEL, dest, graph);
+        final GafferPopEdge edge = new GafferPopEdge(TestGroups.EDGE, outVertex, inVertex, graph);
+
+        // Pass element to the generator
+        final GafferPopElementGenerator generator = new GafferPopElementGenerator(graph, true);
+        final GafferPopElement gafferPopElement = generator._apply(element);
+
+        assertThat(gafferPopElement.label()).isEqualTo(edge.label());
+        assertThat(gafferPopElement.isReadOnly()).isTrue();
+    }
+
+    @Test
+    public void shouldThrowExceptionForInvalidElement(){
+        final GafferPopGraph graph = mock(GafferPopGraph.class);
+
+        // Mock invalid element
+        final Element element = mock(Element.class);
+        
+        // Pass element to the generator
+        final GafferPopElementGenerator generator = new GafferPopElementGenerator(graph, true);
+
+        //Check exception is thrown
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> generator._apply(element)).withMessageMatching("GafferPopElement has to be Edge or Entity");
+    }
+}

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopElementGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopElementGeneratorTest.java
@@ -43,6 +43,7 @@ public class GafferPopElementGeneratorTest {
         final GafferPopElement gafferPopElement = generator._apply(element);
 
         assertThat(gafferPopElement).isInstanceOf(GafferPopVertex.class);
+        assertThat(gafferPopElement.label()).isEqualTo(TestGroups.ENTITY);
     }
 
     @Test
@@ -54,6 +55,7 @@ public class GafferPopElementGeneratorTest {
         final GafferPopElement gafferPopElement = generator._apply(element);
 
         assertThat(gafferPopElement).isInstanceOf(GafferPopEdge.class);
+        assertThat(gafferPopElement.label()).isEqualTo(TestGroups.EDGE);
     }
 
     @Test

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopElementGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopElementGeneratorTest.java
@@ -69,7 +69,7 @@ public class GafferPopElementGeneratorTest {
     public void shouldThrowExceptionForInvalidElement() {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
-        final Element element = mock(Element.class);   
+        final Element element = mock(Element.class);
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(graph, true);
 
         // Then

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopElementGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopElementGeneratorTest.java
@@ -44,6 +44,7 @@ public class GafferPopElementGeneratorTest {
 
         assertThat(gafferPopElement).isInstanceOf(GafferPopVertex.class);
         assertThat(gafferPopElement.label()).isEqualTo(TestGroups.ENTITY);
+        assertThat(gafferPopElement.graph()).isSameAs(graph);
     }
 
     @Test
@@ -56,6 +57,7 @@ public class GafferPopElementGeneratorTest {
 
         assertThat(gafferPopElement).isInstanceOf(GafferPopEdge.class);
         assertThat(gafferPopElement.label()).isEqualTo(TestGroups.EDGE);
+        assertThat(gafferPopElement.graph()).isSameAs(graph);
     }
 
     @Test

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopVertexGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopVertexGeneratorTest.java
@@ -65,7 +65,7 @@ public class GafferPopVertexGeneratorTest {
         assertThat(gafferPopVertex.label()).isEqualTo(TestGroups.ENTITY);
         assertThat(gafferPopVertex.id()).isEqualTo(vertex);
         assertThat(gafferPopVertex.property(TestPropertyNames.STRING).value()).isEqualTo(propValue);
-        assertThat(gafferPopVertex.properties()).asList().hasSize(1);
+        assertThat(Lists.newArrayList(gafferPopVertex.properties())).hasSize(1);
         assertThat(gafferPopVertex.graph()).isSameAs(graph);
         assertThat(gafferPopVertex.isReadOnly()).isTrue();
     }
@@ -98,7 +98,7 @@ public class GafferPopVertexGeneratorTest {
         assertThat(gafferPopVertex.label()).isEqualTo(TestGroups.ENTITY);
         assertThat(gafferPopVertex.id()).isEqualTo(vertex);
         assertThat(gafferPopVertex.property(TestPropertyNames.STRING).value()).isEqualTo(propValue);
-        assertThat(gafferPopVertex.properties()).asList().hasSize(1);
+        assertThat(Lists.newArrayList(gafferPopVertex.properties())).hasSize(1);
         assertThat(gafferPopVertex.graph()).isSameAs(graph);
         assertThat(gafferPopVertex.isReadOnly()).isFalse();
     }

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopVertexGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopVertexGeneratorTest.java
@@ -28,10 +28,7 @@ import uk.gov.gchq.gaffer.data.element.Entity;
 import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph;
 import uk.gov.gchq.gaffer.tinkerpop.GafferPopVertex;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -61,12 +58,12 @@ public class GafferPopVertexGeneratorTest {
         final GafferPopVertex gafferPopVertex = generator._apply(entity);
 
         // Then
-        assertEquals(TestGroups.ENTITY, gafferPopVertex.label());
-        assertEquals(vertex, gafferPopVertex.id());
-        assertEquals(propValue, gafferPopVertex.property(TestPropertyNames.STRING).value());
-        assertEquals(1, Lists.newArrayList(gafferPopVertex.properties()).size());
-        assertSame(graph, gafferPopVertex.graph());
-        assertTrue(gafferPopVertex.isReadOnly());
+        assertThat(gafferPopVertex.label()).isEqualTo(TestGroups.ENTITY);
+        assertThat(gafferPopVertex.id()).isEqualTo(vertex);
+        assertThat(gafferPopVertex.property(TestPropertyNames.STRING).value()).isEqualTo(propValue);
+        assertThat(Lists.newArrayList(gafferPopVertex.properties()).size()).isEqualTo(1);
+        assertThat(gafferPopVertex.graph()).isSameAs(graph);
+        assertThat(gafferPopVertex.isReadOnly()).isTrue();
     }
 
     @Test
@@ -94,11 +91,11 @@ public class GafferPopVertexGeneratorTest {
         final GafferPopVertex gafferPopVertex = generator._apply(entity);
 
         // Then
-        assertEquals(TestGroups.ENTITY, gafferPopVertex.label());
-        assertEquals(vertex, gafferPopVertex.id());
-        assertEquals(propValue, gafferPopVertex.property(TestPropertyNames.STRING).value());
-        assertEquals(1, Lists.newArrayList(gafferPopVertex.properties()).size());
-        assertSame(graph, gafferPopVertex.graph());
-        assertFalse(gafferPopVertex.isReadOnly());
+        assertThat(gafferPopVertex.label()).isEqualTo(TestGroups.ENTITY);
+        assertThat(gafferPopVertex.id()).isEqualTo(vertex);
+        assertThat(gafferPopVertex.property(TestPropertyNames.STRING).value()).isEqualTo(propValue);
+        assertThat(Lists.newArrayList(gafferPopVertex.properties()).size()).isEqualTo(1);
+        assertThat(gafferPopVertex.graph()).isSameAs(graph);
+        assertThat(gafferPopVertex.isReadOnly()).isFalse();
     }
 }

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopVertexGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopVertexGeneratorTest.java
@@ -24,11 +24,14 @@ import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.commonutil.TestGroups;
 import uk.gov.gchq.gaffer.commonutil.TestPropertyNames;
+import uk.gov.gchq.gaffer.data.element.Edge;
+import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.Entity;
 import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph;
 import uk.gov.gchq.gaffer.tinkerpop.GafferPopVertex;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -98,4 +101,18 @@ public class GafferPopVertexGeneratorTest {
         assertThat(gafferPopVertex.graph()).isSameAs(graph);
         assertThat(gafferPopVertex.isReadOnly()).isFalse();
     }
+
+    @Test 
+    public void shouldThrowExceptionWhenPassedEdge() {
+        // Given
+        final GafferPopGraph graph = mock(GafferPopGraph.class);
+        final Element element = new Edge.Builder().group(TestGroups.EDGE).build();
+        
+        final GafferPopVertexGenerator generator = new GafferPopVertexGenerator(graph, true);
+
+        // Then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> generator._apply(element));
+    }
+
 }

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopVertexGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopVertexGeneratorTest.java
@@ -16,7 +16,6 @@
 
 package uk.gov.gchq.gaffer.tinkerpop.generator;
 
-import com.google.common.collect.Lists;
 import org.apache.tinkerpop.gremlin.structure.Graph.Features;
 import org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexFeatures;
 import org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexPropertyFeatures;

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopVertexGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopVertexGeneratorTest.java
@@ -65,7 +65,7 @@ public class GafferPopVertexGeneratorTest {
         assertThat(gafferPopVertex.label()).isEqualTo(TestGroups.ENTITY);
         assertThat(gafferPopVertex.id()).isEqualTo(vertex);
         assertThat(gafferPopVertex.property(TestPropertyNames.STRING).value()).isEqualTo(propValue);
-        assertThat(Lists.newArrayList(gafferPopVertex.properties())).hasSize(1);
+        assertThat(gafferPopVertex.properties()).toIterable().hasSize(1);
         assertThat(gafferPopVertex.graph()).isSameAs(graph);
         assertThat(gafferPopVertex.isReadOnly()).isTrue();
     }
@@ -98,7 +98,7 @@ public class GafferPopVertexGeneratorTest {
         assertThat(gafferPopVertex.label()).isEqualTo(TestGroups.ENTITY);
         assertThat(gafferPopVertex.id()).isEqualTo(vertex);
         assertThat(gafferPopVertex.property(TestPropertyNames.STRING).value()).isEqualTo(propValue);
-        assertThat(Lists.newArrayList(gafferPopVertex.properties())).hasSize(1);
+        assertThat(gafferPopVertex.properties()).toIterable().hasSize(1);
         assertThat(gafferPopVertex.graph()).isSameAs(graph);
         assertThat(gafferPopVertex.isReadOnly()).isFalse();
     }

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopVertexGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopVertexGeneratorTest.java
@@ -36,6 +36,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 public class GafferPopVertexGeneratorTest {
+
     @Test
     public void shouldConvertGafferEntityToGafferPopReadOnlyEntity() {
         // Given
@@ -102,12 +103,11 @@ public class GafferPopVertexGeneratorTest {
         assertThat(gafferPopVertex.isReadOnly()).isFalse();
     }
 
-    @Test 
+    @Test
     public void shouldThrowExceptionWhenPassedEdge() {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final Element element = new Edge.Builder().group(TestGroups.EDGE).build();
-        
         final GafferPopVertexGenerator generator = new GafferPopVertexGenerator(graph, true);
 
         // Then

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopVertexGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopVertexGeneratorTest.java
@@ -65,7 +65,7 @@ public class GafferPopVertexGeneratorTest {
         assertThat(gafferPopVertex.label()).isEqualTo(TestGroups.ENTITY);
         assertThat(gafferPopVertex.id()).isEqualTo(vertex);
         assertThat(gafferPopVertex.property(TestPropertyNames.STRING).value()).isEqualTo(propValue);
-        assertThat(Lists.newArrayList(gafferPopVertex.properties()).size()).isEqualTo(1);
+        assertThat(gafferPopVertex.properties()).asList().hasSize(1);
         assertThat(gafferPopVertex.graph()).isSameAs(graph);
         assertThat(gafferPopVertex.isReadOnly()).isTrue();
     }
@@ -98,7 +98,7 @@ public class GafferPopVertexGeneratorTest {
         assertThat(gafferPopVertex.label()).isEqualTo(TestGroups.ENTITY);
         assertThat(gafferPopVertex.id()).isEqualTo(vertex);
         assertThat(gafferPopVertex.property(TestPropertyNames.STRING).value()).isEqualTo(propValue);
-        assertThat(Lists.newArrayList(gafferPopVertex.properties()).size()).isEqualTo(1);
+        assertThat(gafferPopVertex.properties()).asList().hasSize(1);
         assertThat(gafferPopVertex.graph()).isSameAs(graph);
         assertThat(gafferPopVertex.isReadOnly()).isFalse();
     }


### PR DESCRIPTION
Added testing to GafferPopElementGenerator to increase test coverage. Also updated testing from JUnit to AssertJ for the other generator classes to aid with improving assertion readability (#3014). Improved test coverage of GafferPopVertexGenerator and GafferPopEdgeGenerator classes.

# Related issue

- Resolve #3056