### PR TITLE
Gh-3108: Improve testing for GafferPopVertexProperty

### DIFF
--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertexProperty.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertexProperty.java
@@ -20,7 +20,6 @@ import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
-import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -110,16 +109,10 @@ public class GafferPopVertexProperty<V> extends GafferPopElement implements Vert
             return Collections.emptyIterator();
         }
 
-        if (propertyKeys.length == 1) {
-            final Property<U> property = properties.get(propertyKeys[0]);
-            return null == property ? Collections.emptyIterator() : IteratorUtils.of(property);
-        }
-
-        return (Iterator<Property<U>>) (Iterator) properties.entrySet()
-                .stream()
-                .filter(entry -> ElementHelper.keyExists(entry.getKey(), propertyKeys))
-                .map(entry -> entry.getValue())
-                .collect(Collectors.toList())
-                .iterator();
+        return properties.entrySet().stream()
+            .filter(entry -> ElementHelper.keyExists(entry.getKey(), propertyKeys))
+            .map(entry -> (Property<U>) entry.getValue())
+            .collect(Collectors.toList())
+            .iterator();
     }
 }

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertexTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertexTest.java
@@ -161,35 +161,39 @@ class GafferPopVertexTest {
         given(features.vertex()).willReturn(vertexFeatures);
         given(vertexFeatures.properties()).willReturn(vertexPropertyFeatures);
         final String propValue = "propValue";
+        final String nestedKey = "nestedKey";
+        final String nestedValue = "nestedValue";
         // Make new vertex with the mocked bits
         final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, GafferPopGraph.ID_LABEL, graph);
         // Make some values to compare against
-        final GafferPopVertexProperty<Object> equalProp = new GafferPopVertexProperty<Object>(vertex, TestPropertyNames.STRING, propValue);
+        final GafferPopVertexProperty<Object> equalProp = new GafferPopVertexProperty<>(vertex, TestPropertyNames.STRING, propValue);
         final String notAProp = "notAProp";
-        final String nestedKey = "nestedKey";
-        final String nestedVal = "nestedVal";
 
+        // When
         // Set and get the property
         vertex.property(Cardinality.list, TestPropertyNames.STRING, propValue);
         GafferPopVertexProperty<Object> prop = (GafferPopVertexProperty<Object>) vertex.property(TestPropertyNames.STRING);
 
         // Then
-        assertThat(prop.element()).isEqualTo(vertex);
-        assertThat(prop.isPresent()).isTrue();
+        // Validate the created property
         assertThat(prop)
                 .hasToString("vp[" + TestPropertyNames.STRING + "->" + propValue + "]")
                 .isEqualTo(equalProp)
                 .hasSameHashCodeAs(equalProp)
                 .isNotEqualTo(notAProp)
                 .doesNotHaveSameHashCodeAs(notAProp);
+        assertThat(prop.element()).isEqualTo(vertex);
+        assertThat(prop.isPresent()).isTrue();
         assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> prop.remove());
+
         // Check nested properties work
-        assertThat(prop.property(nestedKey, nestedVal)).isEqualTo(new GafferPopProperty<Object>(vertex, nestedKey, nestedVal));
+        assertThat(prop.property(nestedKey, nestedValue)).isEqualTo(new GafferPopProperty<Object>(vertex, nestedKey, nestedValue));
         assertThat(prop.keys()).containsExactlyInAnyOrder(nestedKey);
-        assertThat(prop.property(nestedKey)).isEqualTo(new GafferPopProperty<Object>(prop, nestedKey, nestedVal));
+        assertThat(prop.property(nestedKey)).isEqualTo(new GafferPopProperty<Object>(prop, nestedKey, nestedValue));
+
         // Check can't make a bad property
         assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(() -> new GafferPopVertexProperty<Object>(vertex, "InvalidNumberOfArgs", "val1", "KeyNoVal"));
+            .isThrownBy(() -> new GafferPopVertexProperty<Object>(vertex, "InvalidNumberOfArgs", "val1", "KeyNoValue"));
         assertThatExceptionOfType(IllegalArgumentException.class)
             .isThrownBy(() -> new GafferPopVertexProperty<Object>(vertex, "BadKeyType", "val1", 1, "BadKeysValue"));
     }

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertexTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertexTest.java
@@ -192,7 +192,7 @@ class GafferPopVertexTest {
         assertThat(prop.keys()).containsExactlyInAnyOrder(nestedKey);
         assertThat(prop.property(nestedKey)).isEqualTo(new GafferPopProperty<Object>(prop, nestedKey, nestedValue));
 
-        // Check can't make a bad property
+        // Check can't create an invalid property
         assertThatExceptionOfType(IllegalArgumentException.class)
             .isThrownBy(() -> new GafferPopVertexProperty<Object>(vertex, "InvalidNumberOfArgs", "val1", "KeyNoValue"));
         assertThatExceptionOfType(IllegalArgumentException.class)
@@ -216,7 +216,7 @@ class GafferPopVertexTest {
         // Set the vertex to read only
         vertex.setReadOnly();
 
-        // Attempt to add a properties
+        // Attempt to add some properties
         assertThatExceptionOfType(UnsupportedOperationException.class)
             .isThrownBy(() -> vertex.property(Cardinality.list, TestPropertyNames.STRING, "propValue"));
         assertThatExceptionOfType(UnsupportedOperationException.class)

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertexTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertexTest.java
@@ -36,6 +36,14 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 class GafferPopVertexTest {
+    // Common mocks for tests
+    final Features features = mock(Features.class);
+    final VertexFeatures vertexFeatures = mock(VertexFeatures.class);
+    final VertexPropertyFeatures vertexPropertyFeatures = mock(VertexPropertyFeatures.class);
+    final Iterator<GafferPopVertex> vertices = mock(Iterator.class);
+    final Iterator<GafferPopEdge> edges = mock(Iterator.class);
+    final View view = mock(View.class);
+
     @Test
     void shouldConstructVertex() {
         // Given
@@ -54,10 +62,6 @@ class GafferPopVertexTest {
     void shouldOnlyAddAndGetValidVertexProperties() {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
-        final Features features = mock(Features.class);
-        final VertexFeatures vertexFeatures = mock(VertexFeatures.class);
-        final VertexPropertyFeatures vertexPropertyFeatures = mock(VertexPropertyFeatures.class);
-
         final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, GafferPopGraph.ID_LABEL, graph);
         final String stringProp1 = "stringProp1";
         final String stringProp2 = "stringProp2";
@@ -132,9 +136,6 @@ class GafferPopVertexTest {
     void shouldNotAddOrGetIllegalProperties() {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
-        final Features features = mock(Features.class);
-        final VertexFeatures vertexFeatures = mock(VertexFeatures.class);
-        final VertexPropertyFeatures vertexPropertyFeatures = mock(VertexPropertyFeatures.class);
         given(graph.features()).willReturn(features);
         given(features.vertex()).willReturn(vertexFeatures);
         given(vertexFeatures.properties()).willReturn(vertexPropertyFeatures);
@@ -154,9 +155,6 @@ class GafferPopVertexTest {
     void shouldOnlyCreateValidGafferPopVertexPropertyObjects() {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
-        final Features features = mock(Features.class);
-        final VertexFeatures vertexFeatures = mock(VertexFeatures.class);
-        final VertexPropertyFeatures vertexPropertyFeatures = mock(VertexPropertyFeatures.class);
         given(graph.features()).willReturn(features);
         given(features.vertex()).willReturn(vertexFeatures);
         given(vertexFeatures.properties()).willReturn(vertexPropertyFeatures);
@@ -202,9 +200,6 @@ class GafferPopVertexTest {
     void shouldNotAllowChangesWhenVertexReadOnly() {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
-        final Features features = mock(Features.class);
-        final VertexFeatures vertexFeatures = mock(VertexFeatures.class);
-        final VertexPropertyFeatures vertexPropertyFeatures = mock(VertexPropertyFeatures.class);
         given(graph.features()).willReturn(features);
         given(features.vertex()).willReturn(vertexFeatures);
         given(vertexFeatures.properties()).willReturn(vertexPropertyFeatures);
@@ -240,7 +235,6 @@ class GafferPopVertexTest {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, GafferPopGraph.ID_LABEL, graph);
-        final Iterator<GafferPopEdge> edges = mock(Iterator.class);
         given(graph.edges(GafferPopGraph.ID_LABEL, Direction.IN, TestGroups.ENTITY)).willReturn(edges);
 
         // Then
@@ -252,8 +246,6 @@ class GafferPopVertexTest {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, GafferPopGraph.ID_LABEL, graph);
-        final Iterator<GafferPopEdge> edges = mock(Iterator.class);
-        final View view = mock(View.class);
         given(graph.edgesWithView(GafferPopGraph.ID_LABEL, Direction.IN, view)).willReturn(edges);
 
         // Then
@@ -265,7 +257,6 @@ class GafferPopVertexTest {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, GafferPopGraph.ID_LABEL, graph);
-        final Iterator<GafferPopVertex> vertices = mock(Iterator.class);
         given(graph.adjVertices(GafferPopGraph.ID_LABEL, Direction.IN, TestGroups.EDGE)).willReturn(vertices);
 
         // Then
@@ -278,8 +269,6 @@ class GafferPopVertexTest {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, GafferPopGraph.ID_LABEL, graph);
-        final Iterator<GafferPopVertex> vertices = mock(Iterator.class);
-        final View view = mock(View.class);
         given(graph.adjVerticesWithView(GafferPopGraph.ID_LABEL, Direction.IN, view)).willReturn(vertices);
 
         // Then


### PR DESCRIPTION
Improves the testing on `GafferPopVertexProperty` class to above > 80% coverage.

Slight tweak to reduce mock duplication in the existing test class too.

# Related issue

- Resolve #3108