### PR TITLE
Gh-3159: Datasketches library missing from sketches deploy JAR

### DIFF
--- a/library/sketches-library/pom.xml
+++ b/library/sketches-library/pom.xml
@@ -94,8 +94,8 @@
                             </shadedClassifierName>
                             <artifactSet>
                                 <includes>
-                                    <include>com.clearspring.analytics:stream
-                                    </include>
+                                    <include>com.clearspring.analytics:stream</include>
+                                    <include>org.apache.datasketches:datasketches-java</include>
                                 </includes>
                             </artifactSet>
                             <relocations>

--- a/library/sketches-library/pom.xml
+++ b/library/sketches-library/pom.xml
@@ -95,7 +95,7 @@
                             <artifactSet>
                                 <includes>
                                     <include>com.clearspring.analytics:stream</include>
-                                    <include>org.apache.datasketches:datasketches-java</include>
+                                    <include>org.apache.datasketches:*</include>
                                 </includes>
                             </artifactSet>
                             <relocations>

--- a/library/sketches-library/pom.xml
+++ b/library/sketches-library/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016-2023 Crown Copyright
+  ~ Copyright 2016-2024 Crown Copyright
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Related issue

- Resolve #3159