### PR TITLE
Gh-3198: Fix m2e dependency-plugin unpack error

### DIFF
--- a/example/basic/basic-rest/pom.xml
+++ b/example/basic/basic-rest/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2017-2023 Crown Copyright
+  ~ Copyright 2017-2024 Crown Copyright
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/example/basic/basic-rest/pom.xml
+++ b/example/basic/basic-rest/pom.xml
@@ -71,7 +71,7 @@
                 <executions>
                     <execution>
                         <id>unpack</id>
-                        <phase>compile</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>

--- a/example/basic/basic-rest/pom.xml
+++ b/example/basic/basic-rest/pom.xml
@@ -70,6 +70,7 @@
                 </dependencies>
                 <executions>
                     <execution>
+                        <?m2e ignore?>
                         <id>unpack</id>
                         <phase>prepare-package</phase>
                         <goals>

--- a/example/federated-demo/pom.xml
+++ b/example/federated-demo/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2017-2023 Crown Copyright
+  ~ Copyright 2017-2024 Crown Copyright
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/example/federated-demo/pom.xml
+++ b/example/federated-demo/pom.xml
@@ -91,7 +91,7 @@
                 <executions>
                     <execution>
                         <id>unpack</id>
-                        <phase>compile</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>

--- a/example/federated-demo/pom.xml
+++ b/example/federated-demo/pom.xml
@@ -90,6 +90,7 @@
                 </dependencies>
                 <executions>
                     <execution>
+                        <?m2e ignore?>
                         <id>unpack</id>
                         <phase>prepare-package</phase>
                         <goals>

--- a/example/road-traffic/road-traffic-rest/pom.xml
+++ b/example/road-traffic/road-traffic-rest/pom.xml
@@ -150,6 +150,7 @@
                 </dependencies>
                 <executions>
                     <execution>
+                    <?m2e ignore?>
                         <id>unpack</id>
                         <phase>prepare-package</phase>
                         <goals>

--- a/example/road-traffic/road-traffic-rest/pom.xml
+++ b/example/road-traffic/road-traffic-rest/pom.xml
@@ -150,7 +150,7 @@
                 </dependencies>
                 <executions>
                     <execution>
-                    <?m2e ignore?>
+                        <?m2e ignore?>
                         <id>unpack</id>
                         <phase>prepare-package</phase>
                         <goals>

--- a/example/road-traffic/road-traffic-rest/pom.xml
+++ b/example/road-traffic/road-traffic-rest/pom.xml
@@ -151,7 +151,7 @@
                 <executions>
                     <execution>
                         <id>unpack</id>
-                        <phase>compile</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>

--- a/example/road-traffic/road-traffic-rest/pom.xml
+++ b/example/road-traffic/road-traffic-rest/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016-2023 Crown Copyright
+  ~ Copyright 2016-2024 Crown Copyright
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <!-- Maven plugins -->
         <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
         <compiler.plugin.verson>3.9.0</compiler.plugin.verson>
-        <dependency.plugin.version>3.5.0</dependency.plugin.version>
+        <dependency.plugin.version>3.6.1</dependency.plugin.version>
         <depgraph.plugin.version>4.0.2</depgraph.plugin.version>
         <spotbugs.plugin.version>4.7.3.4</spotbugs.plugin.version>
         <pmd.plugin.version>3.20.0</pmd.plugin.version>

--- a/rest-api/accumulo-rest/pom.xml
+++ b/rest-api/accumulo-rest/pom.xml
@@ -105,6 +105,7 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
+                        <?m2e ignore?>
                         <id>unpack</id>
                         <phase>prepare-package</phase>
                         <goals>

--- a/rest-api/accumulo-rest/pom.xml
+++ b/rest-api/accumulo-rest/pom.xml
@@ -106,7 +106,7 @@
                 <executions>
                     <execution>
                         <id>unpack</id>
-                        <phase>compile</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>

--- a/rest-api/accumulo-rest/pom.xml
+++ b/rest-api/accumulo-rest/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016-2023 Crown Copyright
+  ~ Copyright 2016-2024 Crown Copyright
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/rest-api/map-rest/pom.xml
+++ b/rest-api/map-rest/pom.xml
@@ -65,7 +65,7 @@
                 <executions>
                     <execution>
                         <id>unpack</id>
-                        <phase>compile</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>

--- a/rest-api/map-rest/pom.xml
+++ b/rest-api/map-rest/pom.xml
@@ -64,6 +64,7 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
+                        <?m2e ignore?>
                         <id>unpack</id>
                         <phase>prepare-package</phase>
                         <goals>

--- a/rest-api/map-rest/pom.xml
+++ b/rest-api/map-rest/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016-2023 Crown Copyright
+  ~ Copyright 2016-2024 Crown Copyright
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes both causes of the error message described in the issue.

# Related issue

- Resolve #3198