### PR TITLE
Gh-3083: Improve testing of gafferpopvertex

### DIFF
--- a/core/common-util/src/test/java/uk/gov/gchq/gaffer/commonutil/TestPropertyNames.java
+++ b/core/common-util/src/test/java/uk/gov/gchq/gaffer/commonutil/TestPropertyNames.java
@@ -29,6 +29,7 @@ public final class TestPropertyNames {
     public static final String TIMESTAMP = "timestamp";
     public static final String COUNT = "count";
     public static final String VISIBILITY = "visibility";
+    public static final String NULL = "null";
 
     public static final String PROP_1 = "property1";
     public static final String PROP_2 = "property2";

--- a/core/common-util/src/test/java/uk/gov/gchq/gaffer/commonutil/TestPropertyNames.java
+++ b/core/common-util/src/test/java/uk/gov/gchq/gaffer/commonutil/TestPropertyNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Crown Copyright
+ * Copyright 2016-2023 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertexTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertexTest.java
@@ -16,13 +16,10 @@
 
 package uk.gov.gchq.gaffer.tinkerpop;
 
-import com.google.common.collect.Lists;
 import org.apache.tinkerpop.gremlin.structure.Direction;
-import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph.Features;
 import org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexFeatures;
 import org.apache.tinkerpop.gremlin.structure.Graph.Features.VertexPropertyFeatures;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality;
 import org.junit.jupiter.api.Test;
@@ -31,48 +28,40 @@ import uk.gov.gchq.gaffer.commonutil.TestGroups;
 import uk.gov.gchq.gaffer.commonutil.TestPropertyNames;
 import uk.gov.gchq.gaffer.data.elementdefinition.view.View;
 
-import java.util.Arrays;
 import java.util.Iterator;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-public class GafferPopVertexTest {
+class GafferPopVertexTest {
     @Test
-    public void shouldConstructVertex() {
+    void shouldConstructVertex() {
         // Given
-        final String id = GafferPopGraph.ID_LABEL;
         final GafferPopGraph graph = mock(GafferPopGraph.class);
 
         // When
-        final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, id, graph);
+        final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, GafferPopGraph.ID_LABEL, graph);
 
         // Then
-        assertEquals(id, vertex.id());
-        assertSame(graph, vertex.graph());
-        assertTrue(vertex.keys().isEmpty());
+        assertThat(vertex.id()).isEqualTo(GafferPopGraph.ID_LABEL);
+        assertThat(vertex.graph()).isEqualTo(graph);
+        assertThat(vertex.keys()).isEmpty();
     }
 
     @Test
-    void shouldAddAndGetVertexProperties() {
+    void shouldOnlyAddAndGetValidVertexProperties() {
         // Given
-        final String id = GafferPopGraph.ID_LABEL;
-
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final Features features = mock(Features.class);
         final VertexFeatures vertexFeatures = mock(VertexFeatures.class);
         final VertexPropertyFeatures vertexPropertyFeatures = mock(VertexPropertyFeatures.class);
 
-        final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, id, graph);
-        final String propValue1 = "propValue1";
-        final int propValue2 = 10;
+        final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, GafferPopGraph.ID_LABEL, graph);
+        final String stringProp1 = "stringProp1";
+        final String stringProp2 = "stringProp2";
+        final int intProp = 10;
 
         given(graph.features()).willReturn(features);
         given(features.vertex()).willReturn(vertexFeatures);
@@ -80,19 +69,67 @@ public class GafferPopVertexTest {
         given(vertexFeatures.properties()).willReturn(vertexPropertyFeatures);
         given(vertexPropertyFeatures.supportsNullPropertyValues()).willReturn(true);
 
-        // When
-        vertex.property(Cardinality.list, TestPropertyNames.STRING, propValue1);
-        vertex.property(Cardinality.list, TestPropertyNames.INT, propValue2);
-        vertex.property(Cardinality.list, TestPropertyNames.NULL, null);
+        // Ensure adding and getting all properties works as expected
+        // Check currently blank
+        assertThat(vertex.properties())
+            .toIterable()
+            .isEmpty();
 
-        // Then
-        assertThat(vertex.property(TestPropertyNames.STRING).value()).isEqualTo(propValue1);
-        assertThat(vertex.property(TestPropertyNames.INT).value()).isEqualTo(propValue2);
+        // Add string property
+        assertThat(vertex.property(Cardinality.list, TestPropertyNames.STRING, stringProp1))
+            .isInstanceOf(VertexProperty.class);
+
+        // Verify contains
+        assertThat(vertex.properties())
+            .toIterable()
+            .map(VertexProperty::value)
+            .containsExactlyInAnyOrder(stringProp1);
+
+        // Add int property
+        assertThat(vertex.property(Cardinality.list, TestPropertyNames.INT, intProp))
+            .isInstanceOf(VertexProperty.class);
+
+        // Verify contains
+        assertThat(vertex.properties())
+            .toIterable()
+            .map(VertexProperty::value)
+            .containsExactlyInAnyOrder(stringProp1, intProp);
+
+        // Add null property
+        assertThat(vertex.property(Cardinality.list, TestPropertyNames.NULL, null))
+            .isInstanceOf(VertexProperty.class);
+
+        // Verify filtering works
+        assertThat(vertex.properties(TestPropertyNames.STRING))
+            .toIterable()
+            .map(VertexProperty::value)
+            .containsExactlyInAnyOrder(stringProp1);
+
+        // Add another value to a key
+        assertThat(vertex.property(Cardinality.list, TestPropertyNames.STRING, stringProp2))
+            .isInstanceOf(VertexProperty.class);
+
+        // Verify filtering works
+        assertThat(vertex.properties(TestPropertyNames.STRING))
+            .toIterable()
+            .map(VertexProperty::value)
+            .containsExactlyInAnyOrder(stringProp1, stringProp2);
+
+        // Make sure can't access when multiple properties exist for a key
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> vertex.property(TestPropertyNames.STRING));
+
+        // Make sure can get key values that have only one property
+        assertThat(vertex.property(TestPropertyNames.INT).value()).isEqualTo(intProp);
         assertThat(vertex.property(TestPropertyNames.NULL).value()).isNull();
+
+        // Check can get the keys
+        assertThat(vertex.keys())
+            .containsExactlyInAnyOrder(TestPropertyNames.STRING, TestPropertyNames.INT, TestPropertyNames.NULL);
     }
 
     @Test
-    void shouldFailToGetDuplicateProperties() {
+    void shouldNotAddOrGetIllegalProperties() {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final Features features = mock(Features.class);
@@ -103,69 +140,61 @@ public class GafferPopVertexTest {
         given(vertexFeatures.properties()).willReturn(vertexPropertyFeatures);
         // Make new vertex with the mocked bits
         final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, GafferPopGraph.ID_LABEL, graph);
-        String duplicatePropertyValue = "duplicate";
 
-        // When
-        // Add two of the same property
-        vertex.property(Cardinality.list, TestPropertyNames.STRING, duplicatePropertyValue);
-        vertex.property(Cardinality.list, TestPropertyNames.STRING, duplicatePropertyValue);
-
-        // Then
-        assertThatExceptionOfType(IllegalStateException.class)
-            .isThrownBy(() -> vertex.property(TestPropertyNames.STRING));
+        // Ensure can't add illegal properties
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> vertex.property(Cardinality.list, "illegalKeyValueArray", "bad", "bad"));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> vertex.property(Cardinality.list, null, null));
+        // Ensure can't get a bad property
+        assertThat(vertex.property("THIS_DOES_NOT_EXIST")).isEqualTo(VertexProperty.empty());
     }
 
     @Test
-    public void shouldGetIterableOfVertexProperties() {
+    void shouldNotAllowChangesWhenVertexReadOnly() {
         // Given
-        final String id = GafferPopGraph.ID_LABEL;
-
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final Features features = mock(Features.class);
         final VertexFeatures vertexFeatures = mock(VertexFeatures.class);
         final VertexPropertyFeatures vertexPropertyFeatures = mock(VertexPropertyFeatures.class);
-
-        final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, id, graph);
-        final String propValue1 = "propValue1";
-        final int propValue2 = 10;
-
         given(graph.features()).willReturn(features);
         given(features.vertex()).willReturn(vertexFeatures);
-        given(vertexFeatures.supportsNullPropertyValues()).willReturn(true);
         given(vertexFeatures.properties()).willReturn(vertexPropertyFeatures);
-        given(vertexPropertyFeatures.supportsNullPropertyValues()).willReturn(true);
+        // Make new vertex with the mocked bits
+        final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, GafferPopGraph.ID_LABEL, graph);
 
-        vertex.property(Cardinality.list, TestPropertyNames.STRING, propValue1);
-        vertex.property(Cardinality.list, TestPropertyNames.INT, propValue2);
+        // Set the vertex to read only
+        vertex.setReadOnly();
 
-        // When
-        final Iterator<VertexProperty<Object>> props = vertex.properties(TestPropertyNames.STRING, TestPropertyNames.INT);
-
-        // Then
-        final ArrayList<VertexProperty> propList = Lists.newArrayList(props);
-        assertThat(propList).contains(
-                new GafferPopVertexProperty<>(vertex, TestPropertyNames.STRING, propValue1),
-                new GafferPopVertexProperty<>(vertex, TestPropertyNames.INT, propValue2)
-        );
+        // Attempt to add a property
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+            .isThrownBy(() -> vertex.property(Cardinality.list, TestPropertyNames.STRING, "prop"));
     }
 
     @Test
-    public void shouldDelegateEdgesToGraph() {
+    void shouldNotAllowAddingInvalidEdges() {
+        // Given
+        final GafferPopGraph graph = mock(GafferPopGraph.class);
+        final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, GafferPopGraph.ID_LABEL, graph);
+        // Try add a null edge
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> vertex.addEdge("null", null, "null"));
+    }
+
+    @Test
+    void shouldDelegateEdgesToGraph() {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, GafferPopGraph.ID_LABEL, graph);
         final Iterator<GafferPopEdge> edges = mock(Iterator.class);
         given(graph.edges(GafferPopGraph.ID_LABEL, Direction.IN, TestGroups.ENTITY)).willReturn(edges);
 
-        // When
-        final Iterator<Edge> resultEdges = vertex.edges(Direction.IN, TestGroups.ENTITY);
-
         // Then
-        assertSame(edges, resultEdges);
+        assertThat(vertex.edges(Direction.IN, TestGroups.ENTITY)).isEqualTo(edges);
     }
 
     @Test
-    public void shouldDelegateEdgesWithViewToGraph() {
+    void shouldDelegateEdgesWithViewToGraph() {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, GafferPopGraph.ID_LABEL, graph);
@@ -173,31 +202,25 @@ public class GafferPopVertexTest {
         final View view = mock(View.class);
         given(graph.edgesWithView(GafferPopGraph.ID_LABEL, Direction.IN, view)).willReturn(edges);
 
-        // When
-        final Iterator<GafferPopEdge> resultEdges = vertex.edges(Direction.IN, view);
-
         // Then
-        assertSame(edges, resultEdges);
+        assertThat(vertex.edges(Direction.IN, view)).isEqualTo(edges);
     }
 
     @Test
-    public void shouldDelegateVerticesToGraph() {
+    void shouldDelegateVerticesToGraph() {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, GafferPopGraph.ID_LABEL, graph);
         final Iterator<GafferPopVertex> vertices = mock(Iterator.class);
         given(graph.adjVertices(GafferPopGraph.ID_LABEL, Direction.IN, TestGroups.EDGE)).willReturn(vertices);
 
-        // When
-        final Iterator<Vertex> resultVertices = vertex.vertices(Direction.IN, TestGroups.EDGE);
-
         // Then
-        assertSame(vertices, resultVertices);
+        assertThat(vertex.vertices(Direction.IN, TestGroups.EDGE)).isEqualTo(vertices);
     }
 
 
     @Test
-    public void shouldDelegateVerticesWithViewToGraph() {
+    void shouldDelegateVerticesWithViewToGraph() {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, GafferPopGraph.ID_LABEL, graph);
@@ -205,23 +228,17 @@ public class GafferPopVertexTest {
         final View view = mock(View.class);
         given(graph.adjVerticesWithView(GafferPopGraph.ID_LABEL, Direction.IN, view)).willReturn(vertices);
 
-        // When
-        final Iterator<GafferPopVertex> resultVertices = vertex.vertices(Direction.IN, view);
-
         // Then
-        assertSame(vertices, resultVertices);
+        assertThat(vertex.vertices(Direction.IN, view)).isEqualTo(vertices);
     }
 
     @Test
-    public void shouldCreateReadableToString() {
+    void shouldCreateReadableToString() {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, GafferPopGraph.ID_LABEL, graph);
 
-        // When
-        final String toString = vertex.toString();
-
         // Then
-        assertEquals("v[BasicEntity-id]", toString);
+        assertThat(vertex).hasToString("v[BasicEntity-id]");
     }
 }


### PR DESCRIPTION
Improves the test coverage and quality of the testing (measured from mutation testing) on the `GafferPopVertex` class.

Now above 80% coverage and moved to assertJ where possible.

# Related issue

- Resolve #3083