### PR TITLE
Gh-3150: Upgrade Actions versions

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -24,7 +24,7 @@ jobs:
           java-version: '8'
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -33,12 +33,13 @@ jobs:
           restore-keys: Accumulo-gaffer-dependencies
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: java
+          queries: security-extended
 
       - name: Build Code
         run: mvn -B -ntp clean install -Pquick -Dskip.jar-with-dependencies=true -Dshaded.jar.phase=true
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '8'

--- a/.github/workflows/continuous-integration-legacy.yaml
+++ b/.github/workflows/continuous-integration-legacy.yaml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '8'

--- a/.github/workflows/continuous-integration-legacy.yaml
+++ b/.github/workflows/continuous-integration-legacy.yaml
@@ -48,7 +48,7 @@ jobs:
           java-version: '8'
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -20,6 +20,24 @@ jobs:
       - name: Check all modules are tested
         run: ./cd/check_modules.sh
 
+  check-copyright:
+    name: Check Copyright Headers
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+
+      - name: Run Spotless copyright check
+        run: mvn -ntp spotless:check -T0.5C
+
   build-javadoc:
     name: Build Javadoc
     runs-on: ubuntu-latest
@@ -118,10 +136,6 @@ jobs:
 
       - name: Test
         run: mvn -B -ntp verify -P coverage -pl ${{matrix.modules.values}}
-
-      - name: Check Copyright Headers
-        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
-        run: mvn -B -ntp spotless:check -pl ${{matrix.modules.values}}
 
       - name: Add JaCoCo reports to artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -33,7 +33,7 @@ jobs:
           java-version: '8'
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository
@@ -105,7 +105,7 @@ jobs:
           java-version: '8'
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -146,7 +146,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           name: gaffer-coverage
           fail_ci_if_error: true # Ensures upload doesn't fail silently

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '8'
@@ -99,7 +99,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '8'

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -124,10 +124,10 @@ jobs:
         run: mvn -B -ntp spotless:check -pl ${{matrix.modules.values}}
 
       - name: Add JaCoCo reports to artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: matrix.os == 'ubuntu-latest'
         with:
-          name: combined-jacoco-coverage
+          name: jacoco-coverage-${{matrix.modules.name}}
           path: "*/**/jacoco.xml"
           retention-days: 5
 
@@ -140,9 +140,10 @@ jobs:
       - uses: actions/checkout@v4 # Codecov need to see the src code to pair with coverage
 
       - name: Fetch JaCoCo reports artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: combined-jacoco-coverage
+          pattern: jacoco-coverage-*
+          merge-multiple: true
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/release-standalone.yaml
+++ b/.github/workflows/release-standalone.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: '8'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Setup JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: '8'
@@ -81,7 +81,7 @@ jobs:
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
     - name: Setup JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: '8'
@@ -147,7 +147,7 @@ jobs:
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
     - name: Setup JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: '11'
@@ -177,7 +177,7 @@ jobs:
 
     steps:
     - name: Setup JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: '8'

--- a/.github/workflows/update-koryphe-version.yaml
+++ b/.github/workflows/update-koryphe-version.yaml
@@ -25,7 +25,7 @@ jobs:
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
     - name: Setup JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: '8'


### PR DESCRIPTION
Includes moving the copyright check to a dedicated job to prevent it interrupting tests.

# Related issue

- Resolve #3150