### PR TITLE
Gh-3277: Add custom GafferPop Vertex Step

### DIFF
--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -57,6 +57,7 @@ import uk.gov.gchq.gaffer.tinkerpop.generator.GafferEntityGenerator;
 import uk.gov.gchq.gaffer.tinkerpop.generator.GafferPopElementGenerator;
 import uk.gov.gchq.gaffer.tinkerpop.process.traversal.strategy.optimisation.GafferPopGraphStepStrategy;
 import uk.gov.gchq.gaffer.tinkerpop.process.traversal.strategy.optimisation.GafferPopHasStepStrategy;
+import uk.gov.gchq.gaffer.tinkerpop.process.traversal.strategy.optimisation.GafferPopVertexStepStrategy;
 import uk.gov.gchq.gaffer.tinkerpop.process.traversal.util.GafferCustomTypeFactory;
 import uk.gov.gchq.gaffer.tinkerpop.service.GafferPopNamedOperationServiceFactory;
 import uk.gov.gchq.gaffer.user.User;
@@ -288,7 +289,8 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         // Add and register custom traversals
         TraversalStrategies traversalStrategies = GlobalCache.getStrategies(this.getClass()).addStrategies(
                 GafferPopGraphStepStrategy.instance(),
-                GafferPopHasStepStrategy.instance());
+                GafferPopHasStepStrategy.instance(),
+                GafferPopVertexStepStrategy.instance());
         GlobalCache.registerStrategies(this.getClass(), traversalStrategies);
     }
 

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopVertexStep.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopVertexStep.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.tinkerpop.process.traversal.step;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import uk.gov.gchq.gaffer.data.elementdefinition.view.View;
+import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph;
+import uk.gov.gchq.gaffer.tinkerpop.GafferPopVertex;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class GafferPopVertexStep<E extends Element> extends VertexStep<E> {
+  private static final long serialVersionUID = 9061271587784526829L;
+  private static final Logger LOGGER = LoggerFactory.getLogger(GafferPopVertexStep.class);
+  private final transient GafferPopGraph graph;
+
+  public GafferPopVertexStep(final VertexStep<E> originalVertexStep) {
+    super(originalVertexStep.getTraversal(), originalVertexStep.getReturnClass(), originalVertexStep.getDirection(),
+        originalVertexStep.getEdgeLabels());
+    LOGGER.debug("Running custom VertexStep on GafferPopGraph");
+
+    this.graph = (GafferPopGraph) originalVertexStep.getTraversal().getGraph().get();
+  }
+
+  @Override
+  protected Iterator<E> flatMap(final Traverser.Admin<Vertex> traverser) {
+    List<GafferPopVertex> v = (List<GafferPopVertex>) traverser.get();
+    return (Iterator<E>) (Vertex.class.isAssignableFrom(this.getReturnClass()) ? this.vertices(v) : this.edges(v));
+  }
+
+  private Iterator<? extends Vertex> vertices(final List<GafferPopVertex> vertices) {
+    List<Object> vertexIds = vertices.stream().map(Element::id).collect(Collectors.toList());
+
+    String[] edgeLables = this.getEdgeLabels();
+    if (edgeLables.length == 0) {
+      return graph.adjVertices(vertexIds, getDirection());
+    }
+
+    View view = new View.Builder().edges(Arrays.asList(edgeLables)).build();
+    return graph.adjVerticesWithView(vertexIds, getDirection(), view);
+  }
+
+  private Iterator<? extends Edge> edges(final List<GafferPopVertex> vertices) {
+    List<Object> vertexIds = vertices.stream().map(Element::id).collect(Collectors.toList());
+
+    String[] edgeLables = this.getEdgeLabels();
+    if (edgeLables.length == 0) {
+      return graph.edges(vertexIds, getDirection());
+    }
+
+    View view = new View.Builder().edges(Arrays.asList(getEdgeLabels())).build();
+    return graph.edgesWithView(vertexIds, getDirection(), view);
+  }
+}

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/strategy/optimisation/GafferPopVertexStepStrategy.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/strategy/optimisation/GafferPopVertexStepStrategy.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.tinkerpop.process.traversal.strategy.optimisation;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal.Admin;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.FoldStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import uk.gov.gchq.gaffer.tinkerpop.process.traversal.step.GafferPopVertexStep;
+
+public final class GafferPopVertexStepStrategy
+    extends AbstractTraversalStrategy<TraversalStrategy.ProviderOptimizationStrategy>
+    implements TraversalStrategy.ProviderOptimizationStrategy {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(GafferPopVertexStepStrategy.class);
+  private static final GafferPopVertexStepStrategy INSTANCE = new GafferPopVertexStepStrategy();
+
+  private GafferPopVertexStepStrategy() {
+
+  }
+
+  @Override
+  public void apply(final Admin<?, ?> traversal) {
+    TraversalHelper.getStepsOfClass(VertexStep.class, traversal).forEach(originalGraphStep -> {
+      final GafferPopVertexStep<?> gafferPopVertexStep = new GafferPopVertexStep<>(originalGraphStep);
+
+      LOGGER.debug("Inserting FoldStep and replacing VertexStep");
+      TraversalHelper.replaceStep(originalGraphStep, gafferPopVertexStep, traversal);
+      TraversalHelper.insertBeforeStep(new FoldStep<>(originalGraphStep.getTraversal()), gafferPopVertexStep,
+          traversal);
+    });
+  }
+
+  public static GafferPopVertexStepStrategy instance() {
+    return INSTANCE;
+  }
+
+}

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederatedIT.java
@@ -91,7 +91,7 @@ class GafferPopFederatedIT {
 
         // Then
         assertThat(result)
-                .containsExactly(0.4, 0.4, 1.0);
+                .containsExactlyInAnyOrder(0.4, 0.4, 1.0);
     }
 
     @Test

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopHasStepIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopHasStepIT.java
@@ -222,7 +222,7 @@ class GafferPopHasStepIT {
 
          assertThat(result)
                  .extracting(r -> r.id())
-                 .containsExactlyInAnyOrder(RIPPLE.getId(), LOP.getId(), LOP.getId(), LOP.getId());
+                 .containsExactlyInAnyOrder(RIPPLE.getId(), LOP.getId());
      }
 
     @Test


### PR DESCRIPTION
Add a fold step before each vertex step to collect all vertex ids so the input to the new VertexStep is a list rather than single ids. This means we can do a single Gaffer query for all ids.

Note: input seeds are essentially deduped so expected output may change