### PR TITLE
Gh-3157: Fix PMD plugin unnecessary warning

### DIFF
--- a/library/time-library/src/main/java/uk/gov/gchq/gaffer/time/BoundedTimestampSet.java
+++ b/library/time-library/src/main/java/uk/gov/gchq/gaffer/time/BoundedTimestampSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 Crown Copyright
+ * Copyright 2017-2023 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,7 +102,7 @@ public class BoundedTimestampSet implements TimestampSet {
         if (state.equals(State.NOT_FULL)) {
             return rbmBackedTimestampSet.getNumberOfTimestamps();
         }
-        return reservoirLongsUnion.getResult().getNumSamples();
+        return (long) reservoirLongsUnion.getResult().getNumSamples();
     }
 
     @Override

--- a/library/time-library/src/main/java/uk/gov/gchq/gaffer/time/BoundedTimestampSet.java
+++ b/library/time-library/src/main/java/uk/gov/gchq/gaffer/time/BoundedTimestampSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,7 +102,7 @@ public class BoundedTimestampSet implements TimestampSet {
         if (state.equals(State.NOT_FULL)) {
             return rbmBackedTimestampSet.getNumberOfTimestamps();
         }
-        return (long) reservoirLongsUnion.getResult().getNumSamples();
+        return reservoirLongsUnion.getResult().getNumSamples();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -1132,6 +1132,7 @@
                 <artifactId>maven-pmd-plugin</artifactId>
                 <version>${pmd.plugin.version}</version>
                 <configuration>
+                    <linkXRef>false</linkXRef>
                     <printFailingErrors>true</printFailingErrors>
                     <rulesets>
                         <ruleset>code-style/pmd-ruleset.xml</ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency.plugin.version>3.6.1</dependency.plugin.version>
         <depgraph.plugin.version>4.0.2</depgraph.plugin.version>
         <spotbugs.plugin.version>4.7.3.4</spotbugs.plugin.version>
-        <pmd.plugin.version>3.20.0</pmd.plugin.version>
+        <pmd.plugin.version>3.22.0</pmd.plugin.version>
         <spotless.plugin.version>2.30.0</spotless.plugin.version>
         <war.plugin.version>3.2.3</war.plugin.version>
         <gpg.plugin.version>3.1.0</gpg.plugin.version>
@@ -1133,6 +1133,7 @@
                 <version>${pmd.plugin.version}</version>
                 <configuration>
                     <linkXRef>false</linkXRef>
+                    <analysisCache>true</analysisCache>
                     <printFailingErrors>true</printFailingErrors>
                     <rulesets>
                         <ruleset>code-style/pmd-ruleset.xml</ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency.plugin.version>3.6.1</dependency.plugin.version>
         <depgraph.plugin.version>4.0.2</depgraph.plugin.version>
         <spotbugs.plugin.version>4.7.3.4</spotbugs.plugin.version>
-        <pmd.plugin.version>3.22.0</pmd.plugin.version>
+        <pmd.plugin.version>3.21.0</pmd.plugin.version>
         <spotless.plugin.version>2.30.0</spotless.plugin.version>
         <war.plugin.version>3.2.3</war.plugin.version>
         <gpg.plugin.version>3.1.0</gpg.plugin.version>


### PR DESCRIPTION
Also enables the cache and bumps plugin version to latest

# Related issue

- Resolve #3157