### PR TITLE
Gh-3241: Swagger UI not always using correct server URL

### DIFF
--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/GafferWebApplication.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/GafferWebApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Crown Copyright
+ * Copyright 2020-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,14 @@
 
 package uk.gov.gchq.gaffer.rest;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
+@OpenAPIDefinition(servers = {
+    @Server(url = "/rest", description = "Default Server URL") })
 @SpringBootApplication
 public class GafferWebApplication extends SpringBootServletInitializer {
 


### PR DESCRIPTION
Fixes a small bug with the swagger UI not picking up the correct URL and using http in some cases.

# Related issue

- Resolve #3241