### PR TITLE
Gh-2994: Make gremlin logging configurable

### DIFF
--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -637,8 +637,8 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 Object input = ((Input) operation).getInput();
                 if (input != null) {
                    if (input instanceof MappedIterable) {
-                        ((MappedIterable) input).forEach(item -> { 
-                            LOGGER.info("GafferPop operation input: {}", item); 
+                        ((MappedIterable) input).forEach(item -> {
+                            LOGGER.info("GafferPop operation input: {}", item);
                         });
                     } else {
                         LOGGER.info("GafferPop operation input: {}", input);

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -633,7 +633,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         for (final Operation operation : opChain.getOperations()) {
             operation.setOptions(opOptions);
 
-            if (LOGGER.isDebugEnabled() && operation instanceof Input) {
+            if (operation instanceof Input) {
                 Object input = ((Input) operation).getInput();
                 if (input != null) {
                    if (input instanceof MappedIterable) {
@@ -648,7 +648,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         }
 
         try {
-            LOGGER.info("GafferPop operation chain called: {}", opChain);
+            LOGGER.info("GafferPop operation chain called: {}", opChain.toOverviewString());
             return graph.execute(opChain, user);
         } catch (final Exception e) {
             LOGGER.error("Operation chain failed: " + e.getMessage(), e);

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -633,15 +633,15 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         for (final Operation operation : opChain.getOperations()) {
             operation.setOptions(opOptions);
 
-            if (operation instanceof Input) {
+            if (LOGGER.isInfoEnabled() && operation instanceof Input) {
                 Object input = ((Input) operation).getInput();
-                if (input != null && LOGGER.isInfoEnabled()) {
+                if (input != null) {
                    if (input instanceof MappedIterable) {
                         ((MappedIterable) input).forEach(item -> { 
-                            LOGGER.info("GafferPop operation input: {}", item.toString()); 
+                            LOGGER.info("GafferPop operation input: {}", item); 
                         });
                     } else {
-                        LOGGER.info("GafferPop operation input: {}", input.toString());
+                        LOGGER.info("GafferPop operation input: {}", input);
                     }
                 }
             }

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -635,19 +635,20 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
             if (operation instanceof Input) {
                 Object input = ((Input) operation).getInput();
-                if (input != null) {
-                    if (input instanceof MappedIterable) {
-                        ((MappedIterable) input).forEach(item -> { LOGGER.info("GafferPop operation input: " + item.toString()); });
+                if (input != null && LOGGER.isInfoEnabled()) {
+                   if (input instanceof MappedIterable) {
+                        ((MappedIterable) input).forEach(item -> { 
+                            LOGGER.info("GafferPop operation input: {}", item.toString()); 
+                        });
                     } else {
-                        LOGGER.info("GafferPop operation input: " + input.toString());
+                        LOGGER.info("GafferPop operation input: {}", input.toString());
                     }
                 }
             }
-
         }
 
         try {
-            LOGGER.info("GafferPop operation chain called: " + opChain.toString());
+            LOGGER.info("GafferPop operation chain called: {}", opChain);
             return graph.execute(opChain, user);
         } catch (final Exception e) {
             LOGGER.error("Operation chain failed: " + e.getMessage(), e);

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -633,7 +633,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         for (final Operation operation : opChain.getOperations()) {
             operation.setOptions(opOptions);
 
-            if (operation instanceof Input) {
+            if (LOGGER.isDebugEnabled() && operation instanceof Input) {
                 Object input = ((Input) operation).getInput();
                 if (input instanceof MappedIterable) {
                     ((MappedIterable) input).forEach(item -> {

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -633,15 +633,15 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         for (final Operation operation : opChain.getOperations()) {
             operation.setOptions(opOptions);
 
-            if (LOGGER.isInfoEnabled() && operation instanceof Input) {
+            if (LOGGER.isDebugEnabled() && operation instanceof Input) {
                 Object input = ((Input) operation).getInput();
                 if (input != null) {
                    if (input instanceof MappedIterable) {
                         ((MappedIterable) input).forEach(item -> {
-                            LOGGER.info("GafferPop operation input: {}", item);
+                            LOGGER.debug("GafferPop operation input: {}", item);
                         });
                     } else {
-                        LOGGER.info("GafferPop operation input: {}", input);
+                        LOGGER.debug("GafferPop operation input: {}", input);
                     }
                 }
             }

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -635,14 +635,12 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
             if (operation instanceof Input) {
                 Object input = ((Input) operation).getInput();
-                if (input != null) {
-                   if (input instanceof MappedIterable) {
-                        ((MappedIterable) input).forEach(item -> {
-                            LOGGER.debug("GafferPop operation input: {}", item);
-                        });
-                    } else {
-                        LOGGER.debug("GafferPop operation input: {}", input);
-                    }
+                if (input instanceof MappedIterable) {
+                    ((MappedIterable) input).forEach(item -> {
+                        LOGGER.debug("GafferPop operation input: {}", item);
+                    });
+                } else {
+                    LOGGER.debug("GafferPop operation input: {}", input);
                 }
             }
         }


### PR DESCRIPTION
Costly logging should only display now if the SLF4J log level is enabled. 

# Related issue

- Resolve #2994