### PR TITLE
Gh 3288: Store Graphs in cache in federated POC

### DIFF
--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
@@ -61,7 +61,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -209,7 +208,7 @@ public class FederatedStore extends Store {
         }
         super.initialise(graphId, new Schema(), properties);
 
-        graphCache = new Cache<>("federatedGraphCache-" + UUID.randomUUID().toString());
+        graphCache = new Cache<>("federatedGraphCache-" + graphId);
     }
 
     @Override

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/merge/DefaultResultAccumulator.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/merge/DefaultResultAccumulator.java
@@ -75,7 +75,9 @@ public class DefaultResultAccumulator<T> extends FederatedResultAccumulator<T> {
             }
 
             // By default just chain iterables together
-            return (T) IterableUtils.chainedIterable((Iterable<?>) state, updateIterable);
+            // (need to use the iterator to make sure the FluentIterable under the hood serialises correctly)
+            Iterable<Object> chained = () -> IterableUtils.chainedIterable((Iterable<?>) state, updateIterable).iterator();
+            return (T) chained;
         }
 
         return update;

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphIdsHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphIdsHandler.java
@@ -26,13 +26,14 @@ import uk.gov.gchq.gaffer.store.operation.handler.OutputOperationHandler;
 
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public class GetAllGraphIdsHandler implements OutputOperationHandler<GetAllGraphIds, Set<String>> {
 
     @Override
     public Set<String> doOperation(final GetAllGraphIds operation, final Context context, final Store store) throws OperationException {
         // Get all the graphs and convert to a set of just IDs
-        return ((FederatedStore) store).getAllGraphs().stream()
+        return StreamSupport.stream(((FederatedStore) store).getAllGraphs().spliterator(), false)
             .map(GraphSerialisable::getGraphId)
             .collect(Collectors.toSet());
     }

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
@@ -16,8 +16,10 @@
 
 package uk.gov.gchq.gaffer.federated.simple;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.Entity;
 import uk.gov.gchq.gaffer.data.element.Properties;
@@ -43,6 +45,11 @@ import static uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils.StoreT
 import java.util.Set;
 
 class FederatedStoreIT {
+
+    @AfterEach
+    void reset() {
+        CacheServiceLoader.shutdown();
+    }
 
     @Test
     void shouldFederateElementsByAggregation() throws StoreException, OperationException {

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreTest.java
@@ -18,6 +18,7 @@ package uk.gov.gchq.gaffer.federated.simple;
 
 import org.junit.jupiter.api.Test;
 
+import uk.gov.gchq.gaffer.cache.exception.CacheOperationException;
 import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils;
 import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils.StoreType;
 import uk.gov.gchq.gaffer.graph.Graph;
@@ -54,7 +55,7 @@ class FederatedStoreTest {
     }
 
     @Test
-    void shouldAddAndGetGraphsViaStoreInterface() throws StoreException {
+    void shouldAddAndGetGraphsViaStoreInterface() throws StoreException, CacheOperationException {
         // Given
         final String federatedGraphId = "federated";
         final String graphId1 = "graph1";

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreTest.java
@@ -16,8 +16,10 @@
 
 package uk.gov.gchq.gaffer.federated.simple;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
 import uk.gov.gchq.gaffer.cache.exception.CacheOperationException;
 import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils;
 import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils.StoreType;
@@ -31,6 +33,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class FederatedStoreTest {
+
+    @AfterEach
+    void reset() {
+        CacheServiceLoader.shutdown();
+    }
 
     @Test
     void shouldInitialiseNewStore() throws StoreException {

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraphTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraphTest.java
@@ -17,8 +17,10 @@
 package uk.gov.gchq.gaffer.federated.simple.operation;
 
 import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
 import uk.gov.gchq.gaffer.cache.exception.CacheOperationException;
 import uk.gov.gchq.gaffer.exception.SerialisationException;
 import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
@@ -38,6 +40,11 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import java.util.Properties;
 
 class AddGraphTest {
+
+    @AfterEach
+    void reset() {
+        CacheServiceLoader.shutdown();
+    }
 
     @Test
     void shouldAddGraphUsingBuilder() throws StoreException, OperationException, CacheOperationException {

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraphTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraphTest.java
@@ -19,6 +19,7 @@ package uk.gov.gchq.gaffer.federated.simple.operation;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
+import uk.gov.gchq.gaffer.cache.exception.CacheOperationException;
 import uk.gov.gchq.gaffer.exception.SerialisationException;
 import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
 import uk.gov.gchq.gaffer.graph.GraphConfig;
@@ -39,7 +40,7 @@ import java.util.Properties;
 class AddGraphTest {
 
     @Test
-    void shouldAddGraphUsingBuilder() throws StoreException, OperationException {
+    void shouldAddGraphUsingBuilder() throws StoreException, OperationException, CacheOperationException {
         // Given
         final String federatedGraphId = "federated";
         final String graphId = "newGraph";
@@ -75,7 +76,7 @@ class AddGraphTest {
     }
 
     @Test
-    void shouldAddGraphUsingJSONSerialisation() throws StoreException, OperationException, SerialisationException {
+    void shouldAddGraphUsingJSONSerialisation() throws StoreException, OperationException, SerialisationException, CacheOperationException {
         // Given
         final String federatedGraphId = "federated";
         final String graphId = "newGraph";

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/RemoveGraphTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/RemoveGraphTest.java
@@ -16,8 +16,10 @@
 
 package uk.gov.gchq.gaffer.federated.simple.operation;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.Entity;
 import uk.gov.gchq.gaffer.data.element.Properties;
@@ -37,6 +39,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class RemoveGraphTest {
+
+    @AfterEach
+    void reset() {
+        CacheServiceLoader.shutdown();
+    }
 
     @Test
     void shouldRemoveGraphAndPreserveData() throws StoreException, OperationException {


### PR DESCRIPTION
Fairly simple just moves to using the default gaffer cache for storing graphs that have been added to the federated store.

# Related issue

- Resolve #3288