### PR TITLE
fix(sec): upgrade com.google.guava:guava to 32.0.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <commons-collections.version>4.4</commons-collections.version>
         <commons-text.version>1.10.0</commons-text.version>
         <curator.version>2.13.0</curator.version>
-        <guava.version>30.1.1-jre</guava.version>
+        <guava.version>32.0.0-jre</guava.version>
         <javassist.version>3.29.2-GA</javassist.version>
         <javax-activation.version>1.1.1</javax-activation.version>
         <javax-annotation.version>1.3.2</javax-annotation.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.guava:guava 30.1.1-jre
- [CVE-2023-2976](https://www.oscs1024.com/hd/CVE-2023-2976)


### What did I do？
Upgrade com.google.guava:guava from 30.1.1-jre to 32.0.0-jre for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS