### PR TITLE
Gh-3187: Add Open Telemetry proof of concept

### DIFF
--- a/core/common-util/pom.xml
+++ b/core/common-util/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016-2023 Crown Copyright
+  ~ Copyright 2016-2024 Crown Copyright
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -47,6 +47,27 @@
             <groupId>uk.gov.gchq.koryphe</groupId>
             <artifactId>core</artifactId>
             <classifier>jdk8</classifier>
+        </dependency>
+        <!-- Opentelementry libraries -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure-spi</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/core/common-util/src/main/java/uk/gov/gchq/gaffer/commonutil/otel/OtelUtil.java
+++ b/core/common-util/src/main/java/uk/gov/gchq/gaffer/commonutil/otel/OtelUtil.java
@@ -50,7 +50,7 @@ public final class OtelUtil {
     /**
      * Get if OpenTelemetry is in use.
      *
-     * @param active Is active
+     * @return Is active
      */
     public static boolean getOpenTelemetryActive() {
         return openTelemetryActive;

--- a/core/common-util/src/main/java/uk/gov/gchq/gaffer/commonutil/otel/OtelUtil.java
+++ b/core/common-util/src/main/java/uk/gov/gchq/gaffer/commonutil/otel/OtelUtil.java
@@ -31,7 +31,7 @@ public final class OtelUtil {
      * Creates a new span with the given tracer and span names, note will
      * return an 'invalid' span if OpenTelementry is turned off.
      *
-     * @param tracerName Name of the {@link Tracer} to use
+     * @param tracerName Name of the Tracer to use
      * @param spanName Name of the {@link Span} to use.
      * @return new {@link Span}
      */

--- a/core/common-util/src/main/java/uk/gov/gchq/gaffer/commonutil/otel/OtelUtil.java
+++ b/core/common-util/src/main/java/uk/gov/gchq/gaffer/commonutil/otel/OtelUtil.java
@@ -18,9 +18,8 @@ package uk.gov.gchq.gaffer.commonutil.otel;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.Tracer;
 
-public class OtelUtil {
+public final class OtelUtil {
 
     private static boolean openTelemetryActive = false;
 
@@ -31,11 +30,12 @@ public class OtelUtil {
     /**
      * Creates a new span with the given tracer and span names, note will
      * return an 'invalid' span if OpenTelementry is turned off.
+     *
      * @param tracerName Name of the {@link Tracer} to use
      * @param spanName Name of the {@link Span} to use.
      * @return new {@link Span}
      */
-    public static Span startSpan(String tracerName, String spanName) {
+    public static Span startSpan(final String tracerName, final String spanName) {
         // If not using opentelementry use dummy spans
         if (!openTelemetryActive) {
             return Span.getInvalid();
@@ -48,11 +48,11 @@ public class OtelUtil {
     }
 
     /**
-     * Set if OpentTelemetry is in use.
+     * Set if OpenTelemetry is in use.
      *
      * @param active Is active
      */
-    public static void setOpenTelemetryActive(boolean active) {
+    public static void setOpenTelemetryActive(final boolean active) {
         openTelemetryActive = active;
     }
 }

--- a/core/common-util/src/main/java/uk/gov/gchq/gaffer/commonutil/otel/OtelUtil.java
+++ b/core/common-util/src/main/java/uk/gov/gchq/gaffer/commonutil/otel/OtelUtil.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.commonutil.otel;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+
+public class OtelUtil {
+
+    private static boolean openTelemetryActive = false;
+
+    private OtelUtil() {
+        // Utility class
+    }
+
+    /**
+     * Creates a new span with the given tracer and span names, note will
+     * return an 'invalid' span if OpenTelementry is turned off.
+     * @param tracerName Name of the {@link Tracer} to use
+     * @param spanName Name of the {@link Span} to use.
+     * @return new {@link Span}
+     */
+    public static Span startSpan(String tracerName, String spanName) {
+        // If not using opentelementry use dummy spans
+        if (!openTelemetryActive) {
+            return Span.getInvalid();
+        }
+        // Create span and set attributes
+        return GlobalOpenTelemetry
+            .getTracer(tracerName)
+            .spanBuilder(spanName)
+            .startSpan();
+    }
+
+    /**
+     * Set if OpentTelemetry is in use.
+     *
+     * @param active Is active
+     */
+    public static void setOpenTelemetryActive(boolean active) {
+        openTelemetryActive = active;
+    }
+}

--- a/core/common-util/src/main/java/uk/gov/gchq/gaffer/commonutil/otel/OtelUtil.java
+++ b/core/common-util/src/main/java/uk/gov/gchq/gaffer/commonutil/otel/OtelUtil.java
@@ -48,6 +48,15 @@ public final class OtelUtil {
     }
 
     /**
+     * Get if OpenTelemetry is in use.
+     *
+     * @param active Is active
+     */
+    public static boolean getOpenTelemetryActive() {
+        return openTelemetryActive;
+    }
+
+    /**
      * Set if OpenTelemetry is in use.
      *
      * @param active Is active

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/Graph.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/Graph.java
@@ -326,6 +326,7 @@ public final class Graph {
         span.setAttribute("gaffer.user", clonedContext.getUser().getUserId());
 
         O result = null;
+        // Sets the span to current so parent child spans are auto linked
         try (Scope scope = span.makeCurrent()) {
             updateOperationChainView(clonedOpChain);
             for (final GraphHook graphHook : config.getHooks()) {

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/GraphConfig.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/GraphConfig.java
@@ -146,7 +146,7 @@ public final class GraphConfig {
      * Set OpenTelemetry logging to be active
      * @param otelActive is active
      */
-    public void setOtelActive(Boolean otelActive) {
+    public void setOtelActive(final Boolean otelActive) {
         this.otelActive = otelActive;
     }
 

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/GraphConfig.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/GraphConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ import java.util.List;
  *
  * @see uk.gov.gchq.gaffer.graph.GraphConfig.Builder
  */
-@JsonPropertyOrder(value = {"description", "graphId"}, alphabetic = true)
+@JsonPropertyOrder(value = {"description", "graphId", "otelActive"}, alphabetic = true)
 public final class GraphConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(GraphConfig.class);
 
@@ -75,6 +75,7 @@ public final class GraphConfig {
     private GraphLibrary library;
     private String description;
     private final List<GraphHook> hooks = new ArrayList<>();
+    private Boolean otelActive;
 
     public GraphConfig() {
     }
@@ -131,6 +132,22 @@ public final class GraphConfig {
         } else {
             hooks.forEach(this::addHook);
         }
+    }
+
+    /**
+     * Is OpenTelemtery logging set to be active
+     * @return True if active
+     */
+    public Boolean getOtelActive() {
+        return otelActive;
+    }
+
+    /**
+     * Set OpenTelemetry logging to be active
+     * @param otelActive is active
+     */
+    public void setOtelActive(Boolean otelActive) {
+        this.otelActive = otelActive;
     }
 
     /**
@@ -277,6 +294,7 @@ public final class GraphConfig {
                 .append("view", getView())
                 .append("library", library)
                 .append("hooks", hooks)
+                .append("otelActive", otelActive)
                 .toString();
     }
 
@@ -340,6 +358,9 @@ public final class GraphConfig {
             if (config.getDescription() != null) {
                 this.config.setDescription(config.getDescription());
             }
+            if (config.getOtelActive() != null) {
+                this.config.setOtelActive(config.getOtelActive());
+            }
             this.config.getHooks().addAll(config.getHooks());
 
             return this;
@@ -357,6 +378,11 @@ public final class GraphConfig {
 
         public Builder description(final String description) {
             this.config.setDescription(description);
+            return this;
+        }
+
+        public Builder otelActive(final Boolean active) {
+            this.config.setOtelActive(active);
             return this;
         }
 

--- a/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphConfigTest.java
+++ b/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,7 @@ public class GraphConfigTest extends JSONSerialisationTest<GraphConfig> {
         assertEquals(obj.getView(), deserialisedObj.getView());
         assertEquals(obj.getLibrary().getClass(), deserialisedObj.getLibrary().getClass());
         assertEquals(obj.getDescription(), deserialisedObj.getDescription());
+        assertEquals(obj.getOtelActive(), deserialisedObj.getOtelActive());
         assertEquals((List) obj.getHooks().stream().map(GraphHook::getClass).collect(Collectors.toList()), (List) deserialisedObj.getHooks().stream().map(GraphHook::getClass).collect(Collectors.toList()));
     }
 
@@ -142,6 +143,7 @@ public class GraphConfigTest extends JSONSerialisationTest<GraphConfig> {
                 .graphId(graphId)
                 .library(library)
                 .description("testGraphConfig")
+                .otelActive(true)
                 .addHook(hook1)
                 .addHook(hook2)
                 .view(view)

--- a/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphTest.java
+++ b/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphTest.java
@@ -36,6 +36,7 @@ import uk.gov.gchq.gaffer.commonutil.JsonAssert;
 import uk.gov.gchq.gaffer.commonutil.StreamUtil;
 import uk.gov.gchq.gaffer.commonutil.TestGroups;
 import uk.gov.gchq.gaffer.commonutil.TestPropertyNames;
+import uk.gov.gchq.gaffer.commonutil.otel.OtelUtil;
 import uk.gov.gchq.gaffer.commonutil.pair.Pair;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.function.ElementFilter;
@@ -1512,25 +1513,25 @@ public class GraphTest {
 
         // When
         final Graph graph = new Graph.Builder()
-                .config(StreamUtil.graphConfig(getClass()))
-                .storeProperties(storeProperties)
-                .addSchemas(StreamUtil.schemas(getClass()))
-                .build();
+            .config(StreamUtil.graphConfig(getClass()))
+            .storeProperties(storeProperties)
+            .addSchemas(StreamUtil.schemas(getClass()))
+            .build();
 
         // Then
-        assertEquals("graphId1", graph.getGraphId());
-        assertEquals(new View.Builder()
-                .globalElements(new GlobalViewElementDefinition.Builder()
-                        .groupBy()
-                        .build())
-                .build(), graph.getView());
-        assertEquals(HashMapGraphLibrary.class, graph.getGraphLibrary().getClass());
-        assertThat(graph.getGraphHooks())
-            .containsExactlyInAnyOrder(
-                NamedViewResolver.class,
-                OperationChainLimiter.class,
-                AddOperationsToChain.class,
-                FunctionAuthoriser.class);
+        assertThat(graph.getGraphId()).isEqualTo("graphId1");
+        assertThat(OtelUtil.getOpenTelemetryActive()).isTrue();
+        assertThat(graph.getView()).isEqualTo(new View.Builder()
+            .globalElements(new GlobalViewElementDefinition.Builder()
+                .groupBy()
+                .build())
+            .build());
+        assertThat(graph.getGraphLibrary().getClass()).isEqualTo(HashMapGraphLibrary.class);
+        assertThat(graph.getGraphHooks()).containsExactlyInAnyOrder(
+            NamedViewResolver.class,
+            OperationChainLimiter.class,
+            AddOperationsToChain.class,
+            FunctionAuthoriser.class);
     }
 
     @Test

--- a/core/graph/src/test/resources/graphConfig.json
+++ b/core/graph/src/test/resources/graphConfig.json
@@ -1,5 +1,6 @@
 {
   "graphId": "graphId1",
+  "otelActive": true,
   "library": {
     "class": "uk.gov.gchq.gaffer.store.library.HashMapGraphLibrary"
   },

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/Store.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/Store.java
@@ -17,6 +17,11 @@
 package uk.gov.gchq.gaffer.store;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Scope;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -969,17 +974,34 @@ public abstract class Store {
     }
 
     public Object handleOperation(final Operation operation, final Context context) throws OperationException {
+        Span span = GlobalOpenTelemetry.getTracer("Store handle operation")
+            .spanBuilder(operation.getClass()
+            .getName())
+            .setParent((io.opentelemetry.context.Context) context.getVariable("GRAPHSPAN"))
+            .startSpan();
+        span.isRecording();
+        // Only create spans for actual operations not chains as the parent chain is in the Graph class
+        if (operation instanceof OperationChain) {
+            span = Span.getInvalid();
+        }
+        //span.setAttribute("gaffer.user", context.getUser().getUserId());
+
         final OperationHandler<Operation> handler = getOperationHandler(operation.getClass());
         Object result;
-        try {
+        try (Scope scope = span.makeCurrent()) {
             if (nonNull(handler)) {
                 result = handler.doOperation(operation, context, this);
             } else {
                 result = doUnhandledOperation(operation, context);
             }
+            span.addEvent("Finished Operation");
         } catch (final Exception e) {
             CloseableUtil.close(operation);
+            span.setStatus(StatusCode.ERROR, e.getMessage());
+            span.recordException(e);
             throw e;
+        } finally {
+            span.end();
         }
 
         if (isNull(result)) {

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
@@ -52,6 +52,7 @@ public class OperationChainHandler<OUT> implements OutputOperationHandler<Operat
             // OpenTelemetry hooks
             Span span = OtelUtil.startSpan(this.getClass().getName(), op.getClass().getName());
             span.setAttribute("jobId", context.getJobId());
+            // Sets the span to current so parent child spans are auto linked
             try (Scope scope = span.makeCurrent()) {
                 updateOperationInput(op, result);
                 result = store.handleOperation(op, context);

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
@@ -16,6 +16,9 @@
 
 package uk.gov.gchq.gaffer.store.operation.handler;
 
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
+
 import uk.gov.gchq.gaffer.commonutil.otel.OtelUtil;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.OperationChain;
@@ -25,9 +28,6 @@ import uk.gov.gchq.gaffer.store.Store;
 import uk.gov.gchq.gaffer.store.operation.OperationChainValidator;
 import uk.gov.gchq.gaffer.store.optimiser.OperationChainOptimiser;
 import uk.gov.gchq.koryphe.ValidationResult;
-
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.context.Scope;
 
 import java.util.List;
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
         <swagger.version>1.6.6</swagger.version>
         <zookeeper.version>3.4.14</zookeeper.version>
         <mockserver.version>5.15.0</mockserver.version>
+        <opentelemetry.version>1.36.0</opentelemetry.version>
 
         <!-- Maven plugins -->
         <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
@@ -773,6 +774,13 @@
                 <artifactId>jersey-core</artifactId>
                 <version>${jersey.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -792,6 +800,27 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-reload4j</artifactId>
             <version>${slf4j.api.version}</version>
+        </dependency>
+        <!-- Opentelementry libraries -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure-spi</artifactId>
         </dependency>
 
         <!-- Testing Dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -801,27 +801,6 @@
             <artifactId>slf4j-reload4j</artifactId>
             <version>${slf4j.api.version}</version>
         </dependency>
-        <!-- Opentelementry libraries -->
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-logging</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-otlp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk-extension-autoconfigure-spi</artifactId>
-        </dependency>
 
         <!-- Testing Dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016-2023 Crown Copyright
+  ~ Copyright 2016-2024 Crown Copyright
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.


### PR DESCRIPTION
Adds a basic implementation of Open Telemetry that will record Spans across executions of Operations/OperationChains. Can be toggled on via a `otelActive` option in the `graphConfig.json` (off by default).  Hopefully is a useful start point to be expanded on if required.

Is difficult one to demonstrate via unit testing but been manually tested to ensure Spans look useful with relevant data via a `Jaeger` UI. Uses the auto configure feature of Open Telemetry so can be easily configured where and how to export data to via environment variables e.g.
- `OTEL_SERVICE_NAME=gaffer-rest` - sets the service name to `gaffer-rest`
- `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://jaeger:4317` - sets the endpoint to export traces to e.g. `Jaeger`
- `OTEL_TRACES_EXPORTER=console` - sets the exporter to console rather than the default of OTEL (needs to be OTEL to work with Jaeger).

# Related issue

- Resolve #3187