### PR TITLE
Gh-3279: AddGraph Operation for Federated POC

### DIFF
--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/library/GraphLibrary.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/library/GraphLibrary.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
  * A {@code GraphLibrary} stores a graphId and its related Schema and StoreProperties.
  */
 public abstract class GraphLibrary {
-    protected static final Pattern ID_ALLOWED_CHARACTERS = Pattern.compile("[a-zA-Z0-9_]*");
+    protected static final Pattern ID_ALLOWED_CHARACTERS = Pattern.compile("\\w*");
     public static final String A_GRAPH_LIBRARY_CAN_T_BE_ADDED_WITH_A_NULL_S_GRAPH_ID_S = "A GraphLibrary can't be added with a null %s, graphId: %s";
 
     public abstract void initialise(final String path);

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/library/GraphLibrary.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/library/GraphLibrary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
@@ -64,6 +64,10 @@ import java.util.stream.Stream;
  */
 public class FederatedStore extends Store {
 
+    /**
+     * Separator used when the prefix of the federated store is added to a
+     * graph ID.
+     */
     public static final String PREFIX_SEPARATOR = "_";
 
     // Default graph IDs to execute on
@@ -81,7 +85,7 @@ public class FederatedStore extends Store {
     /**
      * Add a new graph so that it is available to this federated store.
      * Note the graph ID of the added graph will have the graph ID of
-     * this federated store prefixed to it so it will be identifiable
+     * this federated store prefixed to it so it will be identifiable,
      * and to avoid collisions with other stores.
      *
      * @param graph The serialisable instance of the graph.

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraph.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraph.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.operation;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import org.apache.commons.lang3.exception.CloneFailedException;
+
+import uk.gov.gchq.gaffer.commonutil.Required;
+import uk.gov.gchq.gaffer.graph.GraphConfig;
+import uk.gov.gchq.gaffer.operation.Operation;
+import uk.gov.gchq.gaffer.store.schema.Schema;
+import uk.gov.gchq.koryphe.Since;
+import uk.gov.gchq.koryphe.Summary;
+
+import java.util.Map;
+import java.util.Properties;
+
+@Since("2.3.1")
+@Summary("Adds a new Graph to the federated store")
+@JsonPropertyOrder(value = { "class", "graphConfig" }, alphabetic = true)
+public class AddGraph implements Operation {
+
+    @Required
+    private GraphConfig graphConfig;
+    private Schema schema;
+    private Properties properties;
+    private Map<String, String> options;
+
+    // Getters
+
+    /**
+     * Get current set {@link GraphConfig}.
+     *
+     * @return The graph config.
+     */
+    public GraphConfig getGraphConfig() {
+        return graphConfig;
+    }
+
+    /**
+     * Get the current set {@link Schema}.
+     *
+     * @return The schema.
+     */
+    public Schema getSchema() {
+        return schema;
+    }
+
+    /**
+     * Get the current set {@link Properties} for the store.
+     *
+     * @return The properties for the store.
+     */
+    public Properties getProperties() {
+        return properties;
+    }
+
+    // Setters
+
+    /**
+     * Set the {@link GraphConfig}.
+     *
+     * @param graphConfig The config to set.
+     */
+    public void setGraphConfig(final GraphConfig graphConfig) {
+        this.graphConfig = graphConfig;
+    }
+
+    /**
+     * Set the {@link Schema}.
+     *
+     * @param schema The schema to set.
+     */
+    public void setSchema(final Schema schema) {
+        this.schema = schema;
+    }
+
+    /**
+     * Set the {@link Properties} for the store.
+     *
+     * @param properties The properties to set.
+     */
+    public void setProperties(final Properties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    @Override
+    public void setOptions(final Map<String, String> options) {
+        this.options = options;
+    }
+
+    @Override
+    public Operation shallowClone() throws CloneFailedException {
+        return new AddGraph.Builder()
+                .graphConfig(graphConfig)
+                .schema(schema)
+                .properties(properties)
+                .options(options)
+                .build();
+    }
+
+    public static class Builder extends Operation.BaseBuilder<AddGraph, Builder> {
+        public Builder() {
+            super(new AddGraph());
+        }
+
+        /**
+         * Set the {@link GraphConfig}.
+         *
+         * @param graphConfig The config to set.
+         * @return The builder.
+         */
+        public Builder graphConfig(final GraphConfig graphConfig) {
+            _getOp().setGraphConfig(graphConfig);
+            return _self();
+        }
+
+        /**
+         * Set the {@link Schema}.
+         *
+         * @param schema The schema to set.
+         * @return The builder.
+         */
+        public Builder schema(final Schema schema) {
+            _getOp().setSchema(schema);
+            return _self();
+        }
+
+        /**
+         * Set the {@link Properties} for the store.
+         *
+         * @param properties The properties to set.
+         * @return The builder.
+         */
+        public Builder properties(final Properties properties) {
+            _getOp().setProperties(properties);
+            return _self();
+        }
+    }
+}

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraph.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraph.java
@@ -30,7 +30,7 @@ import uk.gov.gchq.koryphe.Summary;
 import java.util.Map;
 import java.util.Properties;
 
-@Since("2.3.1")
+@Since("2.4.0")
 @Summary("Adds a new Graph to the federated store")
 @JsonPropertyOrder(value = { "class", "graphConfig" }, alphabetic = true)
 public class AddGraph implements Operation {

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/add/AddGraphHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/add/AddGraphHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.operation.handler.add;
+
+import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
+import uk.gov.gchq.gaffer.federated.simple.operation.AddGraph;
+import uk.gov.gchq.gaffer.graph.GraphSerialisable;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.store.Context;
+import uk.gov.gchq.gaffer.store.Store;
+import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
+
+public class AddGraphHandler implements OperationHandler<AddGraph> {
+
+    @Override
+    public Void doOperation(final AddGraph operation, final Context context, final Store store) throws OperationException {
+        // Create the graph serialisable from the supplied params
+        GraphSerialisable newGraph = new GraphSerialisable.Builder()
+                .config(operation.getGraphConfig())
+                .properties(operation.getProperties())
+                .schema(operation.getSchema())
+                .build();
+
+        // Add the graph
+        ((FederatedStore) store).addGraph(newGraph);
+
+        return null;
+    }
+}

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/add/AddGraphHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/add/AddGraphHandler.java
@@ -31,8 +31,8 @@ public class AddGraphHandler implements OperationHandler<AddGraph> {
         // Create the graph serialisable from the supplied params
         GraphSerialisable newGraph = new GraphSerialisable.Builder()
                 .config(operation.getGraphConfig())
-                .properties(operation.getProperties())
                 .schema(operation.getSchema())
+                .properties(operation.getProperties())
                 .build();
 
         // Add the graph

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetSchemaHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetSchemaHandler.java
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package uk.gov.gchq.gaffer.federated.simple.operation.handler;
+package uk.gov.gchq.gaffer.federated.simple.operation.handler.get;
 
 import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
+import uk.gov.gchq.gaffer.federated.simple.operation.handler.FederatedOutputHandler;
 import uk.gov.gchq.gaffer.graph.GraphSerialisable;
 import uk.gov.gchq.gaffer.operation.OperationException;
 import uk.gov.gchq.gaffer.store.Context;

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
@@ -21,10 +21,11 @@ import org.junit.jupiter.api.Test;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.Entity;
 import uk.gov.gchq.gaffer.data.element.Properties;
+import uk.gov.gchq.gaffer.federated.simple.operation.AddGraph;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.FederatedOperationHandler;
 import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils;
 import uk.gov.gchq.gaffer.graph.Graph;
-import uk.gov.gchq.gaffer.graph.GraphSerialisable;
+import uk.gov.gchq.gaffer.graph.GraphConfig;
 import uk.gov.gchq.gaffer.operation.OperationChain;
 import uk.gov.gchq.gaffer.operation.OperationException;
 import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
@@ -32,8 +33,10 @@ import uk.gov.gchq.gaffer.operation.impl.get.GetAllElements;
 import uk.gov.gchq.gaffer.store.Context;
 import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.store.StoreProperties;
+import uk.gov.gchq.gaffer.store.schema.Schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils.StoreType;
 
 class FederatedStoreIT {
@@ -61,20 +64,6 @@ class FederatedStoreIT {
         graph2ElementProps.put("age", 29);
         Entity graph2Entity = new Entity(group, vertex, graph2ElementProps);
 
-        OperationChain<Void> addGraph1Elements = new OperationChain.Builder()
-            .first(new AddElements.Builder()
-                .input(graph1Entity)
-                .build())
-            .option(FederatedOperationHandler.OPT_GRAPH_IDS, graphId1)
-            .build();
-
-        OperationChain<Void> addGraph2Elements = new OperationChain.Builder()
-            .first(new AddElements.Builder()
-                .input(graph2Entity)
-                .build())
-            .option(FederatedOperationHandler.OPT_GRAPH_IDS, graphId2)
-            .build();
-
         // We expect only one entity to be returned that has merged properties
         Properties mergedProperties = new Properties();
         mergedProperties.putAll(graph1ElementProps);
@@ -83,18 +72,32 @@ class FederatedStoreIT {
 
         // Init store and add graphs
         store.initialise("federated", null, new StoreProperties());
-        store.addGraph(new GraphSerialisable(
-                graph1.getConfig(),
-                graph1.getSchema(),
-                graph1.getStoreProperties()));
-        store.addGraph(new GraphSerialisable(
-                graph2.getConfig(),
-                graph2.getSchema(),
-                graph2.getStoreProperties()));
+        store.execute(
+            new AddGraph.Builder()
+                .graphConfig(graph1.getConfig())
+                .schema(graph1.getSchema())
+                .properties(graph1.getStoreProperties().getProperties()).build(),
+            new Context());
+        store.execute(
+            new AddGraph.Builder()
+                .graphConfig(graph2.getConfig())
+                .schema(graph2.getSchema())
+                .properties(graph2.getStoreProperties().getProperties()).build(),
+            new Context());
 
-        // Add data into graphs
-        store.execute(addGraph1Elements, new Context());
-        store.execute(addGraph2Elements, new Context());
+        // Add element operations
+        AddElements addGraph1Elements = new AddElements.Builder()
+            .input(graph1Entity)
+            .option(FederatedOperationHandler.OPT_GRAPH_IDS, graphId1)
+            .build();
+        AddElements addGraph2Elements = new AddElements.Builder()
+            .input(graph2Entity)
+            .option(FederatedOperationHandler.OPT_GRAPH_IDS, graphId2)
+            .build();
+
+        // Add data into graphs (use the handle method to widen methods that are tested)
+        store.handleOperation(addGraph1Elements, new Context());
+        store.handleOperation(addGraph2Elements, new Context());
 
         // Run a get all on both graphs specifying that we want to merge elements
         OperationChain<Iterable<? extends Element>> getAllElements = new OperationChain.Builder()
@@ -108,6 +111,28 @@ class FederatedStoreIT {
 
         // Then
         assertThat(result).extracting(e -> (Element) e).containsOnly(expectedEntity);
+    }
+
+    @Test
+    void shouldPreventMixOfFederatedAndCoreOperationsInChain() throws StoreException {
+        // Given
+        FederatedStore federatedStore = new FederatedStore();
+        federatedStore.initialise("federated", null, new StoreProperties());
+
+        OperationChain<Iterable<? extends Element>> mixedChain = new OperationChain.Builder()
+            .first(new AddGraph.Builder()
+                .graphConfig(new GraphConfig("dummy"))
+                .schema(new Schema())
+                .properties(new java.util.Properties())
+                .build())
+            .then(new GetAllElements.Builder()
+                .build())
+            .build();
+
+        // When/Then
+        assertThatExceptionOfType(OperationException.class)
+            .isThrownBy(() -> federatedStore.execute(mixedChain, new Context()))
+            .withMessageContaining("Please submit each type separately");
     }
 
 }

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreTest.java
@@ -29,8 +29,6 @@ import uk.gov.gchq.gaffer.store.schema.Schema;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import static uk.gov.gchq.gaffer.federated.simple.FederatedStore.PREFIX_SEPARATOR;
-
 class FederatedStoreTest {
 
     @Test
@@ -68,10 +66,8 @@ class FederatedStoreTest {
         final GraphSerialisable graph1Serialisable = new GraphSerialisable(graph1.getConfig(), graph1.getSchema(), graph1.getStoreProperties());
         final GraphSerialisable graph2Serialisable = new GraphSerialisable(graph2.getConfig(), graph2.getSchema(), graph2.getStoreProperties());
 
-        final Graph expectedGraph1 = ModernDatasetUtils.getBlankGraphWithModernSchema(
-            this.getClass(), federatedGraphId + PREFIX_SEPARATOR + graphId1, StoreType.MAP);
-        final Graph expectedGraph2 = ModernDatasetUtils.getBlankGraphWithModernSchema(
-            this.getClass(), federatedGraphId + PREFIX_SEPARATOR + graphId2, StoreType.MAP);
+        final Graph expectedGraph1 = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId1, StoreType.MAP);
+        final Graph expectedGraph2 = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId2, StoreType.MAP);
 
         // When
         FederatedStore store = new FederatedStore();

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreTest.java
@@ -29,6 +29,8 @@ import uk.gov.gchq.gaffer.store.schema.Schema;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import static uk.gov.gchq.gaffer.federated.simple.FederatedStore.PREFIX_SEPARATOR;
+
 class FederatedStoreTest {
 
     @Test
@@ -56,6 +58,7 @@ class FederatedStoreTest {
     @Test
     void shouldAddGraphsViaStoreInterface() throws StoreException {
         // Given
+        final String federatedGraphId = "federated";
         final String graphId1 = "graph1";
         final String graphId2 = "graph2";
 
@@ -65,14 +68,27 @@ class FederatedStoreTest {
         final GraphSerialisable graph1Serialisable = new GraphSerialisable(graph1.getConfig(), graph1.getSchema(), graph1.getStoreProperties());
         final GraphSerialisable graph2Serialisable = new GraphSerialisable(graph2.getConfig(), graph2.getSchema(), graph2.getStoreProperties());
 
+        final Graph expectedGraph1 = ModernDatasetUtils.getBlankGraphWithModernSchema(
+            this.getClass(), federatedGraphId + PREFIX_SEPARATOR + graphId1, StoreType.MAP);
+        final Graph expectedGraph2 = ModernDatasetUtils.getBlankGraphWithModernSchema(
+            this.getClass(), federatedGraphId + PREFIX_SEPARATOR + graphId2, StoreType.MAP);
+
         // When
         FederatedStore store = new FederatedStore();
-        store.initialise("federated", null, new StoreProperties());
+        store.initialise(federatedGraphId, null, new StoreProperties());
         store.addGraph(graph1Serialisable);
         store.addGraph(graph2Serialisable);
 
         // Then
-        assertThat(store.getGraph(graphId1)).isEqualTo(graph1Serialisable);
-        assertThat(store.getGraph(graphId2)).isEqualTo(graph2Serialisable);
+        assertThat(store.getGraph(graphId1))
+            .isEqualTo(new GraphSerialisable(
+                expectedGraph1.getConfig(),
+                expectedGraph1.getSchema(),
+                expectedGraph1.getStoreProperties()));
+        assertThat(store.getGraph(graphId2))
+            .isEqualTo(new GraphSerialisable(
+                expectedGraph2.getConfig(),
+                expectedGraph2.getSchema(),
+                expectedGraph2.getStoreProperties()));
     }
 }

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraphTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraphTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.operation;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.gaffer.exception.SerialisationException;
+import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
+import uk.gov.gchq.gaffer.graph.GraphConfig;
+import uk.gov.gchq.gaffer.graph.GraphSerialisable;
+import uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser;
+import uk.gov.gchq.gaffer.mapstore.MapStoreProperties;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.store.Context;
+import uk.gov.gchq.gaffer.store.StoreException;
+import uk.gov.gchq.gaffer.store.StoreProperties;
+import uk.gov.gchq.gaffer.store.schema.Schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static uk.gov.gchq.gaffer.federated.simple.FederatedStore.PREFIX_SEPARATOR;
+
+import java.util.Properties;
+
+class AddGraphTest {
+
+    @Test
+    void shouldAddGraphUsingBuilder() throws StoreException, OperationException {
+        // Given
+        final String federatedGraphId = "federated";
+        final String graphId = "newGraph";
+
+        // Create the expected graph that should've been added
+        final GraphSerialisable expectedSerialisable = new GraphSerialisable.Builder()
+                .config(new GraphConfig(graphId))
+                .schema(new Schema())
+                .properties(new Properties())
+                .build();
+        // Add the expected prefix the federated store adds
+        expectedSerialisable.getConfig().setGraphId(federatedGraphId + PREFIX_SEPARATOR + graphId);
+
+        // Build operation
+        AddGraph operation = new AddGraph.Builder()
+                .graphConfig(new GraphConfig(graphId))
+                .schema(new Schema())
+                .properties(new Properties())
+                .build();
+
+        // When
+        FederatedStore federatedStore = new FederatedStore();
+        federatedStore.initialise(federatedGraphId, null, new StoreProperties());
+
+        federatedStore.execute(operation, new Context());
+        GraphSerialisable addedGraph = federatedStore.getGraph(graphId);
+
+        // Then
+        assertThat(addedGraph.getConfig().getGraphId())
+            .isEqualTo(expectedSerialisable.getConfig().getGraphId());
+        assertThat(addedGraph.getSchema())
+            .isEqualTo(expectedSerialisable.getSchema());
+        assertThat(addedGraph.getStoreProperties().getProperties())
+            .isEqualTo(expectedSerialisable.getStoreProperties().getProperties());
+    }
+
+    @Test
+    void shouldAddGraphUsingJSONSerialisation() throws StoreException, OperationException, SerialisationException {
+        // Given
+        final String federatedGraphId = "federated";
+        final String graphId = "newGraph";
+        final StoreProperties storeProperties = new MapStoreProperties();
+        storeProperties.set("gaffer.store.class", "uk.gov.gchq.gaffer.mapstore.MapStore");
+
+        // Set up the graph we expect to be added
+        final GraphSerialisable expectedSerialisable = new GraphSerialisable(
+            new GraphConfig(graphId), null, storeProperties);
+        // Add the expected prefix the federated store adds
+        expectedSerialisable.getConfig().setGraphId(federatedGraphId + PREFIX_SEPARATOR + graphId);
+
+        // JSON version of the operation
+        final JSONObject jsonOperation = new JSONObject()
+            .put("class", "uk.gov.gchq.gaffer.federated.simple.operation.AddGraph")
+            .put("graphConfig", new JSONObject()
+                .put("graphId", graphId))
+            .put("properties", new JSONObject()
+                .put("gaffer.store.class", "uk.gov.gchq.gaffer.mapstore.MapStore")
+                .put("gaffer.store.properties.class", "uk.gov.gchq.gaffer.mapstore.MapStoreProperties"));
+
+        FederatedStore federatedStore = new FederatedStore();
+        federatedStore.initialise(federatedGraphId, null, new StoreProperties());
+
+        // When
+        AddGraph operation = JSONSerialiser.deserialise(jsonOperation.toString(), AddGraph.class);
+        federatedStore.execute(operation, new Context());
+
+        GraphSerialisable addedGraph = federatedStore.getGraph(graphId);
+
+        // Then
+        assertThat(addedGraph.getGraphId()).isEqualTo(expectedSerialisable.getGraphId());
+        assertThat(addedGraph.getSchema()).isEqualTo(expectedSerialisable.getSchema());
+        assertThat(addedGraph.getStoreProperties().getProperties())
+            .isEqualTo(expectedSerialisable.getStoreProperties().getProperties());
+    }
+
+    @Test
+    void shouldPreventAddingGraphWithoutGraphConfig() throws StoreException {
+        // Given
+        FederatedStore federatedStore = new FederatedStore();
+        federatedStore.initialise("federated", null, new StoreProperties());
+
+        AddGraph operation = new AddGraph.Builder()
+            .schema(new Schema())
+            .properties(new Properties())
+            .build();
+        Context context = new Context();
+
+        // When/Then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() ->federatedStore.execute(operation, context))
+            .withMessageContaining("graphConfig is required");
+    }
+
+}

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraphTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraphTest.java
@@ -33,7 +33,6 @@ import uk.gov.gchq.gaffer.store.schema.Schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static uk.gov.gchq.gaffer.federated.simple.FederatedStore.PREFIX_SEPARATOR;
 
 import java.util.Properties;
 
@@ -51,8 +50,6 @@ class AddGraphTest {
                 .schema(new Schema())
                 .properties(new Properties())
                 .build();
-        // Add the expected prefix the federated store adds
-        expectedSerialisable.getConfig().setGraphId(federatedGraphId + PREFIX_SEPARATOR + graphId);
 
         // Build operation
         final AddGraph operation = new AddGraph.Builder()
@@ -88,8 +85,6 @@ class AddGraphTest {
         // Set up the graph we expect to be added
         final GraphSerialisable expectedSerialisable = new GraphSerialisable(
             new GraphConfig(graphId), null, storeProperties);
-        // Add the expected prefix the federated store adds
-        expectedSerialisable.getConfig().setGraphId(federatedGraphId + PREFIX_SEPARATOR + graphId);
 
         // JSON version of the operation
         final JSONObject jsonOperation = new JSONObject()


### PR DESCRIPTION
Adds an `AddGraph` operation to the simple federated POC. To do this some additional logic in the operation handlers has also been added as well as, ensuring a prefix is added to any sub graphs in the federated store to avoid collisions with other instances. 

# Related issue

- Resolve #3279