### PR TITLE
Gh-3283: Remove Graph operation for Federated POC

### DIFF
--- a/store-implementation/simple-federated-store/pom.xml
+++ b/store-implementation/simple-federated-store/pom.xml
@@ -44,6 +44,26 @@
             <version>${project.parent.version}</version>
         </dependency>
 
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>uk.gov.gchq.gaffer</groupId>
+            <artifactId>accumulo-store</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.gchq.gaffer</groupId>
+            <artifactId>accumulo-store</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.accumulo</groupId>
+            <artifactId>accumulo-minicluster</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
@@ -80,7 +80,7 @@ public class FederatedStore extends Store {
      *
      * @param graph The serialisable instance of the graph.
      *
-     * @throws IllegalArgumentException If already a graph wit the supplied ID
+     * @throws IllegalArgumentException If already a graph with the supplied ID
      */
     public void addGraph(final GraphSerialisable graph) {
         // Make sure graph ID doesn't already exist
@@ -89,6 +89,18 @@ public class FederatedStore extends Store {
                 "A graph with Graph ID: '" + graph.getGraphId() + "' has already been added to this store");
         }
         graphs.add(new GraphSerialisable(graph.getConfig(), graph.getSchema(), graph.getStoreProperties()));
+    }
+
+    /**
+     * Remove a graph from the scope of this store.
+     *
+     * @param graphId The graph ID of the graph to remove.
+     *
+     * @throws IllegalArgumentException If graph not found.
+     */
+    public void removeGraph(final String graphId) {
+        GraphSerialisable graphToRemove = getGraph(graphId);
+        graphs.remove(graphToRemove);
     }
 
     /**

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
@@ -122,6 +122,15 @@ public class FederatedStore extends Store {
     }
 
     /**
+     * Returns a list of all the graphs available to this store.
+     *
+     * @return List of {@link GraphSerialisable}s
+     */
+    public List<GraphSerialisable> getAllGraphs() {
+        return graphs;
+    }
+
+    /**
      * Get the default list of graph IDs for this federated store.
      *
      * @return The default list.

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
@@ -20,10 +20,14 @@ import uk.gov.gchq.gaffer.core.exception.GafferRuntimeException;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.id.EntityId;
 import uk.gov.gchq.gaffer.federated.simple.operation.AddGraph;
+import uk.gov.gchq.gaffer.federated.simple.operation.GetAllGraphIds;
+import uk.gov.gchq.gaffer.federated.simple.operation.RemoveGraph;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.FederatedOperationHandler;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.FederatedOutputHandler;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.add.AddGraphHandler;
+import uk.gov.gchq.gaffer.federated.simple.operation.handler.get.GetAllGraphIdsHandler;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.get.GetSchemaHandler;
+import uk.gov.gchq.gaffer.federated.simple.operation.handler.misc.RemoveGraphHandler;
 import uk.gov.gchq.gaffer.graph.GraphSerialisable;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.OperationChain;
@@ -72,7 +76,9 @@ public class FederatedStore extends Store {
     // Store specific handlers
     public final Map<Class<? extends Operation>, OperationHandler<?>> storeHandlers = Stream.of(
             new SimpleEntry<>(AddGraph.class, new AddGraphHandler()),
-            new SimpleEntry<>(GetSchema.class, new GetSchemaHandler()))
+            new SimpleEntry<>(GetAllGraphIds.class, new GetAllGraphIdsHandler()),
+            new SimpleEntry<>(GetSchema.class, new GetSchemaHandler()),
+            new SimpleEntry<>(RemoveGraph.class, new RemoveGraphHandler()))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     /**

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/GetAllGraphIds.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/GetAllGraphIds.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.operation;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import org.apache.commons.lang3.exception.CloneFailedException;
+
+import uk.gov.gchq.gaffer.operation.Operation;
+import uk.gov.gchq.gaffer.operation.io.Output;
+import uk.gov.gchq.gaffer.operation.serialisation.TypeReferenceImpl;
+import uk.gov.gchq.koryphe.Since;
+import uk.gov.gchq.koryphe.Summary;
+
+import java.util.Map;
+import java.util.Set;
+
+@Since("2.4.0")
+@Summary("Get all the graph IDs available to a federated store")
+public class GetAllGraphIds implements Output<Set<String>> {
+
+    private Map<String, String> options;
+
+    @Override
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    @Override
+    public void setOptions(final Map<String, String> options) {
+        this.options = options;
+    }
+
+    @Override
+    public Operation shallowClone() throws CloneFailedException {
+        return new GetAllGraphIds();
+    }
+
+    @Override
+    public TypeReference<Set<String>> getOutputTypeReference() {
+        return new TypeReferenceImpl.Set<>();
+    }
+
+    public static class Builder extends Operation.BaseBuilder<GetAllGraphIds, Builder> {
+        public Builder() {
+            super(new GetAllGraphIds());
+        }
+    }
+
+}

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/RemoveGraph.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/RemoveGraph.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.operation;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import org.apache.commons.lang3.exception.CloneFailedException;
+
+import uk.gov.gchq.gaffer.commonutil.Required;
+import uk.gov.gchq.gaffer.operation.Operation;
+import uk.gov.gchq.koryphe.Since;
+import uk.gov.gchq.koryphe.Summary;
+
+import java.util.Map;
+
+@Since("2.4.0")
+@Summary("Removes a new Graph from the federated store optionally deleting all data")
+@JsonPropertyOrder(value = { "class", "graphId" }, alphabetic = true)
+public class RemoveGraph implements Operation {
+
+    @Required
+    private String graphId;
+    private boolean deleteAllData = false;
+    private Map<String, String> options;
+
+    // Getters
+
+    /**
+     * Get the graph ID of the graph to remove.
+     *
+     * @return The graph ID.
+     */
+    public String getGraphId() {
+        return graphId;
+    }
+
+    /**
+     * Get whether to delete all the data.
+     *
+     * @return True if deleting all.
+     */
+    public boolean getDeleteAllData() {
+        return deleteAllData;
+    }
+
+    // Setters
+
+    /**
+     * Set the graph ID of the graph to remove.
+     *
+     * @param graphId The graph ID.
+     */
+    public void setGraphId(final String graphId) {
+        this.graphId = graphId;
+    }
+
+    /**
+     * Set whether to delete all data as well.
+     *
+     * @param deleteAllData Delete all.
+     */
+    public void setDeleteAllData(final boolean deleteAllData) {
+        this.deleteAllData = deleteAllData;
+    }
+
+    @Override
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    @Override
+    public void setOptions(final Map<String, String> options) {
+        this.options = options;
+    }
+
+    @Override
+    public Operation shallowClone() throws CloneFailedException {
+        return new RemoveGraph.Builder()
+            .graphId(graphId)
+            .deleteAllData(deleteAllData)
+            .options(options)
+            .build();
+    }
+
+    public static class Builder extends Operation.BaseBuilder<RemoveGraph, Builder> {
+        public Builder() {
+            super(new RemoveGraph());
+        }
+
+        /**
+         * Set the graph ID.
+         *
+         * @param graphId The graph ID to set.
+         * @return The builder.
+         */
+        public Builder graphId(final String graphId) {
+            _getOp().setGraphId(graphId);
+            return _self();
+        }
+
+        /**
+         * Set if to delete all data from the graph.
+         *
+         * @param deleteAllData Delete all the data.
+         * @return The builder.
+         */
+        public Builder deleteAllData(final boolean deleteAllData) {
+            _getOp().setDeleteAllData(deleteAllData);
+            return _self();
+        }
+
+    }
+
+}

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphIdsHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphIdsHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.operation.handler.get;
+
+import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
+import uk.gov.gchq.gaffer.federated.simple.operation.GetAllGraphIds;
+import uk.gov.gchq.gaffer.graph.GraphSerialisable;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.store.Context;
+import uk.gov.gchq.gaffer.store.Store;
+import uk.gov.gchq.gaffer.store.operation.handler.OutputOperationHandler;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class GetAllGraphIdsHandler implements OutputOperationHandler<GetAllGraphIds, Set<String>> {
+
+    @Override
+    public Set<String> doOperation(final GetAllGraphIds operation, final Context context, final Store store) throws OperationException {
+        // Get all the graphs and convert to a set of just IDs
+        return ((FederatedStore) store).getAllGraphs().stream()
+            .map(GraphSerialisable::getGraphId)
+            .collect(Collectors.toSet());
+    }
+}

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/RemoveGraphHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/RemoveGraphHandler.java
@@ -28,7 +28,7 @@ import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
 public class RemoveGraphHandler implements OperationHandler<RemoveGraph> {
 
     @Override
-    public Object doOperation(RemoveGraph operation, Context context, Store store) throws OperationException {
+    public Object doOperation(final RemoveGraph operation, final Context context, final Store store) throws OperationException {
         // If asked to delete all data then run that operation first on the requested graph
         if (operation.getDeleteAllData()) {
             DeleteAllData deleteAllOp = new DeleteAllData.Builder()

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/RemoveGraphHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/RemoveGraphHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.operation.handler.misc;
+
+import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
+import uk.gov.gchq.gaffer.federated.simple.operation.RemoveGraph;
+import uk.gov.gchq.gaffer.federated.simple.operation.handler.FederatedOperationHandler;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.store.Context;
+import uk.gov.gchq.gaffer.store.Store;
+import uk.gov.gchq.gaffer.store.operation.DeleteAllData;
+import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
+
+public class RemoveGraphHandler implements OperationHandler<RemoveGraph> {
+
+    @Override
+    public Object doOperation(RemoveGraph operation, Context context, Store store) throws OperationException {
+        // If asked to delete all data then run that operation first on the requested graph
+        if (operation.getDeleteAllData()) {
+            DeleteAllData deleteAllOp = new DeleteAllData.Builder()
+                .option(FederatedOperationHandler.OPT_GRAPH_IDS, operation.getGraphId())
+                .build();
+            store.execute(deleteAllOp, context);
+        }
+
+        // Remove the graph from the scope of the store
+        ((FederatedStore) store).removeGraph(operation.getGraphId());
+
+        // Nothing to return
+        return null;
+    }
+
+}

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
@@ -22,6 +22,7 @@ import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.Entity;
 import uk.gov.gchq.gaffer.data.element.Properties;
 import uk.gov.gchq.gaffer.federated.simple.operation.AddGraph;
+import uk.gov.gchq.gaffer.federated.simple.operation.GetAllGraphIds;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.FederatedOperationHandler;
 import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils;
 import uk.gov.gchq.gaffer.graph.Graph;
@@ -38,6 +39,8 @@ import uk.gov.gchq.gaffer.store.schema.Schema;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils.StoreType;
+
+import java.util.Set;
 
 class FederatedStoreIT {
 
@@ -133,6 +136,33 @@ class FederatedStoreIT {
         assertThatExceptionOfType(OperationException.class)
             .isThrownBy(() -> federatedStore.execute(mixedChain, new Context()))
             .withMessageContaining("Please submit each type separately");
+    }
+
+    @Test
+    void shouldAddAndGetAllGraphs() throws StoreException, OperationException {
+        // Given
+        final String federatedGraphId = "federated";
+        final String graphId = "newGraph";
+
+        // AddGraph operation
+        final AddGraph addGraph = new AddGraph.Builder()
+                .graphConfig(new GraphConfig(graphId))
+                .schema(new Schema())
+                .properties(new java.util.Properties())
+                .build();
+
+        // GetAllGraphIds operation
+        final GetAllGraphIds getAllGraphIds = new GetAllGraphIds();
+
+        // When
+        final FederatedStore federatedStore = new FederatedStore();
+        federatedStore.initialise(federatedGraphId, null, new StoreProperties());
+
+        federatedStore.execute(addGraph, new Context());
+        final Set<String> graphIds = federatedStore.execute(getAllGraphIds, new Context());
+
+        assertThat(graphIds).containsExactly(graphId);
+
     }
 
 }

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreTest.java
@@ -54,7 +54,7 @@ class FederatedStoreTest {
     }
 
     @Test
-    void shouldAddGraphsViaStoreInterface() throws StoreException {
+    void shouldAddAndGetGraphsViaStoreInterface() throws StoreException {
         // Given
         final String federatedGraphId = "federated";
         final String graphId1 = "graph1";
@@ -76,13 +76,22 @@ class FederatedStoreTest {
         store.addGraph(graph2Serialisable);
 
         // Then
-        assertThat(store.getGraph(graphId1))
-            .isEqualTo(new GraphSerialisable(
+        assertThat(store.getGraph(graphId1)).isEqualTo(
+            new GraphSerialisable(
                 expectedGraph1.getConfig(),
                 expectedGraph1.getSchema(),
                 expectedGraph1.getStoreProperties()));
-        assertThat(store.getGraph(graphId2))
-            .isEqualTo(new GraphSerialisable(
+        assertThat(store.getGraph(graphId2)).isEqualTo(
+            new GraphSerialisable(
+                expectedGraph2.getConfig(),
+                expectedGraph2.getSchema(),
+                expectedGraph2.getStoreProperties()));
+        assertThat(store.getAllGraphs()).containsExactlyInAnyOrder(
+            new GraphSerialisable(
+                expectedGraph1.getConfig(),
+                expectedGraph1.getSchema(),
+                expectedGraph1.getStoreProperties()),
+            new GraphSerialisable(
                 expectedGraph2.getConfig(),
                 expectedGraph2.getSchema(),
                 expectedGraph2.getStoreProperties()));

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/RemoveGraphTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/RemoveGraphTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.operation;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.gaffer.data.element.Element;
+import uk.gov.gchq.gaffer.data.element.Entity;
+import uk.gov.gchq.gaffer.data.element.Properties;
+import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
+import uk.gov.gchq.gaffer.federated.simple.operation.handler.FederatedOperationHandler;
+import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils;
+import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils.StoreType;
+import uk.gov.gchq.gaffer.graph.Graph;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
+import uk.gov.gchq.gaffer.operation.impl.get.GetAllElements;
+import uk.gov.gchq.gaffer.store.Context;
+import uk.gov.gchq.gaffer.store.StoreException;
+import uk.gov.gchq.gaffer.store.StoreProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class RemoveGraphTest {
+
+    @Test
+    void shouldRemoveGraphAndPreserveData() throws StoreException, OperationException {
+        // Given
+        final String federatedGraphId = "federated";
+        final String graphId = "shouldRemoveGraphAndPreserveData";
+        final Graph originalGraph = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId, StoreType.ACCUMULO);
+
+        // Entity so we can check data still exists
+        final Properties graphEntityProps = new Properties();
+        graphEntityProps.put("name", "marko");
+        final Entity graphEntity = new Entity("person", "1", graphEntityProps);
+
+        // Remove graph operation
+        final RemoveGraph removeGraph = new RemoveGraph.Builder()
+            .graphId(graphId)
+            .build();
+
+        // When
+        final FederatedStore federatedStore = new FederatedStore();
+        federatedStore.initialise(federatedGraphId, null, new StoreProperties());
+
+        // Add the graph and its elements then remove it
+        addGraphWithElements(federatedStore, originalGraph, graphEntity);
+        federatedStore.execute(removeGraph, new Context());
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> federatedStore.getGraph(graphId))
+            .withMessageContaining("not available to this federated store");
+
+        // See if the graph  data still exists in the cluster
+        Iterable<? extends Element> result = originalGraph.execute(new GetAllElements(), new Context());
+        assertThat(result).extracting(e -> (Element) e).containsExactly(graphEntity);
+    }
+
+    @Test
+    void shouldRemoveGraphAndDeleteAllData() throws StoreException, OperationException {
+        // Given
+        final String federatedGraphId = "federated";
+        final String graphId = "shouldRemoveGraphAndDeleteAllData";
+        final Graph originalGraph = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId, StoreType.ACCUMULO);
+
+        // Entity so we can check data still exists
+        final Properties graphEntityProps = new Properties();
+        graphEntityProps.put("name", "marko");
+        final Entity graphEntity = new Entity("person", "1", graphEntityProps);
+
+        // Remove graph operation with delete all option set
+        final RemoveGraph removeGraph = new RemoveGraph.Builder()
+                .graphId(graphId)
+                .deleteAllData(true)
+                .build();
+
+        // When
+        final FederatedStore federatedStore = new FederatedStore();
+        federatedStore.initialise(federatedGraphId, null, new StoreProperties());
+
+        // Add the graph and its elements then remove it
+        addGraphWithElements(federatedStore, originalGraph, graphEntity);
+        federatedStore.execute(removeGraph, new Context());
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> federatedStore.getGraph(graphId))
+                .withMessageContaining("not available to this federated store");
+
+        // See if the graph data still exists in the cluster
+        Iterable<? extends Element> result = originalGraph.execute(new GetAllElements(), new Context());
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldNotRemoveGraphThatDoesntExist() throws StoreException {
+        // Given
+        final String federatedGraphId = "federated";
+        final String graphId = "shouldNotRemoveGraphThatDoesntExist";
+        final RemoveGraph removeGraph = new RemoveGraph.Builder()
+                .graphId(graphId)
+                .build();
+        final Context context = new Context();
+
+        // When
+        final FederatedStore federatedStore = new FederatedStore();
+        federatedStore.initialise(federatedGraphId, null, new StoreProperties());
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> federatedStore.execute(removeGraph, context))
+                .withMessageContaining("not available to this federated store");
+    }
+
+    /**
+     * Adds a given graph and elements to a federated store.
+     *
+     * @param store The federated store
+     * @param graph The graph to add
+     * @param elements The elements to add to the graph
+     *
+     * @throws OperationException If fails
+     */
+    private void addGraphWithElements(FederatedStore store, Graph graph, Element... elements) throws OperationException {
+        // Add Graph operation
+        final AddGraph addGraph = new AddGraph.Builder()
+                .graphConfig(graph.getConfig())
+                .schema(graph.getSchema())
+                .properties(graph.getStoreProperties().getProperties())
+                .build();
+
+        // Add elements operation
+        final AddElements addGraphElements = new AddElements.Builder()
+                .input(elements)
+                .option(FederatedOperationHandler.OPT_GRAPH_IDS, graph.getGraphId())
+                .build();
+
+        // Add the graph and its elements then remove it
+        store.execute(addGraph, new Context());
+        store.execute(addGraphElements, new Context());
+    }
+}

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/util/ModernDatasetUtils.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/util/ModernDatasetUtils.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.federated.simple.util;
 
+import uk.gov.gchq.gaffer.accumulostore.AccumuloProperties;
 import uk.gov.gchq.gaffer.commonutil.StreamUtil;
 import uk.gov.gchq.gaffer.graph.Graph;
 import uk.gov.gchq.gaffer.graph.GraphConfig;
@@ -30,6 +31,8 @@ public final class ModernDatasetUtils {
 
     public static final MapStoreProperties MAP_STORE_PROPERTIES = MapStoreProperties
         .loadStoreProperties("/map-store.properties");
+    public static final AccumuloProperties ACCUMULO_STORE_PROPERTIES = AccumuloProperties
+            .loadStoreProperties("/accumulo-store.properties");
 
     public static Graph getBlankGraphWithModernSchema(Class<?> clazz, String graphId, StoreType storeType) {
         return new Graph.Builder()
@@ -45,13 +48,15 @@ public final class ModernDatasetUtils {
      * Available store types for sub graphs
      */
     public enum StoreType {
-        MAP;
+        MAP, ACCUMULO;
     }
 
     public static StoreProperties getStoreProperties(StoreType storeType) {
         switch (storeType) {
             case MAP:
                 return MAP_STORE_PROPERTIES;
+            case ACCUMULO:
+                return ACCUMULO_STORE_PROPERTIES;
             default:
                 throw new IllegalArgumentException("Unknown StoreType: " + storeType);
         }

--- a/store-implementation/simple-federated-store/src/test/resources/accumulo-store.properties
+++ b/store-implementation/simple-federated-store/src/test/resources/accumulo-store.properties
@@ -1,0 +1,21 @@
+#
+# Copyright 2024 Crown Copyright
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+gaffer.store.class=uk.gov.gchq.gaffer.accumulostore.SingleUseMiniAccumuloStore
+accumulo.instance=federatedTestInstance
+accumulo.zookeepers=localhost
+accumulo.user=user01
+accumulo.password=password
+accumulo.mini.visibilities=auth1,auth2


### PR DESCRIPTION
Adds a remove graph and get all graph IDs operation to the simple federated store. The remove graph can optionally delete all data or just de reference the graph.