### PR TITLE
gh-3153 fixing flaky test shouldConstructGraphAndCreateViewWithGroups

### DIFF
--- a/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphTest.java
+++ b/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphTest.java
@@ -115,7 +115,6 @@ import java.util.regex.Pattern;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphTest.java
+++ b/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphTest.java
@@ -922,8 +922,8 @@ public class GraphTest {
 
         // Then
         assertNotSame(schema, resultView);
-        assertArrayEquals(entities.keySet().toArray(), resultView.getEntityGroups().toArray());
-        assertArrayEquals(edges.keySet().toArray(), resultView.getEdgeGroups().toArray());
+        assertThat(entities.keySet()).isEqualTo(resultView.getEntityGroups());
+        assertThat(edges.keySet()).isEqualTo(resultView.getEdgeGroups());
 
         for (final ViewElementDefinition resultElementDef : resultView.getEntities().values()) {
             assertNotNull(resultElementDef);


### PR DESCRIPTION
**What is the purpose of this PR**
- [Linked issue](https://github.com/gchq/Gaffer/issues/3153)
- This PR fixes the flaky test: [uk.gov.gchq.gaffer.graph.GraphTest#shouldConstructGraphAndCreateViewWithGroups](https://github.com/gchq/Gaffer/blob/ac602892435bdd0180f783c80f774149f50eb7f0/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphTest.java#L897)
- The test may fail or pass without changes made to the source code when it is run in different JVMs due to the non-deterministic ordering when sets are converted to arrays.

**Why the test fails**
- The assertions at [L925-L926](https://github.com/gchq/Gaffer/blob/ac602892435bdd0180f783c80f774149f50eb7f0/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphTest.java#L925-L926) in this test compare the keys of `Map` objects with the keySet of Maps in `resultView`.
- However, while invoking the `java.util.Map.keySet()` is necessary for comparison, the second conversion by calling  `java.util.Set.toArray()` returns the elements in a non-deterministic order.

**How to reproduce the test failure**

I used a tool called [nondex](https://github.com/TestingResearchIllinois/NonDex).

```
mvn install -pl core/graph -am -DskipTests
mvn -pl core/graph test -Dtest=uk.gov.gchq.gaffer.graph.GraphTest#shouldConstructGraphAndCreateViewWithGroups
mvn -pl core/graph edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=uk.gov.gchq.gaffer.graph.GraphTest#shouldConstructGraphAndCreateViewWithGroups
```

**Expected results**
- The test should run successfully when run with NonDex.

**Actual results**
We get the following failures:
```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.551 s <<< FAILURE! -- in uk.gov.gchq.gaffer.graph.GraphTest
[ERROR] uk.gov.gchq.gaffer.graph.GraphTest.shouldConstructGraphAndCreateViewWithGroups(Store) -- Time elapsed: 0.537 s <<< FAILURE!
org.opentest4j.AssertionFailedError: array contents differ at index [0], expected: <entity2> but was: <entity3>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertArrayEquals.failArraysNotEqual(AssertArrayEquals.java:440)
	at org.junit.jupiter.api.AssertArrayEquals.assertArrayElementsEqual(AssertArrayEquals.java:389)
	at org.junit.jupiter.api.AssertArrayEquals.assertArrayEquals(AssertArrayEquals.java:346)
	at org.junit.jupiter.api.AssertArrayEquals.assertArrayEquals(AssertArrayEquals.java:159)
	at org.junit.jupiter.api.AssertArrayEquals.assertArrayEquals(AssertArrayEquals.java:155)
	at org.junit.jupiter.api.Assertions.assertArrayEquals(Assertions.java:1453)
	at uk.gov.gchq.gaffer.graph.GraphTest.shouldConstructGraphAndCreateViewWithGroups(GraphTest.java:925)
...
```


**Description of fix**
Comparing the sets directly, without converting them to arrays.