### PR TITLE
Gh-3209: GetAll Limit fails on Proxy Store

### DIFF
--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/OperationChain.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/OperationChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Crown Copyright
+ * Copyright 2016-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/OperationChain.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/OperationChain.java
@@ -66,7 +66,7 @@ import java.util.stream.Collectors;
 public class OperationChain<OUT> implements Output<OUT>,
         Operations<Operation> {
     private List<Operation> operations;
-    private Map<String, String> options;
+    private Map<String, String> options = new HashMap<>();
 
     public OperationChain() {
         this(new ArrayList<>());
@@ -186,7 +186,7 @@ public class OperationChain<OUT> implements Output<OUT>,
     public void setOptions(final Map<String, String> options) {
         if (options == null) {
             this.options = new HashMap<>();
-        } else{
+        } else {
             this.options = options;
         }
     }

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/OperationChain.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/OperationChain.java
@@ -184,7 +184,11 @@ public class OperationChain<OUT> implements Output<OUT>,
 
     @Override
     public void setOptions(final Map<String, String> options) {
-        this.options = options;
+        if (options == null) {
+            this.options = new HashMap<>();
+        } else{
+            this.options = options;
+        }
     }
 
     @Override

--- a/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/ValidateOperationChainTest.java
+++ b/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/ValidateOperationChainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Crown Copyright
+ * Copyright 2018-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/ValidateOperationChainTest.java
+++ b/core/operation/src/test/java/uk/gov/gchq/gaffer/operation/impl/ValidateOperationChainTest.java
@@ -29,6 +29,7 @@ import uk.gov.gchq.koryphe.ValidationResult;
 
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
@@ -51,7 +52,7 @@ public class ValidateOperationChainTest extends OperationTest<ValidateOperationC
         final ValidateOperationChain deserialisedOp = JSONSerialiser.deserialise(json, ValidateOperationChain.class);
 
         // Then
-        assertEquals(validateOperationChain.getOperationChain(), deserialisedOp.getOperationChain());
+        assertThat(deserialisedOp.getOperationChain()).isEqualTo(validateOperationChain.getOperationChain());
     }
 
     @Test

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -383,6 +383,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         final OperationChain<Iterable<? extends Element>> getOperation;
 
         if (getAll) {
+            LOGGER.debug("Requested a GetAllElements, results will be truncated to: {}.", getAllElementsLimit);
             getOperation = new Builder()
                     .first(new GetAllElements.Builder()
                             .view(new View.Builder()
@@ -412,9 +413,9 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 .map(e -> (Vertex) e)
                 .iterator();
 
-        if (getAll && IterableUtils.size(translatedResults) > getAllElementsLimit) {
+        if (getAll && IterableUtils.size(translatedResults) == getAllElementsLimit) {
             LOGGER.warn(
-                "Result size is larger than configured limit ({}). Results may have been truncated",
+                "Result size is equal to configured limit ({}). Results may have been truncated",
                  getAllElementsLimit);
         }
         return translatedResults.iterator();
@@ -542,7 +543,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
         final OperationChain<Iterable<? extends Element>> getOperation;
         if (getAll) {
-            LOGGER.warn("Requested a GetAllElements results will be truncated to: {}.", getAllElementsLimit);
+            LOGGER.debug("Requested a GetAllElements, results will be truncated to: {}.", getAllElementsLimit);
             getOperation = new Builder()
                 .first(new GetAllElements.Builder()
                         .view(new View.Builder()
@@ -574,9 +575,9 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 .map(e -> (Edge) e)
                 .iterator();
 
-        if (getAll && IterableUtils.size(translatedResults) >= getAllElementsLimit) {
+        if (getAll && IterableUtils.size(translatedResults) == getAllElementsLimit) {
             LOGGER.warn(
-                "Result size is larger than configured limit ({}). Results may have been truncated",
+                "Result size is equal to configured limit ({}). Results may have been truncated",
                 getAllElementsLimit);
         }
         return translatedResults.iterator();

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -380,7 +380,8 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
     public Iterator<Vertex> vertices(final Object... vertexIds) {
         final boolean getAll = null == vertexIds || 0 == vertexIds.length;
 
-        final Output<Iterable<? extends Element>> getOperation;
+        final OperationChain<Iterable<? extends Element>> getOperation;
+
         if (getAll) {
             getOperation = new Builder()
                     .first(new GetAllElements.Builder()
@@ -388,20 +389,20 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                                     .entities(graph.getSchema().getEntityGroups())
                                     .build())
                             .build())
-                    .then(new Limit<>(getAllElementsLimit, true))
+                    .then(new Limit<Element>(getAllElementsLimit, true))
                     .build();
         } else {
-            getOperation = new GetElements.Builder()
+            getOperation = new Builder()
+                .first(new GetElements.Builder()
                     .input(getElementSeeds(Arrays.asList(vertexIds)))
                     .view(new View.Builder()
                             .entities(graph.getSchema().getEntityGroups())
                             .build())
-                    .build();
+                    .build())
+                .build();
         }
         // Run requested chain on the graph
-        final Iterable<? extends Element> result = execute(new Builder()
-                .first(getOperation)
-                .build());
+        final Iterable<? extends Element> result = execute(getOperation);
 
         // Translate results to Gafferpop elements
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(this);
@@ -411,12 +412,11 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 .map(e -> (Vertex) e)
                 .iterator();
 
-        final int resultSize = IterableUtils.size(translatedResults);
-        if (getAll && resultSize >= getAllElementsLimit) {
-            LOGGER.warn("Result size is equal to configured limit ({}). Results may have been truncated", getAllElementsLimit);
+        if (getAll && IterableUtils.size(translatedResults) > getAllElementsLimit) {
+            LOGGER.warn(
+                "Result size is larger than configured limit ({}). Results may have been truncated",
+                 getAllElementsLimit);
         }
-
-
         return translatedResults.iterator();
     }
 
@@ -540,8 +540,9 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
     public Iterator<Edge> edges(final Object... elementIds) {
         final boolean getAll = null == elementIds || 0 == elementIds.length;
 
-        final Output<Iterable<? extends Element>> getOperation;
+        final OperationChain<Iterable<? extends Element>> getOperation;
         if (getAll) {
+            LOGGER.warn("Requested a GetAllElements results will be truncated to: {}.", getAllElementsLimit);
             getOperation = new Builder()
                 .first(new GetAllElements.Builder()
                         .view(new View.Builder()
@@ -551,18 +552,19 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 .then(new Limit<>(getAllElementsLimit, true))
                 .build();
         } else {
-            getOperation = new GetElements.Builder()
+            getOperation = new Builder()
+                .first(new GetElements.Builder()
                     .input(getElementSeeds(Arrays.asList(elementIds)))
                     .view(new View.Builder()
-                            .edges(graph.getSchema().getEdgeGroups())
-                            .build())
-                    .build();
+                        .edges(graph.getSchema().getEdgeGroups())
+                        .build())
+                    .build())
+                .build();
         }
 
         // Run requested chain on the graph
-        final Iterable<? extends Element> result = execute(new Builder()
-                .first(getOperation)
-                .build());
+        final Iterable<? extends Element> result = execute(getOperation);
+
 
         // Translate results to Gafferpop elements
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(this);
@@ -572,11 +574,11 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 .map(e -> (Edge) e)
                 .iterator();
 
-        final int resultSize = IterableUtils.size(translatedResults);
-        if (getAll && resultSize >= getAllElementsLimit) {
-            LOGGER.warn("Result size is equal to configured limit ({}). Results may have been truncated", getAllElementsLimit);
+        if (getAll && IterableUtils.size(translatedResults) >= getAllElementsLimit) {
+            LOGGER.warn(
+                "Result size is larger than configured limit ({}). Results may have been truncated",
+                getAllElementsLimit);
         }
-
         return translatedResults.iterator();
     }
 

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopGraphStep.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopGraphStep.java
@@ -108,7 +108,7 @@ public class GafferPopGraphStep<S, E extends Element> extends GraphStep<S, E> im
         }
 
         // linear scan as fallback
-        return IteratorUtils.filter(graph.vertices(Arrays.asList(this.ids)), vertex -> HasContainer.testAll(vertex, hasContainers));
+        return IteratorUtils.filter(graph.vertices(this.ids), vertex -> HasContainer.testAll(vertex, hasContainers));
     }
 
     /**

--- a/store-implementation/proxy-store/src/main/java/uk/gov/gchq/gaffer/proxystore/response/deserialiser/impl/DefaultResponseDeserialiser.java
+++ b/store-implementation/proxy-store/src/main/java/uk/gov/gchq/gaffer/proxystore/response/deserialiser/impl/DefaultResponseDeserialiser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Crown Copyright
+ * Copyright 2021-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.proxystore.response.deserialiser.impl;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/store-implementation/proxy-store/src/main/java/uk/gov/gchq/gaffer/proxystore/response/deserialiser/impl/DefaultResponseDeserialiser.java
+++ b/store-implementation/proxy-store/src/main/java/uk/gov/gchq/gaffer/proxystore/response/deserialiser/impl/DefaultResponseDeserialiser.java
@@ -17,11 +17,16 @@ package uk.gov.gchq.gaffer.proxystore.response.deserialiser.impl;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import uk.gov.gchq.gaffer.exception.SerialisationException;
 import uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser;
+import uk.gov.gchq.gaffer.operation.serialisation.TypeReferenceImpl;
 import uk.gov.gchq.gaffer.proxystore.response.deserialiser.ResponseDeserialiser;
 
 public class DefaultResponseDeserialiser<O> implements ResponseDeserialiser<O> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultResponseDeserialiser.class);
 
     private final TypeReference<O> typeReference;
 
@@ -36,8 +41,21 @@ public class DefaultResponseDeserialiser<O> implements ResponseDeserialiser<O> {
             // The input is likely a plain java.lang.String object, so return as-is
             return (O) jsonString;
         } else {
-            // The input is likely a valid JSON value type, so process using the deserialiser
-            return JSONSerialiser.deserialise(encodeString(jsonString), typeReference);
+            // For some operations like 'Limit' we may not know the output type up front so it
+            // will be left as a generic '?', this means some objects will not be deserialised correctly.
+            try {
+                // Check if we can deserialise to common outputs like list of elements.
+                // This is a workaround until proxy store has been refactored
+                if (typeReference.getType().getTypeName().equals(Iterable.class.getName() + "<?>")) {
+                    return (O) JSONSerialiser.deserialise(encodeString(jsonString), new TypeReferenceImpl.IterableElement());
+                } else {
+                    return JSONSerialiser.deserialise(encodeString(jsonString), typeReference);
+                }
+            } catch (SerialisationException e) {
+                // The input is likely a valid JSON value type, so process using the deserialiser
+                LOGGER.error("Unable to deserialse Iterable<?> as Iterable<Elements> using default deserialisation", e);
+                return JSONSerialiser.deserialise(encodeString(jsonString), typeReference);
+            }
         }
     }
 }

--- a/store-implementation/proxy-store/src/main/java/uk/gov/gchq/gaffer/proxystore/response/deserialiser/impl/DefaultResponseDeserialiser.java
+++ b/store-implementation/proxy-store/src/main/java/uk/gov/gchq/gaffer/proxystore/response/deserialiser/impl/DefaultResponseDeserialiser.java
@@ -51,7 +51,7 @@ public class DefaultResponseDeserialiser<O> implements ResponseDeserialiser<O> {
                 } else {
                     return JSONSerialiser.deserialise(encodeString(jsonString), typeReference);
                 }
-            } catch (SerialisationException e) {
+            } catch (final SerialisationException e) {
                 // The input is likely a valid JSON value type, so process using the deserialiser
                 LOGGER.error("Unable to deserialse Iterable<?> as Iterable<Elements> using default deserialisation", e);
                 return JSONSerialiser.deserialise(encodeString(jsonString), typeReference);


### PR DESCRIPTION
Fixes most of the issues in the original issue, two minor fixes:
1. ensures the correct method is called in the `GafferPopGraphStep` 
2. Prevents `null` operation chain options.

Added work around to main serialisation error in the proxy store so that it attempts to deserialise element iterators. This will be fixed in a larger rework of the proxy store so that it does not need to double deserialise.

# Related issue

- Resolve #3209