### PR TITLE
Gh-3100: Add unit testing to GafferPopProperty

### DIFF
--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdgeTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdgeTest.java
@@ -136,6 +136,33 @@ public class GafferPopEdgeTest {
         );
     }
 
+    @Test
+    void shouldCreateValidGafferPopPropertyObjects() {
+        // Given
+        final GafferPopGraph graph = mock(GafferPopGraph.class);
+        final GafferPopEdge edge = new GafferPopEdge(TestGroups.EDGE, SOURCE, DEST, graph);
+        final String propValue1 = "propValue1";
+        // Make some values to compare against
+        final GafferPopProperty<Object> equalProp = new GafferPopProperty<Object>(edge, TestPropertyNames.STRING, propValue1);
+        final String notAProp = "NotAGafferPopProperty";
+
+        // When
+        // Add and get the returned property and check its methods
+        edge.property(TestPropertyNames.STRING, propValue1);
+        GafferPopProperty<Object> prop = (GafferPopProperty<Object>) edge.property(TestPropertyNames.STRING);
+
+        // Then
+        assertThat(prop.element()).isEqualTo(edge);
+        assertThat(prop.isPresent()).isTrue();
+        assertThat(prop)
+            .hasToString("p[stringProperty->" + propValue1 + "]")
+            .isEqualTo(equalProp)
+            .hasSameHashCodeAs(equalProp)
+            .isNotEqualTo(notAProp)
+            .doesNotHaveSameHashCodeAs(notAProp);
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> prop.remove());
+    }
+
 
     @Test
     public void shouldCreateReadableToString() {

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdgeTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdgeTest.java
@@ -144,6 +144,7 @@ public class GafferPopEdgeTest {
         final String propValue1 = "propValue1";
         // Make some values to compare against
         final GafferPopProperty<Object> equalProp = new GafferPopProperty<Object>(edge, TestPropertyNames.STRING, propValue1);
+        final GafferPopProperty<Object> nullProp = new GafferPopProperty<Object>(edge, TestPropertyNames.NULL, null);
         final String notAProp = "NotAGafferPopProperty";
 
         // When
@@ -161,6 +162,7 @@ public class GafferPopEdgeTest {
             .isNotEqualTo(notAProp)
             .doesNotHaveSameHashCodeAs(notAProp);
         assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> prop.remove());
+        assertThat(nullProp.isPresent()).isFalse();
     }
 
 


### PR DESCRIPTION
Expands unit tests for the GafferPopEdges to more rigorously test the GafferPopProperty class is being used and created correctly when properties are added to an edge. Now has  > 80% coverage. 

# Related issue

- Resolve #3100