### PR TITLE
Gh-3292: REST API Gremlin Timeout and Execute Endpoints

### DIFF
--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/util/modern/Person.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/util/modern/Person.java
@@ -17,9 +17,12 @@
 package uk.gov.gchq.gaffer.tinkerpop.util.modern;
 
 import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import uk.gov.gchq.gaffer.commonutil.pair.Pair;
 import uk.gov.gchq.gaffer.data.element.Entity;
+import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph;
+import uk.gov.gchq.gaffer.tinkerpop.generator.GafferPopVertexGenerator;
 
 import static uk.gov.gchq.gaffer.tinkerpop.util.modern.GafferPopModernTestUtils.AGE;
 import static uk.gov.gchq.gaffer.tinkerpop.util.modern.GafferPopModernTestUtils.NAME;
@@ -162,5 +165,9 @@ public class Person {
                 .property(NAME, name)
                 .property(AGE, age)
                 .build();
+    }
+
+    public Vertex toVertex(GafferPopGraph graph) {
+        return new GafferPopVertexGenerator(graph)._apply(toEntity());
     }
 }

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/config/GremlinConfig.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/config/GremlinConfig.java
@@ -21,7 +21,6 @@ import org.apache.commons.configuration2.builder.fluent.Configurations;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
@@ -32,7 +31,6 @@ import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph;
 
 @Configuration
 public class GremlinConfig {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(GremlinConfig.class);
 
     /**
@@ -41,25 +39,24 @@ public class GremlinConfig {
     private static final String DEFAULT_PROPERTIES = "/gaffer/gafferpop.properties";
 
     /**
-     * Default timeout for executing gremlin queries (2 min)
+     * Default timeout for executing gremlin queries (2 min).
      */
     private static final Long DEFAULT_REQUEST_TIMEOUT = 120000L;
 
+    /**
+     * Key for GafferPop properties file to specify the timeout on gremlin queries to the REST API.
+     */
     private static final String REQUEST_TIMEOUT_KEY = "gaffer.rest.timeout";
 
     @Bean
-    public GraphTraversalSource graphTraversalSource(final GraphFactory graphFactory) throws Exception {
+    public GraphTraversalSource graphTraversalSource(final GraphFactory graphFactory) {
         // Obtain the graph traversal
-        try (Graph graph = GafferPopGraph.open(findPropertiesFile(graphFactory), graphFactory.getGraph())) {
-            return graph.traversal();
-        } catch (final ConfigurationException e) {
-            LOGGER.error("Error loading GafferPop config, Gremlin will be unavailable: {}", e.getMessage());
-            return EmptyGraph.instance().traversal();
-        }
+        Graph graph = GafferPopGraph.open(findPropertiesFile(graphFactory), graphFactory.getGraph());
+        return graph.traversal();
     }
 
     @Bean
-    public Long requestTimeout(final GraphFactory graphFactory) throws ConfigurationException {
+    public Long requestTimeout(final GraphFactory graphFactory) {
         return findPropertiesFile(graphFactory).getLong(REQUEST_TIMEOUT_KEY, DEFAULT_REQUEST_TIMEOUT);
     }
 
@@ -70,13 +67,18 @@ public class GremlinConfig {
      * @return Loaded properties from file.
      * @throws ConfigurationException If problem loading.
      */
-    private PropertiesConfiguration findPropertiesFile(final GraphFactory graphFactory) throws ConfigurationException {
-        // Determine where to look for the GafferPop properties
-        String gafferPopProperties = graphFactory.getGraph().getStoreProperties().get(GafferPopGraph.GAFFERPOP_PROPERTIES);
-        if (gafferPopProperties == null) {
-            LOGGER.warn("GafferPop properties file was not specified. Using default location: {}", DEFAULT_PROPERTIES);
-            gafferPopProperties = DEFAULT_PROPERTIES;
+    private PropertiesConfiguration findPropertiesFile(final GraphFactory graphFactory) {
+        try {
+            // Determine where to look for the GafferPop properties
+            String gafferPopProperties = graphFactory.getGraph().getStoreProperties().get(GafferPopGraph.GAFFERPOP_PROPERTIES);
+            if (gafferPopProperties == null) {
+                LOGGER.warn("GafferPop properties file was not specified. Using default location: {}", DEFAULT_PROPERTIES);
+                gafferPopProperties = DEFAULT_PROPERTIES;
+            }
+            return new Configurations().properties(gafferPopProperties);
+        } catch (final ConfigurationException e) {
+            LOGGER.warn("Using default values for GafferPop, failed to load a GafferPop config: {}", e.getMessage());
+            return new PropertiesConfiguration();
         }
-        return new Configurations().properties(gafferPopProperties);
     }
 }

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/config/GremlinWebSocketConfig.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/config/GremlinWebSocketConfig.java
@@ -32,16 +32,18 @@ public class GremlinWebSocketConfig implements WebSocketConfigurer {
 
     private final GraphTraversalSource g;
     private final AbstractUserFactory userFactory;
+    private final Long requestTimeout;
 
     @Autowired
-    public GremlinWebSocketConfig(final GraphTraversalSource g, final AbstractUserFactory userFactory) {
+    public GremlinWebSocketConfig(final GraphTraversalSource g, final AbstractUserFactory userFactory, final Long requestTimeout) {
         this.g = g;
         this.userFactory = userFactory;
+        this.requestTimeout = requestTimeout;
     }
 
     @Override
     public void registerWebSocketHandlers(final WebSocketHandlerRegistry registry) {
-        registry.addHandler(new GremlinWebSocketHandler(g, userFactory), "/gremlin");
+        registry.addHandler(new GremlinWebSocketHandler(g, userFactory, requestTimeout), "/gremlin");
     }
 
 }

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/GremlinController.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/GremlinController.java
@@ -268,7 +268,6 @@ public class GremlinController {
      * @return A pair tuple with result and explain in.
      */
     private Tuple2<Object, JSONObject> runGremlinQuery(final String gremlinQuery) {
-        LOGGER.info("QUERY IS: {} ", gremlinQuery);
         GafferPopGraph gafferPopGraph = (GafferPopGraph) graph;
 
         // OpenTelemetry hooks

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/handler/GremlinWebSocketHandler.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/handler/GremlinWebSocketHandler.java
@@ -88,6 +88,7 @@ public class GremlinWebSocketHandler extends BinaryWebSocketHandler {
 
     private final ExecutorService executorService = Context.taskWrapping(Executors.newFixedThreadPool(4));
     private final ConcurrentBindings bindings = new ConcurrentBindings();
+    private final Long requestTimeout;
     private final AbstractUserFactory userFactory;
     private final Graph graph;
     private final Map<String, Map<String, Object>> plugins = new HashMap<>();
@@ -98,10 +99,11 @@ public class GremlinWebSocketHandler extends BinaryWebSocketHandler {
      * @param g The graph traversal source
      * @param userFactory The user factory
      */
-    public GremlinWebSocketHandler(final GraphTraversalSource g, final AbstractUserFactory userFactory) {
+    public GremlinWebSocketHandler(final GraphTraversalSource g, final AbstractUserFactory userFactory, final Long requestTimeout) {
         bindings.putIfAbsent("g", g);
         graph = g.getGraph();
         this.userFactory = userFactory;
+        this.requestTimeout = requestTimeout;
         // Add cypher plugin so cypher functions can be used in queries
         plugins.put(CypherPlugin.class.getName(), new HashMap<>());
     }
@@ -149,6 +151,7 @@ public class GremlinWebSocketHandler extends BinaryWebSocketHandler {
                 GremlinExecutor gremlinExecutor = GremlinExecutor.build()
                         .globalBindings(bindings)
                         .addPlugins("gremlin-groovy", plugins)
+                        .evaluationTimeout(requestTimeout)
                         .executorService(executorService)
                         .create()) {
             // Set current headers for potential authorisation then set the user

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/GremlinControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/GremlinControllerTest.java
@@ -31,6 +31,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import uk.gov.gchq.gaffer.operation.impl.Limit;
 import uk.gov.gchq.gaffer.operation.impl.get.GetAllElements;
@@ -47,6 +48,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_NDJSON;
 import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 import static uk.gov.gchq.gaffer.tinkerpop.util.modern.GafferPopModernTestUtils.MARKO;
 
@@ -96,10 +98,14 @@ class GremlinControllerTest {
         // When
         MvcResult result = mockMvc
             .perform(MockMvcRequestBuilders
-                    .post(GREMLIN_EXECUTE_ENDPOINT)
-                    .content(gremlinString)
-                    .contentType(TEXT_PLAIN_VALUE))
+                .post(GREMLIN_EXECUTE_ENDPOINT)
+                .content(gremlinString)
+                .contentType(TEXT_PLAIN_VALUE)
+                .accept(APPLICATION_NDJSON))
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
             .andReturn();
+        // Kick of the async dispatch so the result is available
+        mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(result));
 
         // Then
         // Ensure OK response
@@ -194,11 +200,16 @@ class GremlinControllerTest {
                                             .put("@value", 29)))))))));
         // When
         MvcResult result = mockMvc
-                .perform(MockMvcRequestBuilders
-                        .post(CYPHER_EXECUTE_ENDPOINT)
-                        .content(cypherString)
-                        .contentType(TEXT_PLAIN_VALUE))
-                .andReturn();
+            .perform(MockMvcRequestBuilders
+                .post(CYPHER_EXECUTE_ENDPOINT)
+                .content(cypherString)
+                .contentType(TEXT_PLAIN_VALUE)
+                .accept(APPLICATION_NDJSON))
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn();
+
+        // Kick of the async dispatch so the result is available
+        mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(result));
 
         // Then
         // Ensure OK response

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/GremlinControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/GremlinControllerTest.java
@@ -52,6 +52,7 @@ import static uk.gov.gchq.gaffer.tinkerpop.util.modern.GafferPopModernTestUtils.
 @Import(GremlinControllerTest.TestConfig.class)
 class GremlinControllerTest {
 
+    private static final String GREMLIN_EXECUTE_ENDPOINT = "/rest/gremlin/execute";
     private static final String GREMLIN_EXPLAIN_ENDPOINT = "/rest/gremlin/explain";
     private static final String CYPHER_EXPLAIN_ENDPOINT = "/rest/gremlin/cypher/explain";
 
@@ -67,6 +68,11 @@ class GremlinControllerTest {
         public AbstractUserFactory userFactory() {
             return new UnknownUserFactory();
         }
+
+        @Bean
+        public Long timeout() {
+            return 30000L;
+        }
     }
 
     @Autowired
@@ -74,6 +80,25 @@ class GremlinControllerTest {
 
     @Autowired
     private GraphTraversalSource g;
+
+    @Test
+    void shouldExecuteValidGremlinQuery() throws Exception {
+        String gremlinString = "g.V('" + MARKO.getId() + "').toList()";
+        // When
+        MvcResult result = mockMvc
+            .perform(MockMvcRequestBuilders
+                    .post(GREMLIN_EXECUTE_ENDPOINT)
+                    .content(gremlinString)
+                    .contentType(TEXT_PLAIN_VALUE))
+            .andReturn();
+
+        // Then
+        // Ensure OK response
+        assertThat(result.getResponse().getStatus()).isEqualTo(200);
+
+        // Get and check response
+        assertThat(result.getResponse().getContentAsString()).isEqualTo("[v[" + MARKO.getId() + "]]");
+    }
 
     @Test
     void shouldReturnExplainOfValidGremlinQuery() throws Exception {

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/integration/handler/GremlinWebSocketIT.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/integration/handler/GremlinWebSocketIT.java
@@ -80,6 +80,12 @@ class GremlinWebSocketIT {
         public AbstractUserFactory userFactory() {
             return new UnknownUserFactory();
         }
+
+        @Bean
+        @Profile("test")
+        public Long requestTimeout() {
+            return 30000L;
+        }
     }
 
     @LocalServerPort

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/integration/handler/GremlinWebSocketIT.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/integration/handler/GremlinWebSocketIT.java
@@ -83,7 +83,7 @@ class GremlinWebSocketIT {
 
         @Bean
         @Profile("test")
-        public Long requestTimeout() {
+        public Long timeout() {
             return 30000L;
         }
     }


### PR DESCRIPTION
Adds configurable timeout to the REST API for gremlin queries, also enables running queries via endpoints as well as the normal websocket. Few bits of tidying as well.

# Related issue

- Resolve #3292