### PR TITLE
Gh-3219: Fix inV() and outV() missing results

### DIFF
--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Crown Copyright
+ * Copyright 2016-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
@@ -45,14 +45,6 @@ import java.util.stream.StreamSupport;
 /**
  * A <code>GafferPopEdge</code> is an {@link GafferPopElement} and {@link Edge}.
  * <p>
- * inVertex() and outVertex() methods are not supported as it is possible for a
- * edge to have multiple in vertices and multiple out vertices (due to the
- * mapping
- * to a TinkerPop vertex to Gaffer
- * {@link uk.gov.gchq.gaffer.data.element.Entity}.
- * Use vertices(Direction) instead.
- * </p>
- * <p>
  * An ID is required to be a List which contains the source, group, and
  * destination of an edge.
  * </p>

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
@@ -210,7 +210,7 @@ public final class GafferPopEdge extends GafferPopElement implements Edge {
     /**
      * Runs a search to determine the correct Entity to use when a vertex ID
      * is supplied to an edge. Note that this may slow performance.
-     * 
+     *
      * @param vertex The vertex object or ID
      * @return A valid Vertex based on the supplied object or ID.
      */

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
@@ -208,8 +208,9 @@ public final class GafferPopEdge extends GafferPopElement implements Edge {
     }
 
     /**
-     * Finds the Vertex in Gaffer based on vertex ID.
-     *
+     * Runs a search to determine the correct Entity to use when a vertex ID
+     * is supplied to an edge. Note that this may slow performance.
+     * 
      * @param vertex The vertex object or ID
      * @return A valid Vertex based on the supplied object or ID.
      */

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import uk.gov.gchq.gaffer.data.element.Element;
+import uk.gov.gchq.gaffer.data.elementdefinition.view.View;
 import uk.gov.gchq.gaffer.operation.OperationChain;
 import uk.gov.gchq.gaffer.operation.data.EntitySeed;
 import uk.gov.gchq.gaffer.operation.impl.get.GetElements;
@@ -210,6 +211,7 @@ public final class GafferPopEdge extends GafferPopElement implements Edge {
         OperationChain<Iterable<? extends Element>> findBasedOnID = new OperationChain.Builder()
                 .first(new GetElements.Builder()
                         .input(new EntitySeed(vertex.id()))
+                        .view(new View.Builder().allEntities(true).build())
                         .build())
                 .build();
 

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdgeTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdgeTest.java
@@ -175,6 +175,7 @@ public class GafferPopEdgeTest {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final GafferPopEdge edge = new GafferPopEdge(TestGroups.EDGE, SOURCE, DEST, graph);
+        when(graph.execute(Mockito.any())).thenReturn(new ArrayList<>());
 
         // Then
         assertThat(edge).hasToString(StringFactory.edgeString(edge));

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdgeTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdgeTest.java
@@ -23,6 +23,7 @@ import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import uk.gov.gchq.gaffer.commonutil.TestGroups;
 import uk.gov.gchq.gaffer.commonutil.TestPropertyNames;
@@ -49,6 +50,7 @@ public class GafferPopEdgeTest {
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final GafferPopVertex outVertex = new GafferPopVertex(GafferPopGraph.ID_LABEL, SOURCE, graph);
         final GafferPopVertex inVertex = new GafferPopVertex(GafferPopGraph.ID_LABEL, DEST, graph);
+        when(graph.execute(Mockito.any())).thenReturn(new ArrayList<>());
 
         // When
         final GafferPopEdge edge = new GafferPopEdge(TestGroups.EDGE, outVertex, inVertex, graph);
@@ -71,6 +73,7 @@ public class GafferPopEdgeTest {
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final GafferPopVertex outVertex = new GafferPopVertex("label", SOURCE, graph);
         final GafferPopVertex inVertex = new GafferPopVertex("label", DEST, graph);
+        when(graph.execute(Mockito.any())).thenReturn(new ArrayList<>());
 
         // When
         final GafferPopEdge edge = new GafferPopEdge(TestGroups.EDGE, outVertex, inVertex, graph);
@@ -183,6 +186,7 @@ public class GafferPopEdgeTest {
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final GafferPopVertex outVertex = new GafferPopVertex(GafferPopGraph.ID_LABEL, SOURCE, graph);
         final GafferPopVertex inVertex = new GafferPopVertex(GafferPopGraph.ID_LABEL, DEST, graph);
+        when(graph.execute(Mockito.any())).thenReturn(new ArrayList<>());
 
         // When
         final GafferPopEdge edge = new GafferPopEdge(TestGroups.EDGE, outVertex, inVertex, graph);
@@ -197,6 +201,7 @@ public class GafferPopEdgeTest {
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final GafferPopVertex outVertex = new GafferPopVertex(GafferPopGraph.ID_LABEL, SOURCE, graph);
         final GafferPopVertex inVertex = new GafferPopVertex(GafferPopGraph.ID_LABEL, DEST, graph);
+        when(graph.execute(Mockito.any())).thenReturn(new ArrayList<>());
 
         // When
         final GafferPopEdge edge = new GafferPopEdge(TestGroups.EDGE, outVertex, inVertex, graph);
@@ -213,6 +218,7 @@ public class GafferPopEdgeTest {
         final GafferPopVertex inVertex = mock(GafferPopVertex.class);
         when(inVertex.id()).thenReturn("inVertextId");
         when(outVertex.id()).thenReturn("outVertextId");
+        when(graph.execute(Mockito.any())).thenReturn(new ArrayList<>());
 
         // When
         final GafferPopEdge edge = new GafferPopEdge(TestGroups.EDGE, outVertex, inVertex, graph);

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdgeTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdgeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
@@ -101,7 +101,7 @@ public class GafferPopFederatedIT {
         // Then
         assertThat(variables).contains(
                 entry("userId", USER_ID),
-                    entry("dataAuths", new String[] {AUTH_1, AUTH_2}));
+                entry("dataAuths", new String[] {AUTH_1, AUTH_2}));
     }
 
     @Test

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
@@ -101,7 +101,7 @@ public class GafferPopFederatedIT {
         // Then
         assertThat(variables).contains(
                 entry("userId", USER_ID),
-                entry("dataAuths", new String[] {AUTH_1, AUTH_2}));
+                    entry("dataAuths", new String[] {AUTH_1, AUTH_2}));
     }
 
     @Test
@@ -214,6 +214,29 @@ public class GafferPopFederatedIT {
                 .first()
                 .hasFieldOrPropertyWithValue(PERSON_GROUP, 4L)
                 .hasFieldOrPropertyWithValue(SOFTWARE_GROUP, 2L);
+    }
+
+    @Test
+    void shouldGetAllVerticesConnectedToOutGoingEdgeOfGivenVertex() {
+        // Given
+        GraphTraversalSource g = gafferPopGraph.traversal();
+
+        // When
+        List<Object> result = g.V(VERTEX_PERSON_1).outE().inV().values("name").toList();
+
+        assertThat(result).containsExactly(EXPECTED_PERSON_2_VERTEX_MAP.get("name"),
+                EXPECTED_SOFTWARE_1_VERTEX_MAP.get("name"));
+    }
+
+    @Test
+    void shouldGetPropertiesOfIncomingVerticesForSpecificVertex() {
+        // Given
+        GraphTraversalSource g = gafferPopGraph.traversal();
+
+        // When
+        List<Map<Object, Object>> result = g.V(VERTEX_PERSON_2).inE().outV().elementMap().toList();
+
+        assertThat(result).containsAnyOf(EXPECTED_PERSON_1_VERTEX_MAP);
     }
 
     @Test

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertexTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopVertexTest.java
@@ -27,11 +27,13 @@ import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import uk.gov.gchq.gaffer.commonutil.TestGroups;
 import uk.gov.gchq.gaffer.commonutil.TestPropertyNames;
 import uk.gov.gchq.gaffer.data.elementdefinition.view.View;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -40,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class GafferPopVertexTest {
     // Common mocks for tests
@@ -242,6 +245,7 @@ class GafferPopVertexTest {
         final GafferPopGraph graph = mock(GafferPopGraph.class);
         final GafferPopVertex vertex = new GafferPopVertex(TestGroups.ENTITY, GafferPopGraph.ID_LABEL, graph);
         final Iterable<Edge> resultEdges = Arrays.asList(((Edge) new GafferPopEdge(GafferPopGraph.ID_LABEL, vertex, vertex, graph)));
+        when(graph.execute(Mockito.any())).thenReturn(new ArrayList<>());
         given(graph.edgesWithView(GafferPopGraph.ID_LABEL, Direction.IN, new View.Builder()
                 .edges(Collections.singletonList(TestGroups.ENTITY))
                 .build()))

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferEdgeGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferEdgeGeneratorTest.java
@@ -17,6 +17,7 @@
 package uk.gov.gchq.gaffer.tinkerpop.generator;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import uk.gov.gchq.gaffer.commonutil.TestGroups;
 import uk.gov.gchq.gaffer.commonutil.TestPropertyNames;
@@ -26,6 +27,9 @@ import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
 
 public class GafferEdgeGeneratorTest {
     @Test
@@ -38,6 +42,7 @@ public class GafferEdgeGeneratorTest {
         final String propValue = "property value";
         final GafferPopEdge gafferPopEdge = new GafferPopEdge(TestGroups.EDGE, source, dest, graph);
         gafferPopEdge.property(TestPropertyNames.STRING, propValue);
+        when(graph.execute(Mockito.any())).thenReturn(new ArrayList<>());
 
         final GafferEdgeGenerator generator = new GafferEdgeGenerator();
 

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferEdgeGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferEdgeGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
@@ -17,6 +17,7 @@
 package uk.gov.gchq.gaffer.tinkerpop.generator;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import uk.gov.gchq.gaffer.commonutil.TestGroups;
 import uk.gov.gchq.gaffer.commonutil.TestPropertyNames;
@@ -29,12 +30,16 @@ import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
 
 public class GafferPopEdgeGeneratorTest {
     @Test
     public void shouldConvertGafferEdgeToGafferPopReadOnlyEdge() {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
+        when(graph.execute(Mockito.any())).thenReturn(new ArrayList<>());
 
         final String source = "source";
         final String dest = "dest";
@@ -62,6 +67,7 @@ public class GafferPopEdgeGeneratorTest {
     public void shouldConvertGafferEdgeToGafferPopReadWriteEdge() {
         // Given
         final GafferPopGraph graph = mock(GafferPopGraph.class);
+        when(graph.execute(Mockito.any())).thenReturn(new ArrayList<>());
 
         final String source = "source";
         final String dest = "dest";

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/generator/GafferPopEdgeGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Implemented a fix which will use an Operation Chain to search the graph for the vertex by ID to get the right results. Fixes 32 cucumber tests. 

# Related issue

- Resolve #3219