### PR TITLE
Make gremlin config message clearer

### DIFF
--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/config/GremlinConfig.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/config/GremlinConfig.java
@@ -44,7 +44,7 @@ public class GremlinConfig {
         // Determine where to look for the GafferPop properties
         String gafferPopProperties = graphFactory.getGraph().getStoreProperties().get(GafferPopGraph.GAFFERPOP_PROPERTIES);
         if (gafferPopProperties == null) {
-            LOGGER.warn("GafferPop properties file was not specified using default location: {}", DEFAULT_PROPERTIES);
+            LOGGER.warn("GafferPop properties file was not specified. Using default location: {}", DEFAULT_PROPERTIES);
             gafferPopProperties = DEFAULT_PROPERTIES;
         }
         // Obtain the graph traversal


### PR DESCRIPTION
I thought this was saying it wasn't finding the config at the default location