### PR TITLE
Gh-3106: Refactor GafferPopNamedOperationService

### DIFF
--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/service/GafferPopNamedOperationService.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/service/GafferPopNamedOperationService.java
@@ -37,12 +37,13 @@ import java.util.stream.StreamSupport;
  * Service for running Gaffer Named Operations
  *
  * <p>This service should be called at the start
- * of a traversal.
- * @see <a href="https://tinkerpop.apache.org/docs/3.7.0/reference/#call-step">
- * Tinkerpop Call Step Documentation</a></p>
+ * of a traversal.</p>
  *
  * @param <I> Ignored
  * @param <R> Ignored
+ *
+ * @see <a href="https://tinkerpop.apache.org/docs/3.7.0/reference/#call-step">
+ * Tinkerpop Call Step Documentation</a>
  */
 public class GafferPopNamedOperationService<I, R> implements Service<I, R> {
     private final GafferPopGraph graph;

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/service/GafferPopNamedOperationService.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/service/GafferPopNamedOperationService.java
@@ -74,7 +74,7 @@ public class GafferPopNamedOperationService<I, R> implements Service<I, R> {
         } else if (params.containsKey("add")) {
             return addNamedOperation((Map<String, String>) params.get("add"));
         } else {
-            throw new IllegalStateException("Missing parameter");
+            throw new IllegalStateException("Missing parameter, either 'execute' or 'add' expected");
         }
     }
 

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/service/GafferPopNamedOperationService.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/service/GafferPopNamedOperationService.java
@@ -78,11 +78,21 @@ public class GafferPopNamedOperationService<I, R> implements Service<I, R> {
         }
     }
 
+    /**
+     * Find the requested Named Operation and depending on its output class
+     * either execute and then convert all {@link uk.gov.gchq.gaffer.data.element.Element}
+     * to {@link GafferPopElement}, to just execute and return the result as
+     * an Iterable.
+     *
+     * @param name Name of the Named Operation to execute
+     * @return results of the operation execution
+     */
     protected CloseableIterator<R> executeNamedOperation(final String name) {
         // Fetch details for the requested Named Operation or throw an exception if it's not found
         Iterable<NamedOperationDetail> allNamedOps = graph.execute(new OperationChain.Builder().first(new GetAllNamedOperations()).build());
         NamedOperationDetail namedOperation = StreamSupport.stream(allNamedOps.spliterator(), false)
-                .filter((NamedOperationDetail nd) -> nd.getOperationName().equals(name)).findFirst()
+                .filter(nd -> nd.getOperationName().equals(name))
+                .findFirst()
                 .orElseThrow(() -> new IllegalStateException("Named Operation not found"));
 
         // If the Named Operation outputs an Iterable, then execute and convert Elements to GafferPopElement
@@ -105,6 +115,14 @@ public class GafferPopNamedOperationService<I, R> implements Service<I, R> {
         }
     }
 
+    /**
+     * Add a new Named Operation with the supplied Name and Operation Chain.
+     *
+     * @param addParams {@link Map} with Key "name" containing the name to give
+     * the new Named Operation being added and key "OpChain" containing the
+     * operation chain to use with this Named Operation.
+     * @return
+     */
     protected CloseableIterator<R> addNamedOperation(final Map<String, String> addParams) {
         graph.execute(new OperationChain.Builder()
                 .first(new AddNamedOperation.Builder()

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/service/GafferPopNamedOperationService.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/service/GafferPopNamedOperationService.java
@@ -36,6 +36,11 @@ import java.util.stream.StreamSupport;
 /**
  * Service for running Gaffer Named Operations
  *
+ * <p>This service should be called at the start
+ * of a traversal.
+ * @see <a href="https://tinkerpop.apache.org/docs/3.7.0/reference/#call-step">
+ * Tinkerpop Call Step Documentation</a></p>
+ *
  * @param <I> Ignored
  * @param <R> Ignored
  */

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/service/GafferPopNamedOperationService.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/service/GafferPopNamedOperationService.java
@@ -121,7 +121,7 @@ public class GafferPopNamedOperationService<I, R> implements Service<I, R> {
      * @param addParams {@link Map} with Key "name" containing the name to give
      * the new Named Operation being added and key "OpChain" containing the
      * operation chain to use with this Named Operation.
-     * @return
+     * @return Empty
      */
     protected CloseableIterator<R> addNamedOperation(final Map<String, String> addParams) {
         graph.execute(new OperationChain.Builder()

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/service/GafferPopNamedOperationServiceIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/service/GafferPopNamedOperationServiceIT.java
@@ -86,7 +86,7 @@ public class GafferPopNamedOperationServiceIT {
         // Then
         assertThatThrownBy(() -> g.call("namedoperation", params).toList())
                 .isExactlyInstanceOf(IllegalStateException.class)
-                .hasMessage("Missing parameter");
+                .hasMessage("Missing parameter, either 'execute' or 'add' expected");
     }
 
     @Test

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/service/GafferPopNamedOperationServiceTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/service/GafferPopNamedOperationServiceTest.java
@@ -50,6 +50,6 @@ public class GafferPopNamedOperationServiceTest {
         // When / Then
         assertThatThrownBy(() -> namedOpService.execute(null, Collections.singletonMap("invalid", "invalid")))
                 .isExactlyInstanceOf(IllegalStateException.class)
-                .hasMessage("Missing parameter");
+                .hasMessage("Missing parameter, either 'execute' or 'add' expected");
     }
 }


### PR DESCRIPTION
Some Generics handing is not ideal. This is due to the implementation of generators, how this class is used and TinkerPop itself (rawtype `Map`).

# Related issue

- Resolve #3106