### PR TITLE
Gh-3234: TypeSubTypeValue Seeded Query Support in GafferPop

### DIFF
--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -981,15 +981,13 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                         .split(","));
             // Assume entity ID as fallback
             } else {
-                seeds.add(new EntitySeed((getTSTVFromID(id) != null) ? getTSTVFromID(id) : id));
+                seeds.add(new EntitySeed(getIDAsRelevantType(id)));
             }
 
             // If found a list verify source and destination
             if (edgeIdList.size() == 2) {
-                Object source = (getTSTVFromID(edgeIdList.get(0)) != null) ?
-                    getTSTVFromID(edgeIdList.get(0)) : edgeIdList.get(0);
-                Object dest = (getTSTVFromID(edgeIdList.get(1)) != null) ?
-                    getTSTVFromID(edgeIdList.get(1)) : edgeIdList.get(1);
+                Object source = getIDAsRelevantType(edgeIdList.get(0));
+                Object dest = getIDAsRelevantType(edgeIdList.get(1));
                 seeds.add(new EdgeSeed(source, dest));
             }
         });
@@ -998,21 +996,23 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
     }
 
     /**
-     * Returns a new {@link TypeSubTypeValue} (TSTV) from the supplied
-     * ID if valid.
+     * Returns a the relevant Object e.g. {@link TypeSubTypeValue} from the
+     * supplied ID. As a fallback will give back the original ID if no
+     * relevant type was found.
      *
-     * @param id The ID
-     * @return The TSTV or null
+     * @param id The ID.
+     * @return The ID as its relevant type.
      */
-    private TypeSubTypeValue getTSTVFromID(Object id) {
+    private Object getIDAsRelevantType(Object id) {
         if (id instanceof String) {
+            // See if can split into a TSTV
             String[] split = ((String) id).split("\\|");
             if (split.length == 3) {
                 LOGGER.debug("Parsing ID as a TSTV: {}", id);
                 return new TypeSubTypeValue(split[0], split[1], split[2]);
             }
         }
-        return null;
+        return id;
     }
 
     private IncludeIncomingOutgoingType getInOutType(final Direction direction) {

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -248,7 +248,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GafferPopGraph.class);
     private static final String GET_ALL_DEBUG_MSG = "Requested a GetAllElements, results will be truncated to: {}.";
-    private static final Pattern TSTV_REGEX =  Pattern.compile("^tstv:(?<type>[A-Za-z0-9-]*)\\|(?<stype>[A-Za-z0-9-]*)\\|(?<val>[A-Za-z0-9-]*)$");
+    private static final Pattern TSTV_REGEX =  Pattern.compile("^t:(?<type>.*)\\|st:(?<stype>.*)\\|v:(?<val>.*)$");
 
     public GafferPopGraph(final Configuration configuration) {
         this(configuration, createGraph(configuration));

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -1003,7 +1003,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * @param id The ID.
      * @return The ID as its relevant type.
      */
-    private Object getIDAsRelevantType(Object id) {
+    private Object getIDAsRelevantType(final Object id) {
         if (id instanceof String) {
             // See if can split into a TSTV
             String[] split = ((String) id).split("\\|");

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
@@ -310,7 +310,7 @@ public class GafferPopGraphIT {
         final GafferPopGraph graph = GafferPopGraph.open(TEST_CONFIGURATION_1, gafferGraph);
         final TypeSubTypeValue testId = new TypeSubTypeValue("test", "test", "test");
         final GraphTraversalSource g = graph.traversal();
-        
+
         // When
         // Add a vertex then do a seeded query for it
         graph.addVertex(T.label, TSTV_GROUP, T.id, testId);

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
@@ -314,7 +314,7 @@ public class GafferPopGraphIT {
         // When
         // Add a vertex then do a seeded query for it
         graph.addVertex(T.label, TSTV_GROUP, T.id, testId);
-        List<Vertex> result = g.V("test|test|test")
+        List<Vertex> result = g.V("tstv:test|test|test")
             .toList();
 
         // Then

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
@@ -28,11 +28,13 @@ import uk.gov.gchq.gaffer.accumulostore.AccumuloProperties;
 import uk.gov.gchq.gaffer.commonutil.StreamUtil;
 import uk.gov.gchq.gaffer.data.elementdefinition.view.View;
 import uk.gov.gchq.gaffer.graph.Graph;
+import uk.gov.gchq.gaffer.graph.GraphConfig;
 import uk.gov.gchq.gaffer.operation.OperationChain;
 import uk.gov.gchq.gaffer.operation.impl.add.AddElementsFromSocket;
 import uk.gov.gchq.gaffer.operation.impl.get.GetElements;
 import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph.HasStepFilterStage;
 import uk.gov.gchq.gaffer.tinkerpop.util.GafferPopTestUtil;
+import uk.gov.gchq.gaffer.types.TypeSubTypeValue;
 import uk.gov.gchq.gaffer.user.User;
 
 import java.util.ArrayList;
@@ -57,6 +59,7 @@ public class GafferPopGraphIT {
     public static final String VERTEX_2 = "2";
     public static final String SOFTWARE_NAME_GROUP = "software";
     public static final String PERSON_GROUP = "person";
+    public static final String TSTV_GROUP = "tstv";
     public static final String DEPENDS_ON_EDGE_GROUP = "dependsOn";
     public static final String CREATED_EDGE_GROUP = "created";
     public static final String NAME_PROPERTY = "name";
@@ -292,6 +295,31 @@ public class GafferPopGraphIT {
 
         // Then
         testSoftwareVertex(vertices);
+    }
+
+    @Test
+    void shouldGetVerticesWithTSTV() {
+        // Given
+        final Graph gafferGraph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId("tstvGraph")
+                        .build())
+                .storeProperties(PROPERTIES)
+                .addSchemas(StreamUtil.openStreams(this.getClass(), "/gaffer/tstv-schema"))
+                .build();
+        final GafferPopGraph graph = GafferPopGraph.open(TEST_CONFIGURATION_1, gafferGraph);
+        final TypeSubTypeValue testId = new TypeSubTypeValue("test", "test", "test");
+        final GraphTraversalSource g = graph.traversal();
+        
+        // When
+        // Add a vertex then do a seeded query for it
+        graph.addVertex(T.label, TSTV_GROUP, T.id, testId);
+        List<Vertex> result = g.V("test|test|test")
+            .toList();
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0)).extracting(vertex -> vertex.id()).isEqualTo(testId);
     }
 
     @Test

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
@@ -314,7 +314,7 @@ public class GafferPopGraphIT {
         // When
         // Add a vertex then do a seeded query for it
         graph.addVertex(T.label, TSTV_GROUP, T.id, testId);
-        List<Vertex> result = g.V("tstv:test|test|test")
+        List<Vertex> result = g.V("t:test|st:test|v:test")
             .toList();
 
         // Then

--- a/library/tinkerpop/src/test/resources/gaffer/tstv-schema/elements.json
+++ b/library/tinkerpop/src/test/resources/gaffer/tstv-schema/elements.json
@@ -1,0 +1,17 @@
+{
+    "entities": {
+        "tstv": {
+            "vertex": "tstv"
+        }
+    },
+    "edges": {
+        "test": {
+            "source": "tstv",
+            "destination": "tstv",
+            "directed": "true",
+            "properties": {
+                "weight": "weight.double"
+            }
+        }
+    }
+}

--- a/library/tinkerpop/src/test/resources/gaffer/tstv-schema/types.json
+++ b/library/tinkerpop/src/test/resources/gaffer/tstv-schema/types.json
@@ -1,0 +1,19 @@
+{
+  "types": {
+    "tstv": {
+      "class": "uk.gov.gchq.gaffer.types.TypeSubTypeValue",
+      "serialiser": {
+        "class": "uk.gov.gchq.gaffer.serialisation.TypeSubTypeValueSerialiser"
+      }
+    },
+    "true": {
+      "class": "java.lang.Boolean"
+    },
+    "weight.double": {
+      "class": "java.lang.Double",
+      "aggregateFunction": {
+        "class": "uk.gov.gchq.koryphe.impl.binaryoperator.First"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds basic support for seeding queries in GafferPop with TypeSubTypeValues by parsing specific string formats separated via a `|` to construct the correct object to seed the query with. 

As an example `g.V("t:type|st:sub|v:value")` -> `new TypeSubTypeValue("type", "sub", "value")`

# Related issue

- Resolve #3234