### PR TITLE
Gh-3053: ApplyViewToElementsFunction optimisations

### DIFF
--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/handler/impl/FederatedOperationHandler.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/handler/impl/FederatedOperationHandler.java
@@ -43,7 +43,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static com.google.common.collect.Iterables.isEmpty;
 import static java.util.Objects.nonNull;
@@ -118,10 +120,10 @@ public class FederatedOperationHandler<INPUT, OUTPUT> implements OperationHandle
                     && mergeFunction instanceof ApplyViewToElementsFunction
                     && (graphs.size() == 1 || !graphsHaveCommonSchemaGroups(graphs))) {
                 LOGGER.info("Skipping merge function as not required when only one graph or no common groups");
-                // Just flatten current results that are essentially a list of lists into one list and return
-                HashSet<Element> mergedResults = new HashSet<>();
-                resultsFromAllGraphs.forEach(result -> ((Iterable<Element>) result).iterator().forEachRemaining(mergedResults::add));
-                return mergedResults;
+                // Just flatten current results to a single set to return
+                return StreamSupport.stream(resultsFromAllGraphs.spliterator(), false)
+                    .flatMap(result -> StreamSupport.stream(((Iterable<?>) result).spliterator(), false))
+                    .collect(Collectors.toSet());
             }
 
             // Reduce

--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/handler/impl/FederatedOperationHandler.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/handler/impl/FederatedOperationHandler.java
@@ -121,9 +121,10 @@ public class FederatedOperationHandler<INPUT, OUTPUT> implements OperationHandle
                     && (graphs.size() == 1 || !graphsHaveCommonSchemaGroups(graphs))) {
                 LOGGER.info("Skipping merge function as not required when only one graph or no common groups");
                 // Just flatten current results to a single set to return
-                return StreamSupport.stream(resultsFromAllGraphs.spliterator(), false)
+                Iterable<?> iterableStream = () -> StreamSupport.stream(resultsFromAllGraphs.spliterator(), false)
                     .flatMap(result -> StreamSupport.stream(((Iterable<?>) result).spliterator(), false))
-                    .collect(Collectors.toSet());
+                    .iterator();
+                return iterableStream;
             }
 
             // Reduce

--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/handler/impl/FederatedOperationHandler.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/handler/impl/FederatedOperationHandler.java
@@ -179,7 +179,7 @@ public class FederatedOperationHandler<INPUT, OUTPUT> implements OperationHandle
                 Set<String> firstGroupSet = graphSchemas.get(i).getGroups();
                 Set<String> secondGroupSet = graphSchemas.get(j).getGroups();
                 if (!Collections.disjoint(firstGroupSet, secondGroupSet)) {
-                     LOGGER.debug("Found common schema groups between requested graphs");
+                    LOGGER.debug("Found common schema groups between requested graphs");
                     return true;
                 }
             }

--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/handler/impl/FederatedOperationHandler.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/handler/impl/FederatedOperationHandler.java
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import static com.google.common.collect.Iterables.isEmpty;
 import static java.util.Objects.nonNull;

--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/handler/impl/FederatedOperationHandler.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/operation/handler/impl/FederatedOperationHandler.java
@@ -20,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import uk.gov.gchq.gaffer.core.exception.GafferCheckedException;
-import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.federatedstore.FederatedStore;
 import uk.gov.gchq.gaffer.federatedstore.operation.FederatedOperation;
 import uk.gov.gchq.gaffer.federatedstore.util.ApplyViewToElementsFunction;
@@ -39,11 +38,9 @@ import uk.gov.gchq.koryphe.Since;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -183,8 +180,8 @@ public class FederatedOperationHandler<INPUT, OUTPUT> implements OperationHandle
                 // Compare each schema against the others to see if common groups
                 Set<String> firstGroupSet = graphSchemas.get(i).getGroups();
                 Set<String> secondGroupSet = graphSchemas.get(j).getGroups();
-                if (firstGroupSet.stream().anyMatch(secondGroupSet::contains)) {
-                    LOGGER.debug("Found common schema groups between requested graphs");
+                if (!Collections.disjoint(firstGroupSet, secondGroupSet)) {
+                     LOGGER.debug("Found common schema groups between requested graphs");
                     return true;
                 }
             }


### PR DESCRIPTION
Adds in logic to skip the default merge function if only one graph or if no common groups between graph schemas, instead it will just flatten the current list of results and return.

Unsure if there are existing tests for this functionality or the integration tests need fixing first under #3058 

# Related issue

- Resolve #3053