### PR TITLE
Gh-3200: Additional Federated Stores Tinkerpop tests

### DIFF
--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -865,7 +865,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 seeds.add(new EntitySeed(((Vertex) id).id()));
             // Extract Edge ID
             } else if (id instanceof Edge) {
-                seeds.add(new EdgeSeed(((Edge) id).outVertex().id(), ((Edge) id).inVertex().id(), true));
+                seeds.add(new EdgeSeed(((Edge) id).outVertex().id(), ((Edge) id).inVertex().id()));
             // Extract source and destination from ID list
             } else if (id instanceof Iterable) {
                 ((Iterable<?>) id).forEach(edgeIdList::add);
@@ -883,7 +883,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
             // If found a list verify source and destination
             if (edgeIdList.size() == 2) {
-                seeds.add(new EdgeSeed(edgeIdList.get(0), edgeIdList.get(1), true));
+                seeds.add(new EdgeSeed(edgeIdList.get(0), edgeIdList.get(1)));
             }
         });
 

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
@@ -22,7 +22,6 @@ import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
@@ -136,7 +135,6 @@ public class GafferPopFederatedIT {
     }
 
     @Test
-    @Disabled("Filtering by edge label does not work currently")
     void shouldFilterVertexesByPropertyValue() {
         // Given
         GraphTraversalSource g = gafferPopGraph.traversal();
@@ -298,7 +296,6 @@ public class GafferPopFederatedIT {
     }
 
     @Test
-    @Disabled("Filtering by edge label does not work currently")
     void shouldReturnFilteredVerticesFromSpecificGraph() {
         // Given
         GraphTraversalSource g = gafferPopGraph.traversal();

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
@@ -246,11 +246,11 @@ public class GafferPopFederatedIT {
         // Then
         assertThat(result)
                 .extracting(item -> item.id().toString())
-                .containsExactly("[p1, p2]", "[p1, s1]");
+                .containsExactlyInAnyOrder("[p1, p2]", "[p1, s1]");
 
         assertThat(result)
                 .extracting(item -> item.label())
-                .containsExactly("knows", CREATED_EDGE_GROUP);
+                .containsExactlyInAnyOrder("knows", CREATED_EDGE_GROUP);
     }
 
     @Test
@@ -372,19 +372,19 @@ public class GafferPopFederatedIT {
     void shouldGetIncomingEdgesFromSpecificGraph() {
         // Given
         GraphTraversalSource g = gafferPopGraph.traversal();
-        final List<String> graphOptions = Arrays.asList("gaffer.federatedstore.operation.graphIds:graphB");
+        final List<String> graphOptions = Arrays.asList("gaffer.federatedstore.operation.graphIds:graphA");
 
         // When
-        List<Edge> result = g.with(GafferPopGraphVariables.OP_OPTIONS, graphOptions).V("p4").outE()
+        List<Edge> result = g.with(GafferPopGraphVariables.OP_OPTIONS, graphOptions).V(VERTEX_PERSON_1).outE()
                 .toList();
 
         // Then
         assertThat(result)
                 .extracting(item -> item.id().toString())
-                .containsExactly("[p4, s2]");
+                .containsExactlyInAnyOrder("[p1, p2]", "[p1, s1]");
 
         assertThat(result)
                 .extracting(item -> item.label())
-                .containsExactly(CREATED_EDGE_GROUP);
+                .containsExactlyInAnyOrder(CREATED_EDGE_GROUP, "knows");
     }
 }

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
@@ -22,6 +22,7 @@ import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
@@ -135,6 +136,7 @@ public class GafferPopFederatedIT {
     }
 
     @Test
+    @Disabled("Filtering by edge label does not work currently")
     void shouldFilterVertexesByPropertyValue() {
         // Given
         GraphTraversalSource g = gafferPopGraph.traversal();
@@ -146,7 +148,7 @@ public class GafferPopFederatedIT {
 
         // Then
         assertThat(result)
-                .containsExactly(1.0, 0.8);
+                .containsExactly(0.8);
     }
 
     @Test
@@ -296,6 +298,7 @@ public class GafferPopFederatedIT {
     }
 
     @Test
+    @Disabled("Filtering by edge label does not work currently")
     void shouldReturnFilteredVerticesFromSpecificGraph() {
         // Given
         GraphTraversalSource g = gafferPopGraph.traversal();
@@ -303,13 +306,13 @@ public class GafferPopFederatedIT {
 
         // When
         List<Object> result = g.with(GafferPopGraphVariables.OP_OPTIONS, graphOptions).V()
-                .outE(CREATED_EDGE_GROUP).has(WEIGHT_PROPERTY, P.gt(0.4))
+                .outE(CREATED_EDGE_GROUP).has(WEIGHT_PROPERTY, P.gt(0.2))
                 .values(WEIGHT_PROPERTY)
                 .toList();
 
         // Then
         assertThat(result)
-                .containsExactly(1.0);
+                .containsExactly(0.4);
     }
 
     @Test

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
@@ -369,19 +369,19 @@ public class GafferPopFederatedIT {
     void shouldGetIncomingEdgesFromSpecificGraph() {
         // Given
         GraphTraversalSource g = gafferPopGraph.traversal();
-        final List<String> graphOptions = Arrays.asList("gaffer.federatedstore.operation.graphIds:graphA");
+        final List<String> graphOptions = Arrays.asList("gaffer.federatedstore.operation.graphIds:graphB");
 
         // When
-        List<Edge> result = g.with(GafferPopGraphVariables.OP_OPTIONS, graphOptions).V(VERTEX_PERSON_1).outE()
+        List<Edge> result = g.with(GafferPopGraphVariables.OP_OPTIONS, graphOptions).V("p4").outE()
                 .toList();
 
         // Then
         assertThat(result)
                 .extracting(item -> item.id().toString())
-                .containsExactly("[p1, p2]", "[p1, s1]");
+                .containsExactly("[p4, s2]");
 
         assertThat(result)
                 .extracting(item -> item.label())
-                .containsExactly("knows", CREATED_EDGE_GROUP);
+                .containsExactly(CREATED_EDGE_GROUP);
     }
 }


### PR DESCRIPTION
Added a few more tests of a federated store with a GafferPopGraph. These test whether the .with() config options allow users to specify the graph they wish to target for results using Gremlin. 

Also an additional fix in GafferPopGraph which prevented Gremlin queries seeding with edge IDs in cases where edges were not directed. 

Note: docs will need to be added that explain to users how to use the .with() to query federated graphs. 

# Related issue

- Resolve #3200