### PR TITLE
Gh-3178: Javadoc release file copy problem

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -165,7 +165,7 @@ jobs:
         rm -rf uk
         rm -rf jquery
         rm -rf resources
-        mv target/site/apidocs/* .
+        cp -rlf target/site/apidocs/* .
         git add .
         git commit -a -m "Updated javadoc - $RELEASE_VERSION"
         git push


### PR DESCRIPTION
This prevents the situation where mv cannot move if directory not empty

# Related issue

- Resolve #3178