### PR TITLE
Gh-3232: Fix broken links in READMEs

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -38,6 +38,20 @@ jobs:
       - name: Run Spotless copyright check
         run: mvn -ntp spotless:check -T0.5C
 
+  check-markdown-links:
+    name: Check Markdown Links
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run linkspector
+        uses: umbrelladocs/action-linkspector@v1
+        with:
+          filter_mode: nofilter
+          reporter: github-pr-annotations
+          fail_on_error: true
+
   build-javadoc:
     name: Build Javadoc
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Gaffer offers:
  - Retrieval of graph data into Apache Spark for fast and flexible analysis
  - A fully-featured REST API
 
-To get going with Gaffer, visit our getting started pages ([1.x](https://gchq.github.io/gaffer-doc/v1docs/summaries/getting-started.html), [2.x](https://gchq.github.io/gaffer-doc/latest/getting-started/quickstart/)).
+To get going with Gaffer, visit our getting started pages ([1.x](https://gchq.github.io/gaffer-doc/v1docs/summaries/getting-started.html), [2.x](https://gchq.github.io/gaffer-doc/latest/administration-guide/gaffer-deployment/quickstart)).
 We also have a demo available to try that is based around a small uk road use dataset. See the example/road-traffic [README](https://github.com/gchq/Gaffer/blob/master/example/road-traffic/README.md) to try it out.
 
 Gaffer is under active development. Version 1.0 of Gaffer was released in October 2017, version 2.0 was released in May 2023.
@@ -51,7 +51,7 @@ To build Gaffer run `mvn clean install -Pquick` in the top-level directory. This
 
 ### Contribution Process
 
-Detailed information on our ways of working can be found [in our developer docs](https://gchq.github.io/gaffer-doc/latest/dev/ways-of-working/). In brief:
+Detailed information on our ways of working can be found [in our developer docs](https://gchq.github.io/gaffer-doc/latest/development-guide/ways-of-working). In brief:
 
 - Sign the [GCHQ Contributor Licence Agreement](https://cla-assistant.io/gchq/Gaffer)
 - Push your changes to a fork

--- a/core/cache/README.md
+++ b/core/cache/README.md
@@ -1,5 +1,5 @@
 # Cache
 
-For information on using the Cache, see [the Cache section of the Stores guide on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/reference/stores-guide/stores/#caches).
+For information on using the Cache, see [the Cache section of the Stores guide on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/administration-guide/gaffer-stores/store-guide.html#caches).
 
-For implementation details, see [the Cache page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/dev/components/cache/).
+For implementation details, see [the Cache page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/development-guide/project-structure/components/cache).

--- a/core/data/README.md
+++ b/core/data/README.md
@@ -1,3 +1,3 @@
 # Data
 
-For implementation details, see [the Data page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/dev/components/data/).
+For implementation details, see [the Data page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/development-guide/project-structure/components/data).

--- a/core/graph/README.md
+++ b/core/graph/README.md
@@ -1,3 +1,3 @@
 # Graph
 
-For implementation details, see [the Graph page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/dev/components/graph/).
+For implementation details, see [the Graph page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/development-guide/project-structure/components/graph).

--- a/core/operation/README.md
+++ b/core/operation/README.md
@@ -1,5 +1,5 @@
 # Operation
 
-For information on the use Gaffer Operations, see [the user guide on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/getting-started/basics/).
+For information on the use Gaffer Operations, see [the user guide on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/user-guide/introduction).
 
-For implementation details, see [the Operation page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/dev/components/operation/).
+For implementation details, see [the Operation page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/development-guide/project-structure/components/operation).

--- a/core/serialisation/README.md
+++ b/core/serialisation/README.md
@@ -1,3 +1,3 @@
 # Serialisation
 
-For implementation details, see [the Serialisation page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/dev/components/serialisation/).
+For implementation details, see [the Serialisation page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/development-guide/project-structure/components/serialisation).

--- a/core/store/README.md
+++ b/core/store/README.md
@@ -1,5 +1,5 @@
 # Store
 
-For information on the Gaffer Stores, see [the Store guide on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/reference/stores-guide/stores/).
+For information on the Gaffer Stores, see [the Store guide on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/administration-guide/gaffer-stores/store-guide).
 
-For some details on implementing a new store see the [Store developer documentation](https://gchq.github.io/gaffer-doc/latest/dev/components/store/).
+For some details on implementing a new store see the [Store developer documentation](https://gchq.github.io/gaffer-doc/latest/development-guide/project-structure/components/store).

--- a/example/road-traffic/README.md
+++ b/example/road-traffic/README.md
@@ -33,7 +33,7 @@ cd Gaffer
 
 The rest api will be deployed to localhost:8080/rest.
 
-The sample data used is taken from the Department for Transport [GB Road Traffic Counts](https://roadtraffic.dft.gov.uk/downloads) - [Major Roads](https://data.dft.gov.uk/gb-traffic-matrix/Raw_count_data_major_roads.zip), which is licensed under the [Open Government Licence](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).
+The sample data used is taken from the Department for Transport [GB Road Traffic Counts](https://roadtraffic.dft.gov.uk/downloads) (`https://data.dft.gov.uk/gb-traffic-matrix/Raw_count_data_major_roads.zip`), which is licensed under the [Open Government Licence](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).
 
 This data contains information about UK roads, their locations and hourly traffic flow between adjacent road junctions.
 

--- a/example/road-traffic/README.md
+++ b/example/road-traffic/README.md
@@ -33,7 +33,7 @@ cd Gaffer
 
 The rest api will be deployed to localhost:8080/rest.
 
-The sample data used is taken from the Department for Transport [GB Road Traffic Counts](http://data.dft.gov.uk/gb-traffic-matrix/Raw_count_data_major_roads.zip), which is licensed under the [Open Government Licence](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).
+The sample data used is taken from the Department for Transport [GB Road Traffic Counts](https://roadtraffic.dft.gov.uk/downloads) - [Major Roads](https://data.dft.gov.uk/gb-traffic-matrix/Raw_count_data_major_roads.zip), which is licensed under the [Open Government Licence](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).
 
 This data contains information about UK roads, their locations and hourly traffic flow between adjacent road junctions.
 

--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -1,3 +1,3 @@
 # Integration Test
 
-For implementation details, see [the Integration Test page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/dev/components/integration-test/).
+For implementation details, see [the Integration Test page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/development-guide/project-structure/components/integration-test).

--- a/library/bitmap-library/README.md
+++ b/library/bitmap-library/README.md
@@ -1,3 +1,3 @@
 # Bitmap Library
 
-For implementation details, see [the Bitmap Library page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/dev/components/libraries/bitmap/).
+For implementation details, see [the Bitmap Library page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/development-guide/project-structure/components/libraries/bitmap).

--- a/library/flink-library/README.md
+++ b/library/flink-library/README.md
@@ -1,5 +1,5 @@
 # Flink Library
 
-For information on the Flink Operations provided by this library, see [the Flink Operations page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/reference/operations-guide/flink/).
+For information on the Flink Operations provided by this library, see [the Flink Operations page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/reference/operations-guide/flink).
 
-For implementation details, see [the Flink Library page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/dev/components/libraries/flink/).
+For implementation details, see [the Flink Library page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/development-guide/project-structure/components/libraries/flink).

--- a/library/sketches-library/README.md
+++ b/library/sketches-library/README.md
@@ -1,5 +1,5 @@
 # Sketches Library
 
-For information on using the Sketches provided by this library, see [the Cardinality guide on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/getting-started/guide/cardinality/).
+For information on using the Sketches provided by this library, see [the Cardinality guide on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/user-guide/gaffer-basics/what-is-cardinality).
 
-For implementation details, see [the Sketches Library page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/dev/components/libraries/sketches/).
+For implementation details, see [the Sketches Library page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/development-guide/project-structure/components/libraries/sketches).

--- a/library/spark/README.md
+++ b/library/spark/README.md
@@ -1,5 +1,5 @@
 # Spark Library
 
-For information on the Spark Operations provided by this library, see [the Spark Operations page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/reference/operations-guide/spark/).
+For information on the Spark Operations provided by this library, see [the Spark Operations page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/reference/operations-guide/spark).
 
-For implementation details, see [the Spark Library page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/dev/components/libraries/spark/).
+For implementation details, see [the Spark Library page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/dev/components/libraries/spark).

--- a/library/time-library/README.md
+++ b/library/time-library/README.md
@@ -1,3 +1,3 @@
 # Time Library
 
-For implementation details, see [the Time Library page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/dev/components/libraries/time/).
+For implementation details, see [the Time Library page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/development-guide/project-structure/components/libraries/time).

--- a/library/tinkerpop/README.md
+++ b/library/tinkerpop/README.md
@@ -10,6 +10,6 @@ unknown in comparison to using standard Gaffer `OperationChains`.
 Please see the [official Gaffer documentation](https://gchq.github.io/gaffer-doc/latest/)
 for more information on the current GafferPop implementation, some useful links are as follows:
 
-- [Set up a Gremlin console connection using GafferPop](https://gchq.github.io/gaffer-doc/latest/administration-guide/gaffer-deployment/gremlin/).
-- [Basic Gremlin querying guide](https://gchq.github.io/gaffer-doc/latest/user-guide/query/gremlin/gremlin/).
-- [Current limitations of the GafferPop implementation](https://gchq.github.io/gaffer-doc/latest/user-guide/query/gremlin/gremlin-limits/).
+- [Set up a Gremlin console connection using GafferPop](https://gchq.github.io/gaffer-doc/latest/administration-guide/gaffer-deployment/gremlin).
+- [Basic Gremlin querying guide](https://gchq.github.io/gaffer-doc/latest/user-guide/query/gremlin/gremlin).
+- [Current limitations of the GafferPop implementation](https://gchq.github.io/gaffer-doc/latest/user-guide/query/gremlin/gremlin-limits).

--- a/rest-api/core-rest/README.md
+++ b/rest-api/core-rest/README.md
@@ -1,3 +1,3 @@
 # Core REST API
 
-For implementation details, see [the Core REST API page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/dev/components/core-rest/).
+For implementation details, see [the Core REST API page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/development-guide/project-structure/components/core-rest).

--- a/rest-api/spring-rest/README.md
+++ b/rest-api/spring-rest/README.md
@@ -1,3 +1,3 @@
 # Spring REST API
 
-For implementation details, see [the Spring REST API page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/dev/components/spring-rest/).
+For implementation details, see [the Spring REST API page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/development-guide/project-structure/components/spring-rest).

--- a/store-implementation/accumulo-store/README.md
+++ b/store-implementation/accumulo-store/README.md
@@ -1,5 +1,5 @@
 # Accumulo Store
 
-For information on the Accumulo Store, see [the Accumulo Store page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/reference/stores-guide/accumulo/).
+For information on the Accumulo Store, see [the Accumulo Store page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/administration-guide/gaffer-stores/accumulo-store).
 
-For implementation details, see [the Accumulo Store implementation page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/dev/components/accumulo-store/).
+For implementation details, see [the Accumulo Store implementation page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/development-guide/project-structure/components/accumulo-store).

--- a/store-implementation/federated-store/README.md
+++ b/store-implementation/federated-store/README.md
@@ -1,3 +1,3 @@
 # Federated Store
 
-For information on the Federated Store, see [the Federated Store page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/reference/stores-guide/federated/).
+For information on the Federated Store, see [the Federated Store page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/administration-guide/gaffer-stores/federated-store).

--- a/store-implementation/map-store/README.md
+++ b/store-implementation/map-store/README.md
@@ -1,3 +1,3 @@
 # Map Store
 
-For information on the Map Store, see [the Map Store page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/reference/stores-guide/map/).
+For information on the Map Store, see [the Map Store page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/administration-guide/gaffer-stores/map-store).

--- a/store-implementation/proxy-store/README.md
+++ b/store-implementation/proxy-store/README.md
@@ -1,3 +1,3 @@
 # Proxy Store
 
-For information on the Proxy Store, see [the Proxy Store page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/reference/stores-guide/proxy/).
+For information on the Proxy Store, see [the Proxy Store page on the Gaffer Documentation site](https://gchq.github.io/gaffer-doc/latest/administration-guide/gaffer-stores/proxy-store).


### PR DESCRIPTION
Also adds CI check to avoid future broken links

# Related issue

- Resolve #3232