### PR TITLE
Gh-3270: Make DeleteAllData a core operation

### DIFF
--- a/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphTest.java
+++ b/core/graph/src/test/java/uk/gov/gchq/gaffer/graph/GraphTest.java
@@ -81,6 +81,7 @@ import uk.gov.gchq.gaffer.store.StoreTrait;
 import uk.gov.gchq.gaffer.store.TestTypes;
 import uk.gov.gchq.gaffer.store.library.GraphLibrary;
 import uk.gov.gchq.gaffer.store.library.HashMapGraphLibrary;
+import uk.gov.gchq.gaffer.store.operation.DeleteAllData;
 import uk.gov.gchq.gaffer.store.operation.GetTraits;
 import uk.gov.gchq.gaffer.store.operation.handler.GetTraitsHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
@@ -2716,6 +2717,11 @@ public class GraphTest {
 
         @Override
         protected OperationHandler<? extends DeleteElements> getDeleteElementsHandler() {
+            return null;
+        }
+
+        @Override
+        protected OperationHandler<DeleteAllData> getDeleteAllDataHandler() {
             return null;
         }
 

--- a/core/graph/src/test/java/uk/gov/gchq/gaffer/integration/store/TestStore.java
+++ b/core/graph/src/test/java/uk/gov/gchq/gaffer/integration/store/TestStore.java
@@ -32,6 +32,7 @@ import uk.gov.gchq.gaffer.serialisation.ToBytesSerialiser;
 import uk.gov.gchq.gaffer.store.Context;
 import uk.gov.gchq.gaffer.store.Store;
 import uk.gov.gchq.gaffer.store.StoreTrait;
+import uk.gov.gchq.gaffer.store.operation.DeleteAllData;
 import uk.gov.gchq.gaffer.store.operation.GetTraits;
 import uk.gov.gchq.gaffer.store.operation.handler.GetTraitsHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
@@ -86,6 +87,11 @@ public class TestStore extends Store {
 
     @Override
     protected OperationHandler<? extends DeleteElements> getDeleteElementsHandler() {
+        return null;
+    }
+
+    @Override
+    protected OperationHandler<DeleteAllData> getDeleteAllDataHandler() {
         return null;
     }
 

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/Store.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/Store.java
@@ -98,6 +98,7 @@ import uk.gov.gchq.gaffer.operation.io.Output;
 import uk.gov.gchq.gaffer.serialisation.Serialiser;
 import uk.gov.gchq.gaffer.store.library.GraphLibrary;
 import uk.gov.gchq.gaffer.store.library.NoGraphLibrary;
+import uk.gov.gchq.gaffer.store.operation.DeleteAllData;
 import uk.gov.gchq.gaffer.store.operation.GetSchema;
 import uk.gov.gchq.gaffer.store.operation.GetTraits;
 import uk.gov.gchq.gaffer.store.operation.HasTrait;
@@ -897,6 +898,14 @@ public abstract class Store {
     protected abstract OperationHandler<? extends DeleteElements> getDeleteElementsHandler();
 
     /**
+     * Get this Store's implementation of the handler for {@link uk.gov.gchq.gaffer.operation.DeleteAllData}.
+     * All Stores must implement this.
+     *
+     * @return the implementation of the handler for {@link uk.gov.gchq.gaffer.operation.DeleteAllData}
+     */
+    protected abstract OperationHandler<DeleteAllData> getDeleteAllDataHandler();
+
+    /**
      * Get this Store's implementation of the handler for {@link uk.gov.gchq.gaffer.store.operation.GetTraits}.
      * All Stores must implement this.
      *
@@ -1016,6 +1025,9 @@ public abstract class Store {
 
         // Delete elements
         addOperationHandler(DeleteElements.class, getDeleteElementsHandler());
+
+        // Delete all data
+        addOperationHandler(DeleteElements.class, getDeleteAllDataHandler());
 
         // Get Elements
         addOperationHandler(GetElements.class, getGetElementsHandler());

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/Store.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/Store.java
@@ -1027,7 +1027,7 @@ public abstract class Store {
         addOperationHandler(DeleteElements.class, getDeleteElementsHandler());
 
         // Delete all data
-        addOperationHandler(DeleteElements.class, getDeleteAllDataHandler());
+        addOperationHandler(DeleteAllData.class, getDeleteAllDataHandler());
 
         // Get Elements
         addOperationHandler(GetElements.class, getGetElementsHandler());

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/StoreTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/StoreTest.java
@@ -112,6 +112,7 @@ import uk.gov.gchq.gaffer.serialisation.implementation.StringSerialiser;
 import uk.gov.gchq.gaffer.serialisation.implementation.tostring.StringToStringSerialiser;
 import uk.gov.gchq.gaffer.store.Store.ScheduledJobRunnable;
 import uk.gov.gchq.gaffer.store.library.GraphLibrary;
+import uk.gov.gchq.gaffer.store.operation.DeleteAllData;
 import uk.gov.gchq.gaffer.store.operation.GetSchema;
 import uk.gov.gchq.gaffer.store.operation.GetTraits;
 import uk.gov.gchq.gaffer.store.operation.HasTrait;
@@ -1176,6 +1177,11 @@ public class StoreTest {
         }
 
         @Override
+        protected OperationHandler<DeleteAllData> getDeleteAllDataHandler() {
+            return null;
+        }
+
+        @Override
         protected OutputOperationHandler<GetTraits, Set<StoreTrait>> getGetTraitsHandler() {
             return new GetTraitsHandler(traits);
         }
@@ -1268,6 +1274,11 @@ public class StoreTest {
 
         @Override
         protected OperationHandler<? extends DeleteElements> getDeleteElementsHandler() {
+            return null;
+        }
+
+        @Override
+        protected OperationHandler<DeleteAllData> getDeleteAllDataHandler() {
             return null;
         }
 
@@ -1373,6 +1384,11 @@ public class StoreTest {
 
         @Override
         protected OperationHandler<? extends DeleteElements> getDeleteElementsHandler() {
+            return null;
+        }
+
+        @Override
+        protected OperationHandler<DeleteAllData> getDeleteAllDataHandler() {
             return null;
         }
 

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/integration/StoreIT.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/integration/StoreIT.java
@@ -36,6 +36,7 @@ import uk.gov.gchq.gaffer.store.Store;
 import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.store.StoreProperties;
 import uk.gov.gchq.gaffer.store.StoreTrait;
+import uk.gov.gchq.gaffer.store.operation.DeleteAllData;
 import uk.gov.gchq.gaffer.store.operation.GetTraits;
 import uk.gov.gchq.gaffer.store.operation.handler.GetTraitsHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
@@ -145,6 +146,11 @@ public class StoreIT {
 
         @Override
         protected OperationHandler<? extends DeleteElements> getDeleteElementsHandler() {
+            return null;
+        }
+
+        @Override
+        protected OperationHandler<DeleteAllData> getDeleteAllDataHandler() {
             return null;
         }
 

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/TestAddToGraphLibraryImpl.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/operation/handler/TestAddToGraphLibraryImpl.java
@@ -27,6 +27,7 @@ import uk.gov.gchq.gaffer.serialisation.Serialiser;
 import uk.gov.gchq.gaffer.serialisation.ToBytesSerialiser;
 import uk.gov.gchq.gaffer.store.Store;
 import uk.gov.gchq.gaffer.store.StoreTrait;
+import uk.gov.gchq.gaffer.store.operation.DeleteAllData;
 import uk.gov.gchq.gaffer.store.operation.GetTraits;
 
 import java.util.HashSet;
@@ -54,6 +55,11 @@ public class TestAddToGraphLibraryImpl extends Store {
 
     @Override
     protected OperationHandler<? extends AddElements> getAddElementsHandler() {
+        return null;
+    }
+
+    @Override
+    protected OperationHandler<DeleteAllData> getDeleteAllDataHandler() {
         return null;
     }
 

--- a/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/AccumuloStore.java
+++ b/store-implementation/accumulo-store/src/main/java/uk/gov/gchq/gaffer/accumulostore/AccumuloStore.java
@@ -43,6 +43,7 @@ import uk.gov.gchq.gaffer.accumulostore.key.AccumuloKeyPackage;
 import uk.gov.gchq.gaffer.accumulostore.key.exception.AccumuloElementConversionException;
 import uk.gov.gchq.gaffer.accumulostore.key.exception.IteratorSettingException;
 import uk.gov.gchq.gaffer.accumulostore.operation.handler.AddElementsHandler;
+import uk.gov.gchq.gaffer.accumulostore.operation.handler.DeleteAllDataHandler;
 import uk.gov.gchq.gaffer.accumulostore.operation.handler.DeleteElementsHandler;
 import uk.gov.gchq.gaffer.accumulostore.operation.handler.GenerateSplitPointsFromSampleHandler;
 import uk.gov.gchq.gaffer.accumulostore.operation.handler.GetAdjacentIdsHandler;
@@ -93,6 +94,7 @@ import uk.gov.gchq.gaffer.store.Store;
 import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.store.StoreProperties;
 import uk.gov.gchq.gaffer.store.StoreTrait;
+import uk.gov.gchq.gaffer.store.operation.DeleteAllData;
 import uk.gov.gchq.gaffer.store.operation.GetTraits;
 import uk.gov.gchq.gaffer.store.operation.handler.GetTraitsHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
@@ -420,6 +422,11 @@ public class AccumuloStore extends Store {
     @Override
     protected OperationHandler<? extends DeleteElements> getDeleteElementsHandler() {
         return new DeleteElementsHandler();
+    }
+
+    @Override
+    protected OperationHandler<DeleteAllData> getDeleteAllDataHandler() {
+        return new DeleteAllDataHandler();
     }
 
     /**

--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/FederatedStore.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/FederatedStore.java
@@ -556,7 +556,7 @@ public class FederatedStore extends Store {
 
     @Override
     protected OperationHandler<DeleteAllData> getDeleteAllDataHandler() {
-        return null;
+        return new FederatedNoOutputHandler<>();
     }
 
     @Override
@@ -564,7 +564,6 @@ public class FederatedStore extends Store {
         return new FederatedOutputIterableHandler<>();
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     protected OperationHandler<? extends AddElements> getAddElementsHandler() {
         return new FederatedNoOutputHandler<>();

--- a/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/FederatedStore.java
+++ b/store-implementation/federated-store/src/main/java/uk/gov/gchq/gaffer/federatedstore/FederatedStore.java
@@ -81,6 +81,7 @@ import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.store.StoreProperties;
 import uk.gov.gchq.gaffer.store.StoreTrait;
 import uk.gov.gchq.gaffer.store.library.GraphLibrary;
+import uk.gov.gchq.gaffer.store.operation.DeleteAllData;
 import uk.gov.gchq.gaffer.store.operation.GetSchema;
 import uk.gov.gchq.gaffer.store.operation.GetTraits;
 import uk.gov.gchq.gaffer.store.operation.OperationChainValidator;
@@ -551,6 +552,11 @@ public class FederatedStore extends Store {
     @Override
     protected OperationHandler<? extends DeleteElements> getDeleteElementsHandler() {
         return new FederatedNoOutputHandler<>();
+    }
+
+    @Override
+    protected OperationHandler<DeleteAllData> getDeleteAllDataHandler() {
+        return null;
     }
 
     @Override

--- a/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/operation/handler/impl/FederatedGetTraitsHandlerTest.java
+++ b/store-implementation/federated-store/src/test/java/uk/gov/gchq/gaffer/federatedstore/operation/handler/impl/FederatedGetTraitsHandlerTest.java
@@ -40,6 +40,7 @@ import uk.gov.gchq.gaffer.store.Store;
 import uk.gov.gchq.gaffer.store.StoreProperties;
 import uk.gov.gchq.gaffer.store.StoreTrait;
 import uk.gov.gchq.gaffer.store.library.HashMapGraphLibrary;
+import uk.gov.gchq.gaffer.store.operation.DeleteAllData;
 import uk.gov.gchq.gaffer.store.operation.GetTraits;
 import uk.gov.gchq.gaffer.store.operation.handler.GetTraitsHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
@@ -288,7 +289,12 @@ public class FederatedGetTraitsHandlerTest {
 
         @Override
         protected OperationHandler<? extends DeleteElements> getDeleteElementsHandler() {
-                return null;
+            return null;
+        }
+
+        @Override
+        protected OperationHandler<DeleteAllData> getDeleteAllDataHandler() {
+            return null;
         }
 
         @Override

--- a/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/MapStore.java
+++ b/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/MapStore.java
@@ -24,6 +24,7 @@ import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.id.EntityId;
 import uk.gov.gchq.gaffer.mapstore.impl.AddElementsHandler;
 import uk.gov.gchq.gaffer.mapstore.impl.CountAllElementsDefaultViewHandler;
+import uk.gov.gchq.gaffer.mapstore.impl.DeleteAllDataHandler;
 import uk.gov.gchq.gaffer.mapstore.impl.DeleteElementsHandler;
 import uk.gov.gchq.gaffer.mapstore.impl.GetAdjacentIdsHandler;
 import uk.gov.gchq.gaffer.mapstore.impl.GetAllElementsHandler;
@@ -45,6 +46,7 @@ import uk.gov.gchq.gaffer.store.Store;
 import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.store.StoreProperties;
 import uk.gov.gchq.gaffer.store.StoreTrait;
+import uk.gov.gchq.gaffer.store.operation.DeleteAllData;
 import uk.gov.gchq.gaffer.store.operation.GetTraits;
 import uk.gov.gchq.gaffer.store.operation.handler.GetTraitsHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
@@ -176,6 +178,11 @@ public class MapStore extends Store {
     @Override
     protected OperationHandler<? extends DeleteElements> getDeleteElementsHandler() {
         return new DeleteElementsHandler();
+    }
+
+    @Override
+    protected OperationHandler<DeleteAllData> getDeleteAllDataHandler() {
+        return new DeleteAllDataHandler();
     }
 
     @Override

--- a/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/SingleUseMapStoreWithoutVisibilitySupport.java
+++ b/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/SingleUseMapStoreWithoutVisibilitySupport.java
@@ -26,11 +26,12 @@ import java.util.Set;
 
 public class SingleUseMapStoreWithoutVisibilitySupport extends SingleUseMapStore {
 
-    private static final Set<StoreTrait> TRAITS = new HashSet<StoreTrait>(MapStore.TRAITS) {
-        {
-            remove(StoreTrait.VISIBILITY);
-        }
-    };
+
+    private static final Set<StoreTrait> TRAITS = new HashSet<>(MapStore.TRAITS);
+
+    static {
+        TRAITS.remove(StoreTrait.VISIBILITY);
+    }
 
     @Override
     public Set<StoreTrait> getTraits() {

--- a/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/SingleUseMapStoreWithoutVisibilitySupport.java
+++ b/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/SingleUseMapStoreWithoutVisibilitySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Crown Copyright
+ * Copyright 2020-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/AddElementsHandler.java
+++ b/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/AddElementsHandler.java
@@ -150,7 +150,6 @@ public class AddElementsHandler implements OperationHandler<AddElements> {
             mapImpl.addIndex(entitySeed, element);
         } else {
             final Edge edge = (Edge) element;
-            edge.getMatchedVertex();
             edge.setIdentifiers(edge.getSource(), edge.getDestination(), edge.isDirected(), MatchedVertex.SOURCE);
             final EntitySeed sourceEntitySeed = new EntitySeed(edge.getSource());
             mapImpl.addIndex(sourceEntitySeed, edge);

--- a/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/AddElementsHandler.java
+++ b/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/AddElementsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import uk.gov.gchq.gaffer.data.element.Edge;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.Entity;
 import uk.gov.gchq.gaffer.data.element.GroupedProperties;
+import uk.gov.gchq.gaffer.data.element.id.EdgeId.MatchedVertex;
 import uk.gov.gchq.gaffer.mapstore.MapStore;
 import uk.gov.gchq.gaffer.operation.OperationException;
 import uk.gov.gchq.gaffer.operation.data.EdgeSeed;
@@ -149,11 +150,12 @@ public class AddElementsHandler implements OperationHandler<AddElements> {
             mapImpl.addIndex(entitySeed, element);
         } else {
             final Edge edge = (Edge) element;
-            edge.setIdentifiers(edge.getSource(), edge.getDestination(), edge.isDirected(), EdgeSeed.MatchedVertex.SOURCE);
+            edge.getMatchedVertex();
+            edge.setIdentifiers(edge.getSource(), edge.getDestination(), edge.isDirected(), MatchedVertex.SOURCE);
             final EntitySeed sourceEntitySeed = new EntitySeed(edge.getSource());
             mapImpl.addIndex(sourceEntitySeed, edge);
 
-            final Edge destMatchedEdge = new Edge(edge.getGroup(), edge.getSource(), edge.getDestination(), edge.isDirected(), EdgeSeed.MatchedVertex.DESTINATION, edge.getProperties());
+            final Edge destMatchedEdge = new Edge(edge.getGroup(), edge.getSource(), edge.getDestination(), edge.isDirected(), MatchedVertex.DESTINATION, edge.getProperties());
             final EntitySeed destinationEntitySeed = new EntitySeed(edge.getDestination());
             mapImpl.addIndex(destinationEntitySeed, destMatchedEdge);
 

--- a/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/DeleteAllDataHandler.java
+++ b/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/DeleteAllDataHandler.java
@@ -30,7 +30,7 @@ public class DeleteAllDataHandler implements OperationHandler<DeleteAllData> {
     private static final Logger LOGGER = LoggerFactory.getLogger(DeleteAllDataHandler.class);
 
     @Override
-    public Object doOperation(DeleteAllData operation, Context context, Store store) throws OperationException {
+    public Object doOperation(final DeleteAllData operation, final Context context, final Store store) throws OperationException {
         try {
             removeAllData((MapStore) store);
             return null;

--- a/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/DeleteAllDataHandler.java
+++ b/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/DeleteAllDataHandler.java
@@ -31,13 +31,9 @@ public class DeleteAllDataHandler implements OperationHandler<DeleteAllData> {
 
     @Override
     public Object doOperation(final DeleteAllData operation, final Context context, final Store store) throws OperationException {
-        try {
-            removeAllData((MapStore) store);
-            return null;
-        } catch (final Exception e) {
-            LOGGER.error("Error deleting graph: {}", store.getGraphId());
-            throw new OperationException(e);
-        }
+        LOGGER.info("Removing all data from graph: {}", store.getGraphId());
+        removeAllData((MapStore) store);
+        return null;
     }
 
     private void removeAllData(final MapStore mapStore) {

--- a/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/DeleteAllDataHandler.java
+++ b/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/DeleteAllDataHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.mapstore.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import uk.gov.gchq.gaffer.mapstore.MapStore;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.store.Context;
+import uk.gov.gchq.gaffer.store.Store;
+import uk.gov.gchq.gaffer.store.operation.DeleteAllData;
+import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
+
+public class DeleteAllDataHandler implements OperationHandler<DeleteAllData> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteAllDataHandler.class);
+
+    @Override
+    public Object doOperation(DeleteAllData operation, Context context, Store store) throws OperationException {
+        try {
+            removeAllData((MapStore) store);
+            return null;
+        } catch (final Exception e) {
+            LOGGER.error("Error deleting graph: {}", store.getGraphId());
+            throw new OperationException(e);
+        }
+    }
+
+    private void removeAllData(final MapStore mapStore) {
+        final MapImpl mapImpl = mapStore.getMapImpl();
+        mapImpl.clear();
+    }
+}

--- a/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/GetAdjacentIdsHandler.java
+++ b/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/GetAdjacentIdsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,8 +52,7 @@ public class GetAdjacentIdsHandler implements OutputOperationHandler<GetAdjacent
 
     private Iterable<EntityId> doOperation(final GetAdjacentIds operation,
                                            final Context context,
-                                           final MapStore mapStore)
-            throws OperationException {
+                                           final MapStore mapStore) {
         if (isNull(operation.getInput()) || !operation.getInput().iterator().hasNext()) {
             return new EmptyIterable<>();
         }

--- a/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/GetAdjacentIdsHandler.java
+++ b/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/GetAdjacentIdsHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.mapstore.impl;
 
 import uk.gov.gchq.gaffer.commonutil.iterable.EmptyIterable;

--- a/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/GetElementsUtil.java
+++ b/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/GetElementsUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/GetElementsUtil.java
+++ b/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/GetElementsUtil.java
@@ -89,34 +89,28 @@ public final class GetElementsUtil {
                         && ((Edge) e).isDirected()
                         && (EdgeId.MatchedVertex.DESTINATION == ((Edge) e).getMatchedVertex()));
             }
+
             // Remove Edges if searching with EntityId and View has no Edges
             if (view.hasEntities() && !view.hasEdges()) {
-                isFiltered = isFiltered.or(e -> e instanceof Edge);
+                isFiltered = isFiltered.or(Edge.class::isInstance);
             }
         } else {
-            relevantElements = new HashSet<>();
-
             final EdgeId edgeId = (EdgeId) elementId;
 
-            if (DirectedType.isEither(edgeId.getDirectedType())) {
-                relevantElements.addAll(mapImpl.lookup(new EdgeSeed(edgeId.getSource(), edgeId.getDestination(), false)));
-                relevantElements.addAll(mapImpl.lookup(new EdgeSeed(edgeId.getSource(), edgeId.getDestination(), true)));
-            } else {
-                relevantElements.addAll(mapImpl.lookup(new EdgeSeed(edgeId.getSource(), edgeId.getDestination(), edgeId.getDirectedType())));
-            }
+            relevantElements = getRelevantElements(mapImpl, edgeId);
 
             mapImpl.lookup(new EntitySeed(edgeId.getSource()))
                     .stream()
-                    .filter(e -> e instanceof Entity)
+                    .filter(Entity.class::isInstance)
                     .forEach(relevantElements::add);
             mapImpl.lookup(new EntitySeed(edgeId.getDestination()))
                     .stream()
-                    .filter(e -> e instanceof Entity)
+                    .filter(Entity.class::isInstance)
                     .forEach(relevantElements::add);
 
             // Remove Entities if searching with EdgeId and View has no Entities
             if (view.hasEdges() && !view.hasEntities()) {
-                isFiltered = isFiltered.or(e -> e instanceof Entity);
+                isFiltered = isFiltered.or(Entity.class::isInstance);
             }
         }
 
@@ -128,6 +122,19 @@ public final class GetElementsUtil {
         }
 
         relevantElements.removeIf(isFiltered);
+        return relevantElements;
+    }
+
+    private static Set<Element> getRelevantElements(final MapImpl mapImpl, final EdgeId edgeId) {
+        final Set<Element> relevantElements = new HashSet<>();
+
+        if (DirectedType.isEither(edgeId.getDirectedType())) {
+            relevantElements.addAll(mapImpl.lookup(new EdgeSeed(edgeId.getSource(), edgeId.getDestination(), false)));
+            relevantElements.addAll(mapImpl.lookup(new EdgeSeed(edgeId.getSource(), edgeId.getDestination(), true)));
+        } else {
+            relevantElements.addAll(mapImpl.lookup(new EdgeSeed(edgeId.getSource(), edgeId.getDestination(), edgeId.getDirectedType())));
+        }
+
         return relevantElements;
     }
 

--- a/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/MapImpl.java
+++ b/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/impl/MapImpl.java
@@ -147,8 +147,8 @@ public class MapImpl {
         nonAggElements.get(element.getGroup()).remove(element);
     }
 
-    Collection<Element> lookup(final EntityId entitId) {
-        Collection<Element> results = entityIdToElements.get(entitId);
+    Collection<Element> lookup(final EntityId entityId) {
+        Collection<Element> results = entityIdToElements.get(entityId);
         if (null == results) {
             results = Collections.emptySet();
         }

--- a/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/multimap/MapOfSets.java
+++ b/store-implementation/map-store/src/main/java/uk/gov/gchq/gaffer/mapstore/multimap/MapOfSets.java
@@ -52,7 +52,7 @@ public class MapOfSets<K, V> implements MultiMap<K, V> {
         final Set<V> existingValue = multiMap.get(key);
         if (null == existingValue) {
             if (value instanceof Set) {
-                multiMap.put(key, ((Set) value));
+                multiMap.put(key, ((Set<V>) value));
             } else {
                 multiMap.put(key, Sets.newHashSet(value));
             }

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/MapStorePropertiesGraphSerialisableTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/MapStorePropertiesGraphSerialisableTest.java
@@ -79,7 +79,7 @@ class MapStorePropertiesGraphSerialisableTest {
     }
 
     @Test
-    void shouldConsumeGraph(){
+    void shouldConsumeGraph() {
         final MapStoreProperties mapStoreProperties = new MapStoreProperties();
         mapStoreProperties.setProperties(properties);
         final Graph graph = new Graph.Builder().addSchema(schema).addStoreProperties(mapStoreProperties).config(config).build();

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/MapStorePropertiesGraphSerialisableTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/MapStorePropertiesGraphSerialisableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,16 +32,16 @@ import uk.gov.gchq.gaffer.store.schema.SchemaEntityDefinition;
 
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class MapStorePropertiesGraphSerialisableTest {
+class MapStorePropertiesGraphSerialisableTest {
     private GraphConfig config;
     private Schema schema;
     private Properties properties;
     private GraphSerialisable expected;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         config = new GraphConfig.Builder()
                 .graphId("testGraphId")
                 .addHook(new NamedViewResolver("testGraphId"))
@@ -71,19 +71,19 @@ public class MapStorePropertiesGraphSerialisableTest {
     }
 
     @Test
-    public void shouldSerialiseAndDeserialise() throws Exception {
+    void shouldSerialiseAndDeserialise() throws Exception {
         final JavaSerialiser javaSerialiser = new JavaSerialiser();
         final byte[] serialise = javaSerialiser.serialise(expected);
         final GraphSerialisable result = (GraphSerialisable) javaSerialiser.deserialise(serialise);
-        assertEquals(expected, result);
+        assertThat(result).isEqualTo(expected);
     }
 
     @Test
-    public void shouldConsumeGraph() throws Exception {
+    void shouldConsumeGraph(){
         final MapStoreProperties mapStoreProperties = new MapStoreProperties();
         mapStoreProperties.setProperties(properties);
         final Graph graph = new Graph.Builder().addSchema(schema).addStoreProperties(mapStoreProperties).config(config).build();
         final GraphSerialisable result = new GraphSerialisable.Builder(graph).build();
-        assertEquals(expected, result);
+        assertThat(result).isEqualTo(expected);
     }
 }

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/MapStorePropertiesTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/MapStorePropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Crown Copyright
+ * Copyright 2021-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.mapstore;
 
 import org.junit.jupiter.api.Test;

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/MapStorePropertiesTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/MapStorePropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Crown Copyright
+ * Copyright 2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,12 @@ import uk.gov.gchq.gaffer.sketches.serialisation.json.SketchesJsonModules;
 import uk.gov.gchq.gaffer.store.StorePropertiesTest.TestCustomJsonModules1;
 import uk.gov.gchq.gaffer.store.StorePropertiesTest.TestCustomJsonModules2;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class MapStorePropertiesTest {
+class MapStorePropertiesTest {
 
     @Test
-    public void shouldMergeJsonModules() {
+    void shouldMergeJsonModules() {
         // Given
         final MapStoreProperties props = new MapStoreProperties();
         props.setJsonSerialiserModules(TestCustomJsonModules1.class.getName() + "," + TestCustomJsonModules2.class.getName());
@@ -35,11 +35,12 @@ public class MapStorePropertiesTest {
         final String modules = props.getJsonSerialiserModules();
 
         // Then
-        assertEquals(SketchesJsonModules.class.getName() + "," + TestCustomJsonModules1.class.getName() + "," + TestCustomJsonModules2.class.getName(), modules);
+        assertThat(modules)
+            .isEqualTo(SketchesJsonModules.class.getName() + "," + TestCustomJsonModules1.class.getName() + "," + TestCustomJsonModules2.class.getName());
     }
 
     @Test
-    public void shouldMergeJsonModulesAndDeduplicate() {
+    void shouldMergeJsonModulesAndDeduplicate() {
         // Given
         final MapStoreProperties props = new MapStoreProperties();
         props.setJsonSerialiserModules(TestCustomJsonModules1.class.getName() + "," + SketchesJsonModules.class.getName());
@@ -48,6 +49,6 @@ public class MapStorePropertiesTest {
         final String modules = props.getJsonSerialiserModules();
 
         // Then
-        assertEquals(SketchesJsonModules.class.getName() + "," + TestCustomJsonModules1.class.getName(), modules);
+        assertThat(modules).isEqualTo(SketchesJsonModules.class.getName() + "," + TestCustomJsonModules1.class.getName());
     }
 }

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/MapStoreTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/MapStoreTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.mapstore;
 
 import org.junit.jupiter.api.Test;

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/MapStoreTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/MapStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,13 +26,12 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class MapStoreTest {
+class MapStoreTest {
 
     @Test
-    public void testTraits() throws StoreException {
+    void testTraits() throws StoreException {
         final MapStore mapStore = new MapStore();
         mapStore.initialise("graphId", new Schema(), new MapStoreProperties());
         final Set<StoreTrait> expectedTraits = new HashSet<>(Arrays.asList(
@@ -44,11 +43,11 @@ public class MapStoreTest {
                 StoreTrait.TRANSFORMATION,
                 StoreTrait.POST_TRANSFORMATION_FILTERING,
                 StoreTrait.MATCHED_VERTEX));
-        assertEquals(expectedTraits, mapStore.getTraits());
+        assertThat(mapStore.getTraits()).isEqualTo(expectedTraits);
     }
 
     @Test
-    public void shouldConfigureCountAllElementsOperationChainOptimiser() throws Exception {
+    void shouldConfigureCountAllElementsOperationChainOptimiser() throws Exception {
         // Given
         final MapStore mapStore = new MapStore();
 
@@ -56,7 +55,7 @@ public class MapStoreTest {
         mapStore.initialise("graphId", new Schema(), new MapStoreProperties());
 
         // Then
-        assertEquals(1, mapStore.getOperationChainOptimisers().size());
-        assertTrue(mapStore.getOperationChainOptimisers().contains(new CountAllElementsOperationChainOptimiser()));
+        assertThat(mapStore.getOperationChainOptimisers()).hasSize(1);
+        assertThat(mapStore.getOperationChainOptimisers()).contains(new CountAllElementsOperationChainOptimiser());
     }
 }

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/factory/SimpleMapFactoryTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/factory/SimpleMapFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.mapstore.MapStoreProperties;
 import uk.gov.gchq.gaffer.mapstore.multimap.MapOfSets;
 import uk.gov.gchq.gaffer.mapstore.utils.ElementCloner;
-import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.store.schema.Schema;
 
 import java.util.LinkedHashMap;
@@ -29,20 +28,16 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class SimpleMapFactoryTest {
+class SimpleMapFactoryTest {
 
     @Test
-    public void shouldThrowExceptionIfMapClassIsInvalid() throws StoreException {
+    void shouldThrowExceptionIfMapClassIsInvalid() {
         // Given
-        final Class mapClass = String.class;
+        final Class<String> mapClass = String.class;
         final Schema schema = mock(Schema.class);
         final MapStoreProperties properties = mock(MapStoreProperties.class);
         final SimpleMapFactory factory = new SimpleMapFactory();
@@ -57,7 +52,7 @@ public class SimpleMapFactoryTest {
     }
 
     @Test
-    public void shouldExtractMapClassFromPropertiesWhenInitialised() throws StoreException {
+    void shouldExtractMapClassFromPropertiesWhenInitialised() {
         // Given
         final Class<? extends Map> mapClass = LinkedHashMap.class;
         final Schema schema = mock(Schema.class);
@@ -70,11 +65,11 @@ public class SimpleMapFactoryTest {
         factory.initialise(schema, properties);
 
         // Then
-        assertEquals(mapClass, factory.getMapClass());
+        assertThat(factory.getMapClass()).isEqualTo(mapClass);
     }
 
     @Test
-    public void shouldCreateNewMapUsingMapClass() throws StoreException {
+    void shouldCreateNewMapUsingMapClass() {
         // Given
         final Class<? extends Map> mapClass = LinkedHashMap.class;
         final Schema schema = mock(Schema.class);
@@ -96,11 +91,11 @@ public class SimpleMapFactoryTest {
         assertThat(map2)
                 .isInstanceOf(LinkedHashMap.class)
                 .isEmpty();
-        assertNotSame(map1, map2);
+        assertThat(map1).isNotSameAs(map2);
     }
 
     @Test
-    public void shouldThrowExceptionIfMapClassCannotBeInstantiated() throws StoreException {
+    void shouldThrowExceptionIfMapClassCannotBeInstantiated() {
         // Given
         final Class<? extends Map> mapClass = Map.class;
         final Schema schema = mock(Schema.class);
@@ -112,11 +107,14 @@ public class SimpleMapFactoryTest {
         factory.initialise(schema, properties);
 
         // When / Then
-        assertThatIllegalArgumentException().isThrownBy(() -> factory.getMap("mapName1", Object.class, Object.class)).extracting("message").isNotNull();
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> factory.getMap("mapName1", Object.class, Object.class))
+            .extracting("message")
+            .isNotNull();
     }
 
     @Test
-    public void shouldCreateNewMultiMap() throws StoreException {
+    void shouldCreateNewMultiMap() {
         // Given
         final Class<? extends Map> mapClass = LinkedHashMap.class;
         final Schema schema = mock(Schema.class);
@@ -128,19 +126,19 @@ public class SimpleMapFactoryTest {
         factory.initialise(schema, properties);
 
         // When
-        final MapOfSets<Object, Object> map1 = (MapOfSets) factory.getMultiMap("mapName1", Object.class, Object.class);
-        final MapOfSets<Object, Object> map2 = (MapOfSets) factory.getMultiMap("mapName2", Object.class, Object.class);
+        final MapOfSets<Object, Object> map1 = (MapOfSets<Object, Object>) factory.getMultiMap("mapName1", Object.class, Object.class);
+        final MapOfSets<Object, Object> map2 = (MapOfSets<Object, Object>) factory.getMultiMap("mapName2", Object.class, Object.class);
 
         // Then
-        assertTrue(map1.getWrappedMap().isEmpty());
-        assertTrue(map1.getWrappedMap().isEmpty());
-        assertTrue(map2.getWrappedMap() instanceof LinkedHashMap);
-        assertTrue(map2.getWrappedMap() instanceof LinkedHashMap);
-        assertNotSame(map1, map2);
+        assertThat(map1.getWrappedMap()).isEmpty();
+        assertThat(map1.getWrappedMap()).isEmpty();
+        assertThat(map2.getWrappedMap()).isInstanceOf(LinkedHashMap.class);
+        assertThat(map2.getWrappedMap()).isInstanceOf(LinkedHashMap.class);
+        assertThat(map1).isNotSameAs(map2);
     }
 
     @Test
-    public void shouldCloneElementUsingCloner() throws StoreException {
+    void shouldCloneElementUsingCloner() {
         // Given
         final ElementCloner elementCloner = mock(ElementCloner.class);
         final Element element = mock(Element.class);
@@ -155,7 +153,8 @@ public class SimpleMapFactoryTest {
 
         // Then
         verify(elementCloner).cloneElement(element, schema);
-        assertSame(expectedClonedElement, clonedElement);
-        assertNotSame(element, clonedElement);
+        assertThat(clonedElement)
+            .isSameAs(expectedClonedElement)
+            .isNotSameAs(element);
     }
 }

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/factory/SimpleMapFactoryTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/factory/SimpleMapFactoryTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.mapstore.factory;
 
 import org.junit.jupiter.api.Test;

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/AddElementsHandlerTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/AddElementsHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Crown Copyright
+ * Copyright 2018-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import uk.gov.gchq.gaffer.data.element.Edge;
 import uk.gov.gchq.gaffer.mapstore.MapStore;
 import uk.gov.gchq.gaffer.mapstore.MapStoreProperties;
 import uk.gov.gchq.gaffer.mapstore.SingleUseMapStore;
-import uk.gov.gchq.gaffer.operation.OperationException;
 import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
 import uk.gov.gchq.gaffer.store.Context;
 import uk.gov.gchq.gaffer.store.StoreException;
@@ -29,13 +28,14 @@ import uk.gov.gchq.gaffer.store.schema.Schema;
 
 import java.util.Arrays;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-public class AddElementsHandlerTest {
+class AddElementsHandlerTest {
 
     @Test
-    public void shouldAddWithNoGroupByProperties() throws OperationException, StoreException {
+    void shouldAddWithNoGroupByProperties() throws StoreException {
         // Given
         final AddElements addElements = mock(AddElements.class);
         given(addElements.getInput()).willReturn((Iterable) Arrays.asList(new Edge("group1")));
@@ -45,6 +45,6 @@ public class AddElementsHandlerTest {
         final AddElementsHandler handler = new AddElementsHandler();
 
         // When / Then - should not throw NPE
-        handler.doOperation(addElements, context, store);
+        assertThatNoException().isThrownBy(() -> handler.doOperation(addElements, context, store));
     }
 }

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/AddElementsHandlerTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/AddElementsHandlerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.mapstore.impl;
 
 import org.junit.jupiter.api.Test;

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/CountAllElementsDefaultViewHandlerTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/CountAllElementsDefaultViewHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,18 +21,17 @@ import uk.gov.gchq.gaffer.graph.Graph;
 import uk.gov.gchq.gaffer.mapstore.operation.CountAllElementsDefaultView;
 import uk.gov.gchq.gaffer.operation.OperationException;
 import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
-import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.user.User;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *
  */
-public class CountAllElementsDefaultViewHandlerTest {
+class CountAllElementsDefaultViewHandlerTest {
 
     @Test
-    public void testCountAllElementsDefaultViewHandler() throws StoreException, OperationException {
+    void testCountAllElementsDefaultViewHandler() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -45,11 +44,11 @@ public class CountAllElementsDefaultViewHandlerTest {
         final Long result = graph.execute(countAllElementsDefaultView, new User());
 
         // Then
-        assertEquals((long) GetAllElementsHandlerTest.getElements().size(), (long) result);
+        assertThat((long) result).isEqualTo((long) GetAllElementsHandlerTest.getElements().size());
     }
 
     @Test
-    public void shouldApplyVisibilityTraitToOperationResults() throws OperationException {
+    void shouldApplyVisibilityTraitToOperationResults() throws OperationException {
         VisibilityTest.executeOperation(
                 new CountAllElementsDefaultView(),
                 VisibilityTest::elementIterableResultSizeConsumer);

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/CountAllElementsDefaultViewHandlerTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/CountAllElementsDefaultViewHandlerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.mapstore.impl;
 
 import org.junit.jupiter.api.Test;

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/DeleteAllDataHandlerTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/DeleteAllDataHandlerTest.java
@@ -21,27 +21,30 @@ import org.junit.jupiter.api.Test;
 import uk.gov.gchq.gaffer.graph.Graph;
 import uk.gov.gchq.gaffer.operation.OperationException;
 import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
+import uk.gov.gchq.gaffer.operation.impl.get.GetAllElements;
 import uk.gov.gchq.gaffer.store.operation.DeleteAllData;
 import uk.gov.gchq.gaffer.user.User;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class DeleteAllDataHandlerTest {
 
-    // @Test
-    // void shouldRemoveAllData() throws OperationException {
-    // // Given
-    // final Graph graph = GetAllElementsHandlerTest.getGraph();
-    // final AddElements addElements = new AddElements.Builder()
-    //         .input(GetAllElementsHandlerTest.getElements())
-    //         .build();
-    // graph.execute(addElements, new User());
+    @Test
+    void shouldRemoveAllData() throws OperationException {
+        // Given
+        final Graph graph = GetAllElementsHandlerTest.getGraph();
+        final AddElements addElements = new AddElements.Builder()
+                .input(GetAllElementsHandlerTest.getElements())
+                .build();
+        graph.execute(addElements, new User());
 
-    // // When
-    // final DeleteAllData deleteAll = new DeleteAllData.Builder().build();
+        // When
+        final DeleteAllData deleteAll = new DeleteAllData.Builder().build();
+        graph.execute(deleteAll, new User());
 
-    // // Then
-    // verify(graph, times(1)).execute(deleteAll, new User());
-    // }
+        final GetAllElements getAllElements = new GetAllElements.Builder().build();
+
+        // Then
+        assertThat(graph.execute(getAllElements, new User())).isEmpty();
+    }
 }

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/DeleteAllDataHandlerTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/DeleteAllDataHandlerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package uk.gov.gchq.gaffer.mapstore.impl;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.gaffer.graph.Graph;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
+import uk.gov.gchq.gaffer.store.operation.DeleteAllData;
+import uk.gov.gchq.gaffer.user.User;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class DeleteAllDataHandlerTest {
+
+    // @Test
+    // void shouldRemoveAllData() throws OperationException {
+    // // Given
+    // final Graph graph = GetAllElementsHandlerTest.getGraph();
+    // final AddElements addElements = new AddElements.Builder()
+    //         .input(GetAllElementsHandlerTest.getElements())
+    //         .build();
+    // graph.execute(addElements, new User());
+
+    // // When
+    // final DeleteAllData deleteAll = new DeleteAllData.Builder().build();
+
+    // // Then
+    // verify(graph, times(1)).execute(deleteAll, new User());
+    // }
+}

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/DeleteAllDataHandlerTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/DeleteAllDataHandlerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
- package uk.gov.gchq.gaffer.mapstore.impl;
+package uk.gov.gchq.gaffer.mapstore.impl;
 
 import org.junit.jupiter.api.Test;
 

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/GetAdjacentIdsTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/GetAdjacentIdsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,10 +39,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static uk.gov.gchq.gaffer.mapstore.impl.VisibilityTest.VERTEX_1;
 
-public class GetAdjacentIdsTest {
+class GetAdjacentIdsTest {
 
     @Test
-    public void shouldGetAdjacentIdsWhenThereAreNone() throws OperationException {
+    void shouldGetAdjacentIdsWhenThereAreNone() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -63,7 +63,7 @@ public class GetAdjacentIdsTest {
     }
 
     @Test
-    public void shouldGetAdjacentEntityId() throws OperationException {
+    void shouldGetAdjacentEntityId() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -139,7 +139,7 @@ public class GetAdjacentIdsTest {
     }
 
     @Test
-    public void shouldGetAdjacentEntityIdWithViewRestrictedByGroup() throws OperationException {
+    void shouldGetAdjacentEntityIdWithViewRestrictedByGroup() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -183,7 +183,7 @@ public class GetAdjacentIdsTest {
     }
 
     @Test
-    public void shouldGetElementsByEntityIdWithViewRestrictedByGroupAndAPreAggregationFilter()
+    void shouldGetElementsByEntityIdWithViewRestrictedByGroupAndAPreAggregationFilter()
             throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
@@ -234,7 +234,7 @@ public class GetAdjacentIdsTest {
     }
 
     @Test
-    public void shouldGetElementsByEntityIdWithViewRestrictedByGroupAndAPostAggregationFilter()
+    void shouldGetElementsByEntityIdWithViewRestrictedByGroupAndAPostAggregationFilter()
             throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
@@ -285,7 +285,7 @@ public class GetAdjacentIdsTest {
     }
 
     @Test
-    public void shouldFailValidationWhenEntityHasFilter() throws OperationException {
+    void shouldFailValidationWhenEntityHasFilter() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -316,7 +316,7 @@ public class GetAdjacentIdsTest {
     }
 
     @Test
-    public void shouldPassValidationOnEntitiesWithoutFilters() throws OperationException {
+    void shouldPassValidationOnEntitiesWithoutFilters() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -368,7 +368,7 @@ public class GetAdjacentIdsTest {
     }
 
     @Test
-    public void shouldApplyVisibilityTraitToOperationResults() throws OperationException {
+    void shouldApplyVisibilityTraitToOperationResults() throws OperationException {
         VisibilityTest.executeOperation(new GetAdjacentIds.Builder().input(new EntitySeed(VERTEX_1)).build(),
                 VisibilityTest::vertex1AdjacentIdsResultConsumer);
     }

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/GetAdjacentIdsTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/GetAdjacentIdsTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.mapstore.impl;
 
 import org.junit.jupiter.api.Test;

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/GetAllElementsHandlerTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/GetAllElementsHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.mapstore.impl;
 
 import org.junit.jupiter.api.Test;

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/GetAllElementsHandlerTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/GetAllElementsHandlerTest.java
@@ -33,7 +33,6 @@ import uk.gov.gchq.gaffer.mapstore.MapStoreProperties;
 import uk.gov.gchq.gaffer.operation.OperationException;
 import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
 import uk.gov.gchq.gaffer.operation.impl.get.GetAllElements;
-import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.store.schema.Schema;
 import uk.gov.gchq.gaffer.user.User;
 import uk.gov.gchq.koryphe.impl.predicate.IsMoreThan;
@@ -60,7 +59,7 @@ public class GetAllElementsHandlerTest {
     private static final int NUM_LOOPS = 10;
 
     @Test
-    public void testAddAndGetAllElementsNoAggregation() throws StoreException, OperationException {
+    void testAddAndGetAllElementsNoAggregation() throws OperationException {
         // Given
         final Graph graph = getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -85,7 +84,7 @@ public class GetAllElementsHandlerTest {
     }
 
     @Test
-    public void testAddAndGetAllElementsWithAggregation() throws StoreException, OperationException {
+    void testAddAndGetAllElementsWithAggregation() throws OperationException {
         // Given
         final Graph graph = getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -138,7 +137,7 @@ public class GetAllElementsHandlerTest {
     }
 
     @Test
-    public void testGetAllElementsWithViewRestrictedByGroup() throws OperationException {
+    void testGetAllElementsWithViewRestrictedByGroup() throws OperationException {
         // Given
         final Graph graph = getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -165,7 +164,7 @@ public class GetAllElementsHandlerTest {
     }
 
     @Test
-    public void testGetAllElementsWithViewRestrictedByGroupAndAPreAggregationFilter() throws OperationException {
+    void testGetAllElementsWithViewRestrictedByGroupAndAPreAggregationFilter() throws OperationException {
         // Given
         final Graph graph = getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -197,7 +196,7 @@ public class GetAllElementsHandlerTest {
     }
 
     @Test
-    public void testGetAllElementsWithViewRestrictedByGroupAndAPostAggregationFilter() throws OperationException {
+    void testGetAllElementsWithViewRestrictedByGroupAndAPostAggregationFilter() throws OperationException {
         // Given
         final Graph graph = getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -230,7 +229,7 @@ public class GetAllElementsHandlerTest {
     }
 
     @Test
-    public void testGetAllElementsWithAndWithEntities() throws OperationException {
+    void testGetAllElementsWithAndWithEntities() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -275,7 +274,7 @@ public class GetAllElementsHandlerTest {
     }
 
     @Test
-    public void testGetAllElementsDirectedTypeOption() throws OperationException {
+    void testGetAllElementsDirectedTypeOption() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -505,7 +504,7 @@ public class GetAllElementsHandlerTest {
     }
 
     @Test
-    public void shouldApplyVisibilityTraitToOperationResults() throws OperationException {
+    void shouldApplyVisibilityTraitToOperationResults() throws OperationException {
         VisibilityTest.executeOperation(
                 new GetAllElements.Builder().build(),
                 VisibilityTest::elementIterableResultConsumer);

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/GetElementsHandlerTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/GetElementsHandlerTest.java
@@ -75,7 +75,7 @@ class GetElementsHandlerTest {
     }
 
     @Test
-    void testGetElementsWhenNoEntityIdsProvided() throws OperationException {
+    void testGetElementsWhenNoIdsAreProvided() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -107,27 +107,6 @@ class GetElementsHandlerTest {
         // When
         final GetElements getElements = new GetElements.Builder()
                 .input(new EdgeSeed("NOT_PRESENT", "ALSO_NOT_PRESENT", true))
-                .build();
-        final Iterable<? extends Element> results = graph.execute(getElements, new User());
-
-        // Then
-        final Set<Element> resultsSet = new HashSet<>();
-        Streams.toStream(results).forEach(resultsSet::add);
-        assertThat(resultsSet).isEmpty();
-    }
-
-    @Test
-    void testGetElementsWhenNoEdgeIdsProvided() throws OperationException {
-        // Given
-        final Graph graph = GetAllElementsHandlerTest.getGraph();
-        final AddElements addElements = new AddElements.Builder()
-                .input(getElements())
-                .build();
-        graph.execute(addElements, new User());
-
-        // When
-        final GetElements getElements = new GetElements.Builder()
-                .input(new EmptyIterable<>())
                 .build();
         final Iterable<? extends Element> results = graph.execute(getElements, new User());
 

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/GetElementsHandlerTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/GetElementsHandlerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.mapstore.impl;
 
 import org.junit.jupiter.api.Test;

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/GetElementsHandlerTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/GetElementsHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,6 @@ import uk.gov.gchq.gaffer.operation.data.EntitySeed;
 import uk.gov.gchq.gaffer.operation.graph.SeededGraphFilters.IncludeIncomingOutgoingType;
 import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
 import uk.gov.gchq.gaffer.operation.impl.get.GetElements;
-import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.user.User;
 import uk.gov.gchq.koryphe.function.KorypheFunction;
 import uk.gov.gchq.koryphe.impl.predicate.IsMoreThan;
@@ -51,11 +50,11 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class GetElementsHandlerTest {
+class GetElementsHandlerTest {
     private static final int NUM_LOOPS = 10;
 
     @Test
-    public void testGetElementsByNonExistentEntityId() throws OperationException {
+    void testGetElementsByNonExistentEntityId() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -76,7 +75,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsWhenNoEntityIdsProvided() throws OperationException {
+    void testGetElementsWhenNoEntityIdsProvided() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -97,7 +96,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsByNonExistentEdgeId() throws OperationException {
+    void testGetElementsByNonExistentEdgeId() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -118,7 +117,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsWhenNoEdgeIdsProvided() throws OperationException {
+    void testGetElementsWhenNoEdgeIdsProvided() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -139,7 +138,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsByEntityId() throws OperationException {
+    void testGetElementsByEntityId() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -176,7 +175,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsByEdgeId() throws OperationException {
+    void testGetElementsByEdgeId() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -302,7 +301,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testAddAndGetAllElementsNoAggregationAndDuplicateElements() throws StoreException, OperationException {
+    void testAddAndGetAllElementsNoAggregationAndDuplicateElements() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraphNoAggregation();
         final AddElements addElements = new AddElements.Builder()
@@ -337,7 +336,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsByEntityIdWithViewRestrictedByGroup() throws OperationException {
+    void testGetElementsByEntityIdWithViewRestrictedByGroup() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -373,7 +372,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsByEdgeIdWithViewRestrictedByGroup() throws OperationException {
+    void testGetElementsByEdgeIdWithViewRestrictedByGroup() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -410,7 +409,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsByEntityIdWithViewRestrictedByGroupAndAPreAggregationFilter() throws OperationException {
+    void testGetElementsByEntityIdWithViewRestrictedByGroupAndAPreAggregationFilter() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -452,7 +451,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsByEdgeIdWithViewRestrictedByGroupAndAPreAggregationFilter() throws OperationException {
+    void testGetElementsByEdgeIdWithViewRestrictedByGroupAndAPreAggregationFilter() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -495,7 +494,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsByEntityIdWithViewRestrictedByGroupAndAPostAggregationFilter()
+    void testGetElementsByEntityIdWithViewRestrictedByGroupAndAPostAggregationFilter()
             throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
@@ -538,7 +537,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsByEdgeIdWithViewRestrictedByGroupAndAPostAggregationFilter() throws OperationException {
+    void testGetElementsByEdgeIdWithViewRestrictedByGroupAndAPostAggregationFilter() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -590,7 +589,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsByEntityIdWithViewRestrictedByGroupAndATransform() throws OperationException {
+    void testGetElementsByEntityIdWithViewRestrictedByGroupAndATransform() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -638,7 +637,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsByEdgeIdWithViewRestrictedByGroupAndATransform() throws OperationException {
+    void testGetElementsByEdgeIdWithViewRestrictedByGroupAndATransform() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -687,7 +686,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsByEntityIdWithViewRestrictedByGroupAndAPostTransformFilter() throws OperationException {
+    void testGetElementsByEntityIdWithViewRestrictedByGroupAndAPostTransformFilter() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -733,7 +732,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsByEdgeSeedWithViewRestrictedByGroupAndAPostTransformFilter() throws OperationException {
+    void testGetElementsByEdgeSeedWithViewRestrictedByGroupAndAPostTransformFilter() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -787,7 +786,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsIncludeEntitiesOption() throws OperationException {
+    void testGetElementsIncludeEntitiesOption() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -847,7 +846,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsDirectedTypeOption() throws OperationException {
+    void testGetElementsDirectedTypeOption() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -959,7 +958,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsInOutTypeOption() throws OperationException {
+    void testGetElementsInOutTypeOption() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -1053,7 +1052,7 @@ public class GetElementsHandlerTest {
 
     // Test equivalent for seedMatching
     @Test
-    public void testGetElementsSeedMatchingTypeOption() throws OperationException {
+    void testGetElementsSeedMatchingTypeOption() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -1131,7 +1130,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testGetElementsWhenNotMaintainingIndices() throws OperationException {
+    void testGetElementsWhenNotMaintainingIndices() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraphNoIndices();
         final AddElements addElements = new AddElements.Builder()
@@ -1150,7 +1149,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void testElementsAreClonedBeforeBeingReturned() throws OperationException {
+    void testElementsAreClonedBeforeBeingReturned() throws OperationException {
         // Given
         final Graph graph = GetAllElementsHandlerTest.getGraph();
         final AddElements addElements = new AddElements.Builder()
@@ -1209,7 +1208,7 @@ public class GetElementsHandlerTest {
     }
 
     @Test
-    public void shouldApplyVisibilityTraitToOperationResults() throws OperationException {
+    void shouldApplyVisibilityTraitToOperationResults() throws OperationException {
         VisibilityTest.executeOperation(
                 new GetElements.Builder()
                         .input(new EntitySeed(VisibilityTest.VERTEX_1), new EntitySeed(VisibilityTest.VERTEX_2))

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/MapImplTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/MapImplTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.mapstore.impl;
 
 import com.google.common.collect.Sets;

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/MapImplTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/MapImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import uk.gov.gchq.gaffer.data.element.id.EntityId;
 import uk.gov.gchq.gaffer.mapstore.MapStoreProperties;
 import uk.gov.gchq.gaffer.mapstore.factory.MapFactory;
 import uk.gov.gchq.gaffer.mapstore.multimap.MultiMap;
-import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.store.schema.Schema;
 
 import java.util.Map;
@@ -38,7 +37,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-public class MapImplTest {
+class MapImplTest {
     private static MapFactory mockMapFactory;
 
     @BeforeEach
@@ -52,14 +51,14 @@ public class MapImplTest {
     }
 
     @Test
-    public void shouldCreateMapsUsingMapFactory() throws StoreException {
+    void shouldCreateMapsUsingMapFactory() {
         // Given
         final Schema schema = mock(Schema.class);
         final MapStoreProperties properties = mock(MapStoreProperties.class);
-        final Map aggElements = mock(Map.class);
-        final Map nonAggElements = mock(Map.class);
-        final MultiMap entityIdToElements = mock(MultiMap.class);
-        final MultiMap edgeIdToElements = mock(MultiMap.class);
+        final Map<Element, GroupedProperties> aggElements = mock(Map.class);
+        final Map<Element, Integer> nonAggElements = mock(Map.class);
+        final MultiMap<EntityId, Element> entityIdToElements = mock(MultiMap.class);
+        final MultiMap<EdgeId, Element> edgeIdToElements = mock(MultiMap.class);
 
         given(schema.getGroups()).willReturn(Sets.newHashSet(TestGroups.EDGE));
         given(properties.getMapFactory()).willReturn(TestMapFactory.class.getName());
@@ -80,12 +79,12 @@ public class MapImplTest {
     }
 
     @Test
-    public void shouldNotCreateIndexesIfNotRequired() throws StoreException {
+    void shouldNotCreateIndexesIfNotRequired() {
         // Given
         final Schema schema = mock(Schema.class);
         final MapStoreProperties properties = mock(MapStoreProperties.class);
-        final Map aggElements = mock(Map.class);
-        final Map nonAggElements = mock(Map.class);
+        final Map<Element, GroupedProperties> aggElements = mock(Map.class);
+        final Map<Element, Integer> nonAggElements = mock(Map.class);
 
         given(schema.getGroups()).willReturn(Sets.newHashSet(TestGroups.EDGE));
         given(properties.getMapFactory()).willReturn(TestMapFactory.class.getName());

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/OperationChainTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/OperationChainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import uk.gov.gchq.gaffer.operation.data.EntitySeed;
 import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
 import uk.gov.gchq.gaffer.operation.impl.get.GetAdjacentIds;
 import uk.gov.gchq.gaffer.operation.impl.get.GetElements;
-import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.user.User;
 
 import java.util.ArrayList;
@@ -40,12 +39,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class OperationChainTest {
+class OperationChainTest {
 
     @Test
-    public void testOperationChain() throws StoreException, OperationException {
+    void testOperationChain() throws OperationException {
         // Given
         final Graph graph = new Graph.Builder()
                 .config(new GraphConfig.Builder()
@@ -82,7 +81,7 @@ public class OperationChainTest {
                     return edge.getSource().equals("vertex1") || edge.getDestination().equals("vertex2");
                 })
                 .forEach(expectedResults::add);
-        assertEquals(expectedResults, resultsSet);
+        assertThat(resultsSet).isEqualTo(expectedResults);
     }
 
     private static List<Element> getElements() {

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/OperationChainTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/impl/OperationChainTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.mapstore.impl;
 
 import org.junit.jupiter.api.Test;

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/multimap/MapOfSetsTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/multimap/MapOfSetsTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.mapstore.multimap;
 
 import com.google.common.collect.Sets;

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/multimap/MapOfSetsTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/multimap/MapOfSetsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@ package uk.gov.gchq.gaffer.mapstore.multimap;
 import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
 
-import uk.gov.gchq.gaffer.store.StoreException;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,16 +25,14 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class MapOfSetsTest {
+class MapOfSetsTest {
     @Test
-    public void shouldPutValueInExistingMapSet() throws StoreException {
+    void shouldPutValueInExistingMapSet() {
         // Given
         final String key = "key1";
         final String value = "value1";
@@ -51,12 +47,12 @@ public class MapOfSetsTest {
         final boolean putResult = mapOfSets.put(key, value);
 
         // Then
-        assertTrue(putResult);
+        assertThat(putResult).isTrue();
         verify(set).add(value);
     }
 
     @Test
-    public void shouldPutValueInMapWhenNullSetAndNullSetClass() throws StoreException {
+    void shouldPutValueInMapWhenNullSetAndNullSetClass() {
         // Given
         final String key = "key1";
         final String value = "value1";
@@ -67,12 +63,12 @@ public class MapOfSetsTest {
         final boolean putResult = mapOfSets.put(key, value);
 
         // Then
-        assertTrue(putResult);
-        assertEquals(Sets.newHashSet(value), mapOfSets.get(key));
+        assertThat(putResult).isTrue();
+        assertThat(mapOfSets.get(key)).isEqualTo(Sets.newHashSet(value));
     }
 
     @Test
-    public void shouldPutValueInMapWhenNullSetAndLinkedHashSetClass() throws StoreException {
+    void shouldPutValueInMapWhenNullSetAndLinkedHashSetClass() {
         // Given
         final String key = "key1";
         final String value = "value1";
@@ -83,12 +79,12 @@ public class MapOfSetsTest {
         final boolean putResult = mapOfSets.put(key, value);
 
         // Then
-        assertTrue(putResult);
-        assertEquals(Sets.newLinkedHashSet(Collections.singleton(value)), map.get(key));
+        assertThat(putResult).isTrue();
+        assertThat(map).containsEntry(key, Sets.newLinkedHashSet(Collections.singleton(value)));
     }
 
     @Test
-    public void shouldGetSetFromMap() throws StoreException {
+    void shouldGetSetFromMap() {
         // Given
         final String key = "key1";
         final Set<String> set = mock(Set.class);
@@ -102,11 +98,11 @@ public class MapOfSetsTest {
 
         // Then
         verify(map).get(key);
-        assertSame(set, result);
+        assertThat(result).isSameAs(set);
     }
 
     @Test
-    public void shouldClearMap() throws StoreException {
+    void shouldClearMap() {
         // Given
         final String key = "key1";
         final Set<String> set = mock(Set.class);

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/optimiser/CountAllElementsOperationChainOptimiserTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/optimiser/CountAllElementsOperationChainOptimiserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Crown Copyright
+ * Copyright 2020-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/optimiser/CountAllElementsOperationChainOptimiserTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/optimiser/CountAllElementsOperationChainOptimiserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Crown Copyright
+ * Copyright 2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,11 +33,10 @@ import uk.gov.gchq.gaffer.operation.impl.get.GetElements;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-public class CountAllElementsOperationChainOptimiserTest {
+class CountAllElementsOperationChainOptimiserTest {
 
     private static final Operation COUNT_ALL_ELEMENTS_DEFAULT_VIEW = new CountAllElementsDefaultView.Builder().build();
     private static final Operation GET_ALL_ELEMENTS_DEFAULT_VIEW = new GetAllElements.Builder().build();
@@ -51,7 +50,7 @@ public class CountAllElementsOperationChainOptimiserTest {
 
     @ParameterizedTest
     @MethodSource("inputOperationChainAndExpectedOptimizedOperationChain")
-    public void shouldReturnExpectedOptimisedOperationChain(final OperationChain inputOperationChain, final OperationChain expectedOptimisedOperationChain) {
+    void shouldReturnExpectedOptimisedOperationChain(final OperationChain inputOperationChain, final OperationChain expectedOptimisedOperationChain) {
         //Given
         final CountAllElementsOperationChainOptimiser optimiser = new CountAllElementsOperationChainOptimiser();
 
@@ -59,11 +58,11 @@ public class CountAllElementsOperationChainOptimiserTest {
         final OperationChain optimisedOperationChain = optimiser.optimise(inputOperationChain);
 
         // Then
-        assertEquals(expectedOptimisedOperationChain.getOperations().size(), optimisedOperationChain.getOperations().size());
+        assertThat(optimisedOperationChain.getOperations()).hasSameSizeAs(expectedOptimisedOperationChain.getOperations());
         final Iterator<Operation> optimisedOperationsIterator = optimisedOperationChain.getOperations().iterator();
         final Iterator<Operation> expectedOperationsIterator = expectedOptimisedOperationChain.getOperations().iterator();
         while (optimisedOperationsIterator.hasNext()) {
-            assertSame(expectedOperationsIterator.next().getClass(), optimisedOperationsIterator.next().getClass());
+            assertThat(optimisedOperationsIterator.next().getClass()).isSameAs(expectedOperationsIterator.next().getClass());
         }
     }
 
@@ -83,7 +82,7 @@ public class CountAllElementsOperationChainOptimiserTest {
 
     @ParameterizedTest
     @MethodSource("nonOptimisableInputOperationChain")
-    public void shouldNotOptimiseOperationChain(final OperationChain inputOperationChain) {
+    void shouldNotOptimiseOperationChain(final OperationChain inputOperationChain) {
         //Given
         final CountAllElementsOperationChainOptimiser optimiser = new CountAllElementsOperationChainOptimiser();
 
@@ -91,7 +90,7 @@ public class CountAllElementsOperationChainOptimiserTest {
         final OperationChain optimisedOperationChain = optimiser.optimise(inputOperationChain);
 
         // Then
-        assertEquals(inputOperationChain.getOperations(), optimisedOperationChain.getOperations());
+        assertThat(optimisedOperationChain.getOperations()).isEqualTo(inputOperationChain.getOperations());
     }
 
     static Stream<Arguments> nonOptimisableInputOperationChain() {

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/utils/ElementClonerTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/utils/ElementClonerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.mapstore.utils;
 
 import org.junit.jupiter.api.Test;

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/utils/ElementClonerTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/utils/ElementClonerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,10 @@ import uk.gov.gchq.gaffer.store.StoreException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ElementClonerTest {
+class ElementClonerTest {
 
     @Test
-    public void testElementCloner() throws StoreException {
+    void testElementCloner() throws StoreException {
         // Given
         final ElementCloner cloner = new ElementCloner();
         final MapStore mapStore = new MapStore();

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/utils/MapWrapperTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/utils/MapWrapperTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.mapstore.utils;
 
 import org.junit.jupiter.api.Test;

--- a/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/utils/MapWrapperTest.java
+++ b/store-implementation/map-store/src/test/java/uk/gov/gchq/gaffer/mapstore/utils/MapWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,22 +17,19 @@ package uk.gov.gchq.gaffer.mapstore.utils;
 
 import org.junit.jupiter.api.Test;
 
-import uk.gov.gchq.gaffer.store.StoreException;
-
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class MapWrapperTest {
+class MapWrapperTest {
 
     @Test
-    public void shouldDelegateAllCallsToMap() throws StoreException {
+    void shouldDelegateAllCallsToMap() {
         // Given
         final String key = "key1";
         final String value = "value1";
@@ -62,37 +59,37 @@ public class MapWrapperTest {
         // When / Then - put
         final String putResult = wrapper.put(key, value);
         verify(map).put(key, value);
-        assertEquals(value2, putResult);
+        assertThat(putResult).isEqualTo(value2);
 
         // When / Then - get
         final String getResult = wrapper.get(key);
         verify(map).get(key);
-        assertEquals(value, getResult);
+        assertThat(getResult).isEqualTo(value);
 
         // When / Then - size
         final int sizeResult = wrapper.size();
         verify(map).size();
-        assertEquals(size, sizeResult);
+        assertThat(sizeResult).isEqualTo(size);
 
         // When / Then - isEmpty
         final boolean isEmptyResult = wrapper.isEmpty();
         verify(map).size();
-        assertEquals(isEmpty, isEmptyResult);
+        assertThat(isEmptyResult).isEqualTo(isEmpty);
 
         // When / Then - containsKey
         final boolean containsKeyResult = wrapper.containsKey(key);
         verify(map).containsKey(key);
-        assertEquals(containsKey, containsKeyResult);
+        assertThat(containsKeyResult).isEqualTo(containsKey);
 
         // When / Then - containsValue
         final boolean containsValueResult = wrapper.containsValue(value);
         verify(map).containsValue(value);
-        assertEquals(containsValue, containsValueResult);
+        assertThat(containsValueResult).isEqualTo(containsValue);
 
         // When / Then - remove
         final String removeResult = wrapper.remove(key);
         verify(map).remove(key);
-        assertEquals(value, removeResult);
+        assertThat(removeResult).isEqualTo(value);
 
         // When / Then - putAll
         wrapper.putAll(map2);
@@ -105,20 +102,20 @@ public class MapWrapperTest {
         // When / Then - keySet
         final Set<String> keySetResult = wrapper.keySet();
         verify(map).keySet();
-        assertSame(keySet, keySetResult);
+        assertThat(keySetResult).isEqualTo(keySet);
 
         // When / Then - values
         final Collection<String> valuesResult = wrapper.values();
         verify(map).values();
-        assertSame(values, valuesResult);
+        assertThat(valuesResult).isSameAs(values);
 
         // When / Then - entrySet
         final Set<Map.Entry<String, String>> entrySetResult = wrapper.entrySet();
         verify(map).entrySet();
-        assertSame(entrySet, entrySetResult);
+        assertThat(entrySetResult).isSameAs(entrySet);
 
         // When / Then - getMap
         final Map<String, String> mapResult = wrapper.getMap();
-        assertSame(map, mapResult);
+        assertThat(mapResult).isSameAs(map);
     }
 }

--- a/store-implementation/proxy-store/src/main/java/uk/gov/gchq/gaffer/proxystore/ProxyStore.java
+++ b/store-implementation/proxy-store/src/main/java/uk/gov/gchq/gaffer/proxystore/ProxyStore.java
@@ -57,6 +57,7 @@ import uk.gov.gchq.gaffer.store.Store;
 import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.store.StoreProperties;
 import uk.gov.gchq.gaffer.store.StoreTrait;
+import uk.gov.gchq.gaffer.store.operation.DeleteAllData;
 import uk.gov.gchq.gaffer.store.operation.GetSchema;
 import uk.gov.gchq.gaffer.store.operation.GetTraits;
 import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
@@ -366,6 +367,11 @@ public class ProxyStore extends Store {
 
     @Override
     protected OperationHandler<? extends DeleteElements> getDeleteElementsHandler() {
+        return null;
+    }
+
+    @Override
+    protected OperationHandler<DeleteAllData> getDeleteAllDataHandler() {
         return null;
     }
 


### PR DESCRIPTION
The operation DeleteAllData previously had to be added to the operationsdeclarations.json to be available, and this was only in Accumulo Stores. This work adds the operation to all stores and enables it for any graph as otherwise you must restart the graph to add this to the operationdeclarations file for it to be available. 

Also addresses some technical debt in the MapStore.

# Related issue

- Resolve #3270