### PR TITLE
gh-3153 fixing flaky test shouldConsumeGraph

### DIFF
--- a/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphSerialisableTest.java
+++ b/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphSerialisableTest.java
@@ -95,7 +95,9 @@ public class GraphSerialisableTest {
         final GraphSerialisable result = new GraphSerialisable.Builder(graph).build();
 
         // When / Then
-        assertThat(result).isEqualTo(expected);
+        assertThat(result.getSerialisedConfig()).isEqualTo(expected.getSerialisedConfig());
+        assertThat(result.getSerialisedSchema()).isEqualTo(expected.getSerialisedSchema());
+        assertThat(result.getStoreProperties()).isEqualTo(expected.getStoreProperties());
     }
 
     @Test

--- a/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphSerialisableTest.java
+++ b/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphSerialisableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What is the purpose of this PR**
- [Linked issue](https://github.com/gchq/Gaffer/issues/3153)
- This PR fixes the flaky test: [uk.gov.gchq.gaffer.graph.GraphSerialisableTest#shouldConsumeGraph](https://github.com/gchq/Gaffer/blob/ac602892435bdd0180f783c80f774149f50eb7f0/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphSerialisableTest.java#L92)
- The test may fail or pass without changes made to the source code when it is run in different JVMs due to the non-deterministic ordering when properties are serialized.

**Why the test fails**
- The assertion at [L98](https://github.com/gchq/Gaffer/blob/ac602892435bdd0180f783c80f774149f50eb7f0/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphSerialisableTest.java#L98) in this test compares two instances of `uk.gov.gchq.gaffer.graph.GraphSerialisable` objects using the overridden `Object.equals()` method.
- However, the elements of `serialisedProperties` are in a non-deterministic order and cause the assertion to fail.

**How to reproduce the test failure**

I used a tool called [nondex](https://github.com/TestingResearchIllinois/NonDex).

```
mvn install -pl core/graph -am -DskipTests
mvn -pl core/graph test -Dtest=uk.gov.gchq.gaffer.graph.GraphSerialisableTest#shouldConsumeGraph 
mvn -pl core/graph edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=uk.gov.gchq.gaffer.graph.GraphSerialisableTest#shouldConsumeGraph
```

**Expected results**
- The test should run successfully when run with NonDex.

**Actual results**
We get the following failures:
```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.586 s <<< FAILURE! -- in uk.gov.gchq.gaffer.graph.GraphSerialisableTest
[ERROR] uk.gov.gchq.gaffer.graph.GraphSerialisableTest.shouldConsumeGraph -- Time elapsed: 0.577 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 

expected: 
  GraphSerialisable[config=GraphConfig[graphId=testGraphId,view=View[{
    "entities" : {
      "e1" : { }
    }
  }],library=uk.gov.gchq.gaffer.store.library.NoGraphLibrary@661d88a,hooks=[uk.gov.gchq.gaffer.graph.hook.NamedViewResolver@4b0b64cc, uk.gov.gchq.gaffer.graph.hook.FunctionAuthoriser@59ce792e]],schema=Schema[{
    "entities" : {
      "e1" : {
        "vertex" : "string"
      }
    },
    "types" : {
      "string" : {
        "class" : "java.lang.String"
      }
    }
  }],properties={gaffer.store.class=uk.gov.gchq.gaffer.integration.store.TestStore, gaffer.store.properties.class=uk.gov.gchq.gaffer.store.StoreProperties}]
 but was: 
  GraphSerialisable[config=GraphConfig[graphId=testGraphId,view=View[{
    "entities" : {
      "e1" : { }
    }
  }],library=uk.gov.gchq.gaffer.store.library.NoGraphLibrary@56399b9e,hooks=[uk.gov.gchq.gaffer.graph.hook.NamedViewResolver@34b9eb03, uk.gov.gchq.gaffer.graph.hook.FunctionAuthoriser@43fda8d9]],schema=Schema[{
    "entities" : {
      "e1" : {
        "vertex" : "string"
      }
    },
    "types" : {
      "string" : {
        "class" : "java.lang.String"
      }
    }
  }],properties={gaffer.store.properties.class=uk.gov.gchq.gaffer.store.StoreProperties, gaffer.store.class=uk.gov.gchq.gaffer.integration.store.TestStore}]
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at uk.gov.gchq.gaffer.graph.GraphSerialisableTest.shouldConsumeGraph(GraphSerialisableTest.java:98)
...
```
We can see that the two jsons differ due to the non-deterministic order of properties, [`StoreProperties`, `TestStore`].

**Description of fix**

The flakiness can be resolved by evaluating the assertion using the overridden equals of [StoreProperties](https://github.com/gchq/Gaffer/blob/ac602892435bdd0180f783c80f774149f50eb7f0/core/store/src/main/java/uk/gov/gchq/gaffer/store/StoreProperties.java#L516-L530) instead of [GraphSerialisable](https://github.com/gchq/Gaffer/blob/ac602892435bdd0180f783c80f774149f50eb7f0/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/GraphSerialisable.java#L117-L131). We continue to compare the config and schema the same way as before.


**Maven logs for before and after the fix:**
[graphSerialisableTestFail.txt](https://github.com/omkrpt/Gaffer/files/14281064/graphSerialisableTestFail.txt)
[graphSerialisableTestSuccess.txt](https://github.com/omkrpt/Gaffer/files/14281065/graphSerialisableTestSuccess.txt)

Logs for flakiness detected in first commit: [graphSerialisableTestFail_516915ea4.txt](https://github.com/omkrpt/Gaffer/files/14314822/graphSerialisableTestFail_516915ea4.txt)
