### PR TITLE
Gh-3210: Fix GafferPopVertex.properties() output

### DIFF
--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertex.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertex.java
@@ -80,7 +80,7 @@ public class GafferPopVertex extends GafferPopElement implements Vertex {
 
     @Override
     public <V> Iterator<VertexProperty<V>> properties(final String... propertyKeys) {
-        return null == properties ?
+        return properties == null ?
                 Collections.emptyIterator() :
                 (Iterator) properties.entrySet()
                         .stream()

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertex.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertex.java
@@ -23,7 +23,6 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
-import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * A <code>GafferPopEdge</code> is an {@link GafferPopElement} and {@link Vertex}.
@@ -82,26 +80,13 @@ public class GafferPopVertex extends GafferPopElement implements Vertex {
 
     @Override
     public <V> Iterator<VertexProperty<V>> properties(final String... propertyKeys) {
-        if (properties == null) {
-            return Collections.emptyIterator();
-        }
-        if (propertyKeys.length == 1) {
-            final List<VertexProperty> props = properties.getOrDefault(propertyKeys[0], Collections.emptyList());
-            if (props.size() == 1) {
-                return IteratorUtils.of(props.get(0));
-            } else if (props.isEmpty()) {
-                return Collections.emptyIterator();
-            } else {
-                return (Iterator) new ArrayList<>(props).iterator();
-            }
-        } else {
-            return (Iterator) properties.entrySet()
-                    .stream()
-                    .filter(entry -> ElementHelper.keyExists(entry.getKey(), propertyKeys))
-                    .flatMap(entry -> entry.getValue().stream())
-                    .collect(Collectors.toList())
-                    .iterator();
-        }
+        return null == properties ?
+                Collections.emptyIterator() :
+                (Iterator) properties.entrySet()
+                        .stream()
+                        .filter(entry -> ElementHelper.keyExists(entry.getKey(), propertyKeys))
+                        .flatMap(entry -> entry.getValue().stream())
+                        .iterator();
     }
 
     /**

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertexProperty.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertexProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Crown Copyright
+ * Copyright 2016-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertexProperty.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertexProperty.java
@@ -35,7 +35,7 @@ public class GafferPopVertexProperty<V> extends GafferPopElement implements Vert
     private final V value;
 
     public GafferPopVertexProperty(final GafferPopVertex vertex, final String key, final V value, final Object... propertyKeyValues) {
-        super(vertex.label(), vertex.id(), vertex.graph());
+        super(key, String.format("[%s,%s,%s]", vertex.id(), key, value), vertex.graph());
         this.vertex = vertex;
         this.key = key;
         this.value = value;

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertexTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertexTest.java
@@ -165,6 +165,7 @@ class GafferPopVertexTest {
         given(features.vertex()).willReturn(vertexFeatures);
         given(vertexFeatures.properties()).willReturn(vertexPropertyFeatures);
         final String propValue = "propValue";
+        final int intPropValue = 1;
         final String nestedKey = "nestedKey";
         final String nestedValue = "nestedValue";
         // Make new vertex with the mocked bits
@@ -172,6 +173,8 @@ class GafferPopVertexTest {
         // Make some values to compare against
         final GafferPopVertexProperty<Object> equalProp = new GafferPopVertexProperty<>(vertex, TestPropertyNames.STRING, propValue);
         final String notAProp = "notAProp";
+        final GafferPopVertexProperty<Object> notEqualProp = new GafferPopVertexProperty<>(vertex, TestPropertyNames.INT, intPropValue);
+
 
         // When
         // Set and get the property
@@ -185,7 +188,9 @@ class GafferPopVertexTest {
                 .isEqualTo(equalProp)
                 .hasSameHashCodeAs(equalProp)
                 .isNotEqualTo(notAProp)
-                .doesNotHaveSameHashCodeAs(notAProp);
+                .doesNotHaveSameHashCodeAs(notAProp)
+                .isNotEqualTo(notEqualProp)
+                .doesNotHaveSameHashCodeAs(notEqualProp);
         assertThat(prop.element()).isEqualTo(vertex);
         assertThat(prop.isPresent()).isTrue();
         assertThat(prop.keys()).isEmpty();


### PR DESCRIPTION
Set a proper ID for GafferPopVertexProperties so that equals and hashCode work as expected
simplify GafferPopVertex.properties() method
add unit test to catch error

# Related issue

- Resolve #3210