### PR TITLE
Gh-3223: Change GafferPopEdge id representation

### DIFF
--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
@@ -59,7 +59,7 @@ public final class GafferPopEdge extends GafferPopElement implements Edge {
 
     public GafferPopEdge(final String label, final Object outVertex, final Object inVertex,
             final GafferPopGraph graph) {
-        super(label, Arrays.asList(getVertexId(outVertex), getVertexId(inVertex)), graph);
+        super(label, Arrays.asList(getVertexId(outVertex), label, getVertexId(inVertex)), graph);
         this.outVertex = getValidVertex(outVertex, graph);
         this.inVertex = getValidVertex(inVertex, graph);
     }

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -1009,7 +1009,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 List<String> idElements = parseString((String) id);
 
                 // If contains label, extract to use in View as edge group
-                if(idElements.size() == 3){
+                if (idElements.size() == 3) {
                     labels.add(idElements.get(1));
                 } else {
                     // Fallback is to use all schema edge groups
@@ -1027,7 +1027,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * @param id The id that is to be parsed
      * @return The edge ids and any labels
      */
-    private List<String> parseString(String id) {
+    private List<String> parseString(final String id) {
         List<String> idElements = new ArrayList<>();
 
         String regex1 = "^\\[(?<first>.*),\\s*(?<middle>[a-zA-Z0-9|-]*)?\\s*,\\s*(?<last>.*)\\]$";
@@ -1037,18 +1037,18 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         Pattern pattern2 = Pattern.compile(regex2);
         Matcher matcher2 = pattern2.matcher(id);
 
-        if(matcher1.find()){
+        if (matcher1.find()) {
             // Add source
             idElements.add(matcher1.group("first"));
 
             // Add label
-            if(matcher1.group("middle") != null){
+            if (matcher1.group("middle") != null) {
                 idElements.add(matcher1.group("middle"));
             }
 
             // Add dest
             idElements.add(matcher1.group("last"));
-        } else if (matcher2.find()){
+        } else if (matcher2.find()) {
             // Add source
             idElements.add(matcher2.group("first"));
 

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -249,7 +249,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GafferPopGraph.class);
     private static final String GET_ALL_DEBUG_MSG = "Requested a GetAllElements, results will be truncated to: {}.";
-    private static final Pattern EDGE_ID_REGEX = Pattern.compile("^\\[(?<src>[a-zA-Z0-9|-]*)(,\\s*(?<label>[a-zA-Z0-9|-]*))?\\s*,\\s*(?<dest>[a-zA-Z0-9|-]*)\\]$");
+    private static final Pattern EDGE_ID_REGEX = Pattern.compile("^\\[\\s*(?<src>[a-zA-Z0-9|-]*)\\s*(,\\s*(?<label>[a-zA-Z0-9|-]*))?\\s*,\\s*(?<dest>[a-zA-Z0-9|-]*)\\s*\\]$");
 
     public GafferPopGraph(final Configuration configuration) {
         this(configuration, createGraph(configuration));
@@ -975,7 +975,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 ((Iterable<?>) id).forEach(edgeIdList::add);
             // Attempt to extract source and destination IDs from a string from of an
             // array/list
-            } else if ((id instanceof String) && (EDGE_ID_REGEX.matcher((String) id).matches())) {
+            } else if ((id instanceof String) && EDGE_ID_REGEX.matcher((String) id).matches()) {
                 Matcher edgeIDMatcher = EDGE_ID_REGEX.matcher((String) id);
 
                 if (edgeIDMatcher.matches()) {

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -644,7 +644,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * @see #edges(Object...)
      */
     public Iterator<Edge> edges(final Iterable<Object> ids, final Direction direction, final String... labels) {
-        return edgesWithView(getElementSeeds(ids), direction, createView(labels));
+        return edgesWithView(ids, direction, createView(labels));
     }
 
     /**

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -973,7 +973,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
             // Extract source and destination from ID list
             } else if (id instanceof Iterable) {
                 ((Iterable<?>) id).forEach(edgeIdList::add);
-            // Attempt to extract source and destination IDs from a string form of an
+            // Attempt to extract source and destination IDs from a string from of an
             // array/list
             } else if ((id instanceof String) && (EDGE_ID_REGEX.matcher((String) id).matches())) {
                 Matcher edgeIDMatcher = EDGE_ID_REGEX.matcher((String) id);

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -972,13 +972,8 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 ((Iterable<?>) id).forEach(edgeIdList::add);
             // Attempt to extract source and destination IDs from a string form of an
             // array/list
-            } else if ((id instanceof String) && ((String) id).matches("^\\[.*,[a-zA-Z0-9]*,.*\\]$")) {
-                edgeIdList = Arrays.asList(((String) id)
-                        .replaceAll("\\s", "")
-                        .replace("[", "")
-                        .replace("]", "")
-                        .split(","));
-            } else if ((id instanceof String) && ((String) id).matches("^\\[.*,.*\\]$")) {
+            } else if ((id instanceof String) && (((String) id).matches("^\\[.*,.*\\]$")
+                || ((String) id).matches("^\\[.*,[a-zA-Z0-9]*,.*\\]$"))) {
                 edgeIdList = Arrays.asList(((String) id)
                         .replaceAll("\\s", "")
                         .replace("[", "")

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -1002,6 +1002,14 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         return seeds;
     }
 
+    /**
+     * Determines the edge group used in the view based on supplied IDs.
+     * If ID contains a label, this is extracted and used in the view.
+     * If not, all edge groups are used.
+     *
+     * @param ids The iterable of IDs
+     * @return Set of edge labels for the view
+     */
     private Set<String> getEdgeViewGroup(final Iterable<Object> ids) {
         Set<String> labels = new HashSet<>();
 

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -975,7 +975,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
             // Attempt to extract source and destination IDs from a string form of an
             // array/list
             } else if ((id instanceof String) && (((String) id).matches("^\\[.*,.*\\]$")
-                || ((String) id).matches("^\\[.*,[a-zA-Z0-9]*,.*\\]$"))) {
+                || ((String) id).matches("^\\[.*,[a-zA-Z0-9|-]*,.*\\]$"))) {
                 parseString((String) id).forEach(edgeIdList::add);
             // Assume entity ID as a fallback
             } else {

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -973,14 +973,12 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 ((Iterable<?>) id).forEach(edgeIdList::add);
             // Attempt to extract source and destination IDs from a string form of an
             // array/list
-            } else if ((id instanceof String) && ((String) id).matches("^\\[.*-.*->.*\\]$")) {
+            } else if ((id instanceof String) && ((String) id).matches("^\\[.*,[a-zA-Z0-9]*,.*\\]$")) {
                 edgeIdList = Arrays.asList(((String) id)
                         .replaceAll("\\s", "")
                         .replace("[", "")
-                        .replace("-", " ")
-                        .replace(">", "")
                         .replace("]", "")
-                        .split(" "));
+                        .split(","));
             } else if ((id instanceof String) && ((String) id).matches("^\\[.*,.*\\]$")) {
                 edgeIdList = Arrays.asList(((String) id)
                         .replaceAll("\\s", "")
@@ -1014,7 +1012,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         Set<String> labels = new HashSet<>();
 
         ids.forEach(id -> {
-            if ((id instanceof String) && ((String) id).matches("^\\[.*-.*->.*\\]$")) {
+            if ((id instanceof String) && ((String) id).matches("^\\[.*,[a-zA-Z0-9]*,.*\\]$")) {
                 List<String> edgeIdList = Arrays.asList(((String) id)
                         .replaceAll("\\s", "")
                         .replace("[", "")

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -445,7 +445,8 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * Supports input as a {@link Vertex}, {@link Edge}, List of Edge IDs or individual Vertex IDs.
      * @param labels labels of Entities to filter for.
      * Alternatively you can supply a Gaffer View serialised into JSON.
-     * @return iterator of {@link GafferPopVertex}s, each vertex represents an {@link uk.gov.gchq.gaffer.data.element.Entity} in Gaffer
+     * @return iterator of {@link GafferPopVertex}s, each vertex represents an
+     * {@link uk.gov.gchq.gaffer.data.element.Entity} in Gaffer
      * @see #vertices(Object...)
      */
     public Iterator<GafferPopVertex> vertices(final Iterable<Object> ids, final String... labels) {
@@ -479,8 +480,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * an {@link uk.gov.gchq.gaffer.data.element.Entity} in Gaffer
      * @see #vertices(Object...)
      */
-    public Iterator<GafferPopVertex> verticesWithView(final Iterable<Object> ids,
-            final ViewElementDefinition elementDefinition, final List<String> labels) {
+    public Iterator<GafferPopVertex> verticesWithView(final Iterable<Object> ids, final ViewElementDefinition elementDefinition, final List<String> labels) {
         View.Builder viewBuilder = new View.Builder();
 
         // If no labels specified, default to all
@@ -524,8 +524,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * @param labels    labels of vertices and edges. Alternatively you can supply a Gaffer View serialised into JSON.
      * @return iterator of {@link GafferPopVertex}
      */
-    public Iterator<Vertex> adjVertices(final Iterable<Object> vertexIds, final Direction direction,
-            final String... labels) {
+    public Iterator<Vertex> adjVertices(final Iterable<Object> vertexIds, final Direction direction, final String... labels) {
         return adjVerticesWithView(vertexIds, direction, createView(labels));
     }
 
@@ -559,8 +558,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * @param view      a Gaffer {@link View} containing edge and entity groups.
      * @return iterator of {@link GafferPopVertex}
      */
-    public Iterator<Vertex> adjVerticesWithView(final Iterable<Object> vertexIds, final Direction direction,
-            final View view) {
+    public Iterator<Vertex> adjVerticesWithView(final Iterable<Object> vertexIds, final Direction direction, final View view) {
         return adjVerticesWithSeedsAndView(getElementSeeds(vertexIds), direction, view);
     }
 
@@ -688,8 +686,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * @return iterator of {@link GafferPopEdge}s.
      * @see #edges(Object...)
      */
-    public Iterator<Edge> edgesWithView(final Iterable<Object> ids, final Direction direction,
-            final ViewElementDefinition elementDefinition, final List<String> labels) {
+    public Iterator<Edge> edgesWithView(final Iterable<Object> ids, final Direction direction, final ViewElementDefinition elementDefinition, final List<String> labels) {
         View.Builder viewBuilder = new View.Builder();
 
         // If no labels specified, default to all
@@ -829,8 +826,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
     }
 
-    private Iterator<Vertex> adjVerticesWithSeedsAndView(final List<ElementSeed> seeds, final Direction direction,
-            final View view) {
+    private Iterator<Vertex> adjVerticesWithSeedsAndView(final List<ElementSeed> seeds, final Direction direction, final View view) {
         if (null == seeds || seeds.isEmpty()) {
             throw new UnsupportedOperationException("There could be a lot of vertices, so please add some seeds");
         }
@@ -842,8 +838,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                         .view(processedView)
                         .inOutType(getInOutType(direction))
                         .build())
-                // GetAdjacentIds provides list of entity seeds so run a GetElements to get the
-                // actual Entities
+                // GetAdjacentIds provides list of entity seeds so run a GetElements to get the actual Entities
                 .then(new GetElements())
                 .build());
 
@@ -858,8 +853,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         return translatedResults.iterator();
     }
 
-    private Iterator<Edge> edgesWithSeedsAndView(final List<ElementSeed> seeds, final Direction direction,
-            final View view) {
+    private Iterator<Edge> edgesWithSeedsAndView(final List<ElementSeed> seeds, final Direction direction, final View view) {
         final boolean getAll = null == seeds || seeds.isEmpty();
 
         View edgesView = view;
@@ -990,6 +984,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                         .replace("[", "")
                         .replace("]", "")
                         .split(","));
+            // Assume entity ID as a fallback
             } else {
                 seeds.add(new EntitySeed(id));
             }
@@ -1058,9 +1053,9 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         variables.set(GafferPopGraphVariables.USER_ID, defaultUser.getUserId());
         variables.set(GafferPopGraphVariables.DATA_AUTHS, configuration().getStringArray(DATA_AUTHS));
         variables.set(GafferPopGraphVariables.GET_ALL_ELEMENTS_LIMIT,
-                configuration().getInteger(GET_ALL_ELEMENTS_LIMIT, DEFAULT_GET_ALL_ELEMENTS_LIMIT));
+            configuration().getInteger(GET_ALL_ELEMENTS_LIMIT, DEFAULT_GET_ALL_ELEMENTS_LIMIT));
         variables.set(GafferPopGraphVariables.HAS_STEP_FILTER_STAGE,
-                configuration().getString(HAS_STEP_FILTER_STAGE, DEFAULT_HAS_STEP_FILTER_STAGE.toString()));
+            configuration().getString(HAS_STEP_FILTER_STAGE, DEFAULT_HAS_STEP_FILTER_STAGE.toString()));
     }
 
     /**

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -977,7 +977,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 ((Iterable<?>) id).forEach(edgeIdList::add);
             // Attempt to extract source and destination IDs from a string from of an
             // array/list
-            } else if ((id instanceof String)) {
+            } else if (id instanceof String) {
                 Matcher edgeIDMatcher = EDGE_ID_REGEX.matcher((String) id);
                 // Check if contains label in edge ID
                 if (edgeIDMatcher.matches()) {

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -1016,10 +1016,9 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 List<String> edgeIdList = Arrays.asList(((String) id)
                         .replaceAll("\\s", "")
                         .replace("[", "")
-                        .replace("-", " ")
-                        .replace(">", "")
                         .replace("]", "")
-                        .split(" "));
+                        .split(","));
+                LOGGER.debug("EDDGE ID {}", edgeIdList);
                 labels.add(edgeIdList.get(1));
             } else {
                 labels.addAll(graph.getSchema().getEdgeGroups());

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -69,10 +69,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
@@ -337,9 +339,9 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
         /*
          * TODO: Check the ID type is relevant for the group (a.k.a label) in the schema and auto convert
-         *       as the some Standard tinkerpop tests add data for the same group but with a different
-         *       Object type for the ID. Using a String ID manager might be the most flexible for these
-         *       tests.
+         *     as the some Standard tinkerpop tests add data for the same group but with a different
+         *     Object type for the ID. Using a String ID manager might be the most flexible for these
+         *     tests.
          * Basic idea of auto converting the type is below:
          *
          * String idSchemaType = graph.getSchema().getEntity(label).getVertex();
@@ -430,8 +432,8 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
         if (getAll && IterableUtils.size(translatedResults) == getAllElementsLimit) {
             LOGGER.warn(
-                "Result size is equal to configured limit ({}). Results may have been truncated",
-                 getAllElementsLimit);
+                    "Result size is equal to configured limit ({}). Results may have been truncated",
+                    getAllElementsLimit);
         }
         return translatedResults.iterator();
     }
@@ -445,8 +447,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * Supports input as a {@link Vertex}, {@link Edge}, List of Edge IDs or individual Vertex IDs.
      * @param labels labels of Entities to filter for.
      * Alternatively you can supply a Gaffer View serialised into JSON.
-     * @return iterator of {@link GafferPopVertex}s, each vertex represents
-     * an {@link uk.gov.gchq.gaffer.data.element.Entity} in Gaffer
+     * @return iterator of {@link GafferPopVertex}s, each vertex represents an {@link uk.gov.gchq.gaffer.data.element.Entity} in Gaffer
      * @see #vertices(Object...)
      */
     public Iterator<GafferPopVertex> vertices(final Iterable<Object> ids, final String... labels) {
@@ -480,7 +481,8 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * an {@link uk.gov.gchq.gaffer.data.element.Entity} in Gaffer
      * @see #vertices(Object...)
      */
-    public Iterator<GafferPopVertex> verticesWithView(final Iterable<Object> ids, final ViewElementDefinition elementDefinition, final List<String> labels) {
+    public Iterator<GafferPopVertex> verticesWithView(final Iterable<Object> ids,
+            final ViewElementDefinition elementDefinition, final List<String> labels) {
         View.Builder viewBuilder = new View.Builder();
 
         // If no labels specified, default to all
@@ -493,7 +495,6 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
         return verticesWithView(ids, viewBuilder.build());
     }
-
 
     /**
      * This performs GetAdjacentIds then GetElements operation chain
@@ -525,7 +526,8 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * @param labels    labels of vertices and edges. Alternatively you can supply a Gaffer View serialised into JSON.
      * @return iterator of {@link GafferPopVertex}
      */
-    public Iterator<Vertex> adjVertices(final Iterable<Object> vertexIds, final Direction direction, final String... labels) {
+    public Iterator<Vertex> adjVertices(final Iterable<Object> vertexIds, final Direction direction,
+            final String... labels) {
         return adjVerticesWithView(vertexIds, direction, createView(labels));
     }
 
@@ -559,7 +561,8 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * @param view      a Gaffer {@link View} containing edge and entity groups.
      * @return iterator of {@link GafferPopVertex}
      */
-    public Iterator<Vertex> adjVerticesWithView(final Iterable<Object> vertexIds, final Direction direction, final View view) {
+    public Iterator<Vertex> adjVerticesWithView(final Iterable<Object> vertexIds, final Direction direction,
+            final View view) {
         return adjVerticesWithSeedsAndView(getElementSeeds(vertexIds), direction, view);
     }
 
@@ -594,7 +597,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 .first(new GetElements.Builder()
                     .input(getElementSeeds(Arrays.asList(elementIds)))
                     .view(new View.Builder()
-                        .edges(graph.getSchema().getEdgeGroups())
+                        .edges(getEdgeViewGroup(Arrays.asList(elementIds)))
                         .build())
                     .build())
                 .build();
@@ -602,7 +605,6 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
         // Run requested chain on the graph
         final Iterable<? extends Element> result = execute(getOperation);
-
 
         // Translate results to Gafferpop elements
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(this);
@@ -614,8 +616,8 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
         if (getAll && IterableUtils.size(translatedResults) == getAllElementsLimit) {
             LOGGER.warn(
-                "Result size is equal to configured limit ({}). Results may have been truncated",
-                getAllElementsLimit);
+                    "Result size is equal to configured limit ({}). Results may have been truncated",
+                    getAllElementsLimit);
         }
         return translatedResults.iterator();
     }
@@ -626,7 +628,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * @param id vertex ID or edge ID to be queried for.
      * Supports input as a {@link Vertex}, {@link Edge}, List of Edge IDs or individual Vertex IDs.
      * @param direction {@link Direction} of edges to return.
-     * @param labels    labels of edges. Alternatively you can supply a Gaffer View serialised into JSON.
+     * @param labels labels of edges. Alternatively you can supply a Gaffer View serialised into JSON.
      * @return iterator of {@link GafferPopEdge}s.
      * @see #edges(Object...)
      */
@@ -640,12 +642,12 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * @param ids vertex IDs or edge IDs to be queried for.
      * Supports input as a {@link Vertex}, {@link Edge}, List of Edge IDs or individual Vertex IDs.
      * @param direction {@link Direction} of edges to return.
-     * @param labels    labels of edges. Alternatively you can supply a Gaffer View serialised into JSON.
+     * @param labels labels of edges. Alternatively you can supply a Gaffer View serialised into JSON.
      * @return iterator of {@link GafferPopEdge}s.
      * @see #edges(Object...)
      */
     public Iterator<Edge> edges(final Iterable<Object> ids, final Direction direction, final String... labels) {
-        return edgesWithView(ids, direction, createView(labels));
+        return edgesWithView(getElementSeeds(ids), direction, createView(labels));
     }
 
     /**
@@ -689,7 +691,8 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * @return iterator of {@link GafferPopEdge}s.
      * @see #edges(Object...)
      */
-    public Iterator<Edge> edgesWithView(final Iterable<Object> ids, final Direction direction, final ViewElementDefinition elementDefinition, final List<String> labels) {
+    public Iterator<Edge> edgesWithView(final Iterable<Object> ids, final Direction direction,
+            final ViewElementDefinition elementDefinition, final List<String> labels) {
         View.Builder viewBuilder = new View.Builder();
 
         // If no labels specified, default to all
@@ -698,8 +701,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
             labels;
 
         // Apply ViewElementDefinition to each group
-        edgeGroups.stream()
-            .forEach(g -> viewBuilder.edge(g, elementDefinition));
+        edgeGroups.stream().forEach(g -> viewBuilder.edge(g, elementDefinition));
 
         return edgesWithView(ids, direction, viewBuilder.build());
     }
@@ -826,7 +828,8 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
     }
 
-    private Iterator<Vertex> adjVerticesWithSeedsAndView(final List<ElementSeed> seeds, final Direction direction, final View view) {
+    private Iterator<Vertex> adjVerticesWithSeedsAndView(final List<ElementSeed> seeds, final Direction direction,
+            final View view) {
         if (null == seeds || seeds.isEmpty()) {
             throw new UnsupportedOperationException("There could be a lot of vertices, so please add some seeds");
         }
@@ -838,7 +841,8 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                         .view(processedView)
                         .inOutType(getInOutType(direction))
                         .build())
-                // GetAdjacentIds provides list of entity seeds so run a GetElements to get the actual Entities
+                // GetAdjacentIds provides list of entity seeds so run a GetElements to get the
+                // actual Entities
                 .then(new GetElements())
                 .build());
 
@@ -853,7 +857,8 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         return translatedResults.iterator();
     }
 
-    private Iterator<Edge> edgesWithSeedsAndView(final List<ElementSeed> seeds, final Direction direction, final View view) {
+    private Iterator<Edge> edgesWithSeedsAndView(final List<ElementSeed> seeds, final Direction direction,
+            final View view) {
         final boolean getAll = null == seeds || seeds.isEmpty();
 
         View edgesView = view;
@@ -966,14 +971,22 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
             // Extract source and destination from ID list
             } else if (id instanceof Iterable) {
                 ((Iterable<?>) id).forEach(edgeIdList::add);
-            // Attempt to extract source and destination IDs from a string form of an array/list
-            } else if ((id instanceof String) && (((String) id).matches("^\\[.*,.*\\]$"))) {
+            // Attempt to extract source and destination IDs from a string form of an
+            // array/list
+            } else if ((id instanceof String) && ((String) id).matches("^\\[.*-.*->.*\\]$")) {
+                edgeIdList = Arrays.asList(((String) id)
+                        .replaceAll("\\s", "")
+                        .replace("[", "")
+                        .replace("-", " ")
+                        .replace(">", "")
+                        .replace("]", "")
+                        .split(" "));
+            } else if ((id instanceof String) && ((String) id).matches("^\\[.*,.*\\]$")) {
                 edgeIdList = Arrays.asList(((String) id)
                         .replaceAll("\\s", "")
                         .replace("[", "")
                         .replace("]", "")
                         .split(","));
-            // Assume entity ID as fallback
             } else {
                 seeds.add(new EntitySeed(id));
             }
@@ -981,10 +994,33 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
             // If found a list verify source and destination
             if (edgeIdList.size() == 2) {
                 seeds.add(new EdgeSeed(edgeIdList.get(0), edgeIdList.get(1)));
+            } else if (edgeIdList.size() == 3) {
+                seeds.add(new EdgeSeed(edgeIdList.get(0), edgeIdList.get(2)));
             }
         });
 
         return seeds;
+    }
+
+    private Set<String> getEdgeViewGroup(final Iterable<Object> ids) {
+        Set<String> labels = new HashSet<>();
+
+        ids.forEach(id -> {
+            if ((id instanceof String) && ((String) id).matches("^\\[.*-.*->.*\\]$")) {
+                List<String> edgeIdList = Arrays.asList(((String) id)
+                        .replaceAll("\\s", "")
+                        .replace("[", "")
+                        .replace("-", " ")
+                        .replace(">", "")
+                        .replace("]", "")
+                        .split(" "));
+                labels.add(edgeIdList.get(1));
+            } else {
+                labels.addAll(graph.getSchema().getEdgeGroups());
+            }
+        });
+
+        return labels;
     }
 
     private IncludeIncomingOutgoingType getInOutType(final Direction direction) {
@@ -1011,14 +1047,13 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         variables.set(GafferPopGraphVariables.USER_ID, defaultUser.getUserId());
         variables.set(GafferPopGraphVariables.DATA_AUTHS, configuration().getStringArray(DATA_AUTHS));
         variables.set(GafferPopGraphVariables.GET_ALL_ELEMENTS_LIMIT,
-            configuration().getInteger(GET_ALL_ELEMENTS_LIMIT, DEFAULT_GET_ALL_ELEMENTS_LIMIT));
+                configuration().getInteger(GET_ALL_ELEMENTS_LIMIT, DEFAULT_GET_ALL_ELEMENTS_LIMIT));
         variables.set(GafferPopGraphVariables.HAS_STEP_FILTER_STAGE,
-            configuration().getString(HAS_STEP_FILTER_STAGE, DEFAULT_HAS_STEP_FILTER_STAGE.toString()));
+                configuration().getString(HAS_STEP_FILTER_STAGE, DEFAULT_HAS_STEP_FILTER_STAGE.toString()));
     }
 
     /**
-     * Gets the next ID to assign to a supplied vertex based on the currently configured
-     * ID manager.
+     * Gets the next ID to assign to a supplied vertex based on the currently configured ID manager.
      *
      * @return Next ID Object
      */

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
@@ -262,7 +262,7 @@ public class GafferPopFederatedIT {
         GraphTraversalSource g = gafferPopGraph.traversal();
 
         // When
-        List<Edge> result = g.E("[p1-created->s1]").toList();
+        List<Edge> result = g.E("[p1, created, s1]").toList();
 
         assertThat(result)
                 .extracting(item -> item.id().toString())

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
@@ -249,11 +249,24 @@ public class GafferPopFederatedIT {
 
         assertThat(result)
                 .extracting(item -> item.id().toString())
-                .containsExactly("[p1, s1]", "[p3, s1]");
+                .containsExactly("[p1, created, s1]", "[p3, created, s1]");
 
         assertThat(result)
                 .extracting(item -> item.label())
                 .containsExactly(CREATED_EDGE_GROUP, CREATED_EDGE_GROUP);
+    }
+
+    @Test
+    void shouldGetEdgesByIdAndLabel() {
+        // Given
+        GraphTraversalSource g = gafferPopGraph.traversal();
+
+        // When
+        List<Edge> result = g.E("[p1-created->s1]").toList();
+
+        assertThat(result)
+                .extracting(item -> item.id().toString())
+                .containsExactly("[p1, created, s1]");
     }
 
     @Test
@@ -267,7 +280,7 @@ public class GafferPopFederatedIT {
         // Then
         assertThat(result)
                 .extracting(item -> item.id().toString())
-                .containsExactlyInAnyOrder("[p1, p2]", "[p1, s1]");
+                .containsExactlyInAnyOrder("[p1, knows, p2]", "[p1, created, s1]");
 
         assertThat(result)
                 .extracting(item -> item.label())
@@ -362,7 +375,7 @@ public class GafferPopFederatedIT {
 
         assertThat(result)
                 .extracting(item -> item.id().toString())
-                .containsExactly("[p4, s2]");
+                .containsExactly("[p4, created, s2]");
 
         assertThat(result)
                 .extracting(item -> item.label())
@@ -381,7 +394,7 @@ public class GafferPopFederatedIT {
         // Then
         assertThat(result)
                 .extracting(item -> item.id().toString())
-                .containsExactly("[p4, s2]");
+                .containsExactly("[p4, created, s2]");
 
         assertThat(result)
                 .extracting(item -> item.label())
@@ -401,7 +414,7 @@ public class GafferPopFederatedIT {
         // Then
         assertThat(result)
                 .extracting(item -> item.id().toString())
-                .containsExactlyInAnyOrder("[p1, p2]", "[p1, s1]");
+                .containsExactlyInAnyOrder("[p1, created, s1]", "[p1, knows, p2]");
 
         assertThat(result)
                 .extracting(item -> item.label())

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
@@ -270,6 +270,37 @@ public class GafferPopFederatedIT {
     }
 
     @Test
+    void shouldGetEdgesByIdNoWhitespace() {
+        // Given
+        GraphTraversalSource g = gafferPopGraph.traversal();
+
+        // When
+        List<Edge> result = g.E("[p1,s1]", "[p3,created,s1]").toList();
+
+        assertThat(result)
+                .extracting(item -> item.id().toString())
+                .containsExactly("[p1, created, s1]", "[p3, created, s1]");
+    }
+
+    @Test
+    void shouldGetEdgesByIdRandomWhitespace() {
+        // Given
+        GraphTraversalSource g = gafferPopGraph.traversal();
+
+        // When
+        List<Edge> result1 = g.E("[ p1  , s1 ]", "[p3 ,created, s1]").toList();
+        List<Edge> result2 = g.E("[ p1,s1 ]", "[ p3 ,created, s1]").toList();
+
+        assertThat(result1)
+                .extracting(item -> item.id().toString())
+                .containsExactly("[p1, created, s1]", "[p3, created, s1]");
+
+        assertThat(result2)
+                .extracting(item -> item.id().toString())
+                .containsExactly("[p1, created, s1]", "[p3, created, s1]");
+    }
+
+    @Test
     void shouldGetOutgoingEdges() {
         // Given
         GraphTraversalSource g = gafferPopGraph.traversal();

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
@@ -376,7 +376,7 @@ public class GafferPopGraphIT {
         // When
         graph.addEdge(edgeToAdd);
 
-        List<Edge> edges = g.E("[" + VERTEX_1 + "-" + CREATED_EDGE_GROUP + "->" + VERTEX_2 + "]").toList();
+        List<Edge> edges = g.E("[1, created, 2]").toList();
 
         // Then
         assertThat(edges)

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
@@ -436,6 +436,7 @@ public class GafferPopGraphIT {
         // Then
         assertThat(edges).toIterable().contains(edgeToAdd1, edgeToAdd2);
     }
+
     @Test
     public void shouldGetEdgeInGroupWithNullView() {
         // Given

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
@@ -362,6 +362,29 @@ public class GafferPopGraphIT {
     }
 
     @Test
+    public void shouldAddAndGetEdgeWithLabelInId() {
+        // Given
+        final Graph gafferGraph = getGafferGraph();
+        final GafferPopGraph graph = GafferPopGraph.open(TEST_CONFIGURATION_1, gafferGraph);
+        final GafferPopVertex gafferPopOutVertex = new GafferPopVertex(GafferPopGraph.ID_LABEL, VERTEX_1, graph);
+        final GafferPopVertex gafferPopInVertex = new GafferPopVertex(GafferPopGraph.ID_LABEL, VERTEX_2, graph);
+        final GafferPopEdge edgeToAdd = new GafferPopEdge(CREATED_EDGE_GROUP, gafferPopOutVertex, gafferPopInVertex,
+                graph);
+        final GraphTraversalSource g = graph.traversal();
+        edgeToAdd.property(WEIGHT_PROPERTY, 1.5);
+
+        // When
+        graph.addEdge(edgeToAdd);
+
+        List<Edge> edges = g.E("[" + VERTEX_1 + "-" + CREATED_EDGE_GROUP + "->" + VERTEX_2 + "]").toList();
+
+        // Then
+        assertThat(edges)
+                .extracting(edge -> edge.toString())
+                .containsExactly(edgeToAdd.toString());
+    }
+
+    @Test
     public void shouldGetEdgeInGroup() {
         // Given
         final Graph gafferGraph = getGafferGraph();

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
@@ -376,7 +376,7 @@ public class GafferPopGraphIT {
         // When
         graph.addEdge(edgeToAdd);
 
-        List<Edge> edges = g.E("[1, created, 2]").toList();
+        List<Edge> edges = g.E("[" + VERTEX_1 + "," + CREATED_EDGE_GROUP + "," + VERTEX_2 + "]").toList();
 
         // Then
         assertThat(edges)

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopHasStepIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopHasStepIT.java
@@ -20,6 +20,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.TextP;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -276,11 +277,11 @@ public class GafferPopHasStepIT {
 
     @Test
     public void shouldGetEdgesByIdAndLabelThenFilterById() {
-        final List<Edge> result = g.E("[4-created->3]").outV().outE().hasId("[4, created, 5]").toList();
+        final List<Edge> result = g.E("[4-created->3]").outV().outE().has(T.id,"[4, created, 5]").toList();
 
         assertThat(result)
-                .extracting(r -> r.id())
-                .containsExactly(JOSH.created(RIPPLE));
+            .extracting(r -> r.id())
+            .containsExactly(JOSH.created(RIPPLE));
     }
 
     @Test

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopHasStepIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopHasStepIT.java
@@ -272,7 +272,7 @@ public class GafferPopHasStepIT {
 
         assertThat(result)
                 .extracting(r -> r.id())
-                .containsExactlyInAnyOrder(MARKO.knows(VADAS), MARKO.knows(JOSH));
+                .containsExactlyInAnyOrder(MARKO.knows(VADAS));
     }
 
     @Test

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopHasStepIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopHasStepIT.java
@@ -266,6 +266,24 @@ public class GafferPopHasStepIT {
     }
 
     @Test
+    public void shouldGetEdgesByIdAndLabelThenFilterByLabel() {
+        final List<Edge> result = g.E("[1-knows->2]").hasLabel("knows").toList();
+
+        assertThat(result)
+                .extracting(r -> r.id())
+                .containsExactlyInAnyOrder(MARKO.knows(VADAS), MARKO.knows(JOSH));
+    }
+
+    @Test
+    public void shouldGetEdgesByIdAndLabelThenFilterById() {
+        final List<Edge> result = g.E("[4-created->3]").outV().outE().hasId("[4, created, 5]").toList();
+
+        assertThat(result)
+                .extracting(r -> r.id())
+                .containsExactly(JOSH.created(RIPPLE));
+    }
+
+    @Test
     public void shouldThrowWhenFilterEdgesByInvalidLabels() {
         // Included this as it's an example from the docs that won't run due to Gaffer limitation
         // Gaffer checks labels in the view are valid before querying

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopHasStepIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopHasStepIT.java
@@ -268,7 +268,7 @@ public class GafferPopHasStepIT {
 
     @Test
     public void shouldGetEdgesByIdAndLabelThenFilterByLabel() {
-        final List<Edge> result = g.E("[1-knows->2]").hasLabel("knows").toList();
+        final List<Edge> result = g.E("[1, knows, 2]").hasLabel("knows").toList();
 
         assertThat(result)
                 .extracting(r -> r.id())
@@ -277,7 +277,7 @@ public class GafferPopHasStepIT {
 
     @Test
     public void shouldGetEdgesByIdAndLabelThenFilterById() {
-        final List<Edge> result = g.E("[4-created->3]").outV().outE().has(T.id,"[4, created, 5]").toList();
+        final List<Edge> result = g.E("[4, created, 3]").outV().outE().has(T.id, "[4, created, 5]").toList();
 
         assertThat(result)
             .extracting(r -> r.id())

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/util/GafferPopModernTestUtils.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/util/GafferPopModernTestUtils.java
@@ -176,7 +176,7 @@ public final class GafferPopModernTestUtils {
          */
         public List<List<String>> knowsEdges() {
             return knows.stream()
-                .map(e -> Arrays.asList(this.getId(), e.getFirst().getId()))
+                .map(e -> Arrays.asList(this.getId(), KNOWS, e.getFirst().getId()))
                 .collect(Collectors.toList());
         }
 
@@ -187,7 +187,7 @@ public final class GafferPopModernTestUtils {
          * @return Returns an EdgeId
          */
         public List<String> knows(Person otherPerson) {
-            return Arrays.asList(this.getId(), otherPerson.getId());
+            return Arrays.asList(this.getId(), KNOWS, otherPerson.getId());
         }
 
         public void setCreated(Pair<Software, Double> ... software) {
@@ -218,7 +218,7 @@ public final class GafferPopModernTestUtils {
          * @return Returns an EdgeId
          */
         public List<String> created(Software software) {
-            return Arrays.asList(this.getId(), software.getId());
+            return Arrays.asList(this.getId(), CREATED, software.getId());
         }
     }
 


### PR DESCRIPTION
Able to now query edges with the id in format [1, knows, 2] in addition to [1, 2]. If the label is included this is used in the GetElements View.

Label also added to the returned edge id.

# Related issue

- Resolve #3223