### PR TITLE
Gh-3295: Fix issue with Accumulo iterators when smart merging Federated POC

### DIFF
--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
@@ -16,6 +16,9 @@
 
 package uk.gov.gchq.gaffer.federated.simple;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import uk.gov.gchq.gaffer.cache.Cache;
 import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
 import uk.gov.gchq.gaffer.cache.exception.CacheOperationException;
@@ -65,9 +68,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static uk.gov.gchq.gaffer.cache.CacheServiceLoader.DEFAULT_SERVICE_NAME;
 import static uk.gov.gchq.gaffer.federated.simple.FederatedStoreProperties.PROP_DEFAULT_GRAPH_IDS;

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/merge/operator/ElementAggregateOperator.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/merge/operator/ElementAggregateOperator.java
@@ -67,21 +67,21 @@ public class ElementAggregateOperator implements BinaryOperator<Iterable<Element
                 // Compare the current element with all others to do a full merge
                 for (final Element inner : chainedResult) {
                     // No merge required if not in same group
-                    if (!e.getGroup().equals(inner.getGroup())) {
+                    if (!e.getGroup().equals(inner.getGroup()) || e.equals(inner)) {
                         continue;
                     }
 
                     if ((e instanceof Entity)
                             && (inner instanceof Entity)
                             && ((Entity) e).getVertex().equals(((Entity) inner).getVertex())) {
-                        result = aggregator.apply(inner, result);
+                        result = aggregator.apply(inner.shallowClone(), result).shallowClone();
                     }
 
                     if ((e instanceof Edge)
                             && (inner instanceof Edge)
                             && ((Edge) e).getSource().equals(((Edge) inner).getSource())
                             && ((Edge) e).getDestination().equals(((Edge) inner).getDestination())) {
-                        result = aggregator.apply(inner, result);
+                        result = aggregator.apply(inner.shallowClone(), result);
                     }
                 }
                 return result;

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOperationHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOperationHandler.java
@@ -16,6 +16,9 @@
 
 package uk.gov.gchq.gaffer.federated.simple.operation.handler;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import uk.gov.gchq.gaffer.cache.exception.CacheOperationException;
 import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
 import uk.gov.gchq.gaffer.graph.GraphSerialisable;
@@ -34,9 +37,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Main default handler for federated operations. Handles delegation to selected

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOperationHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOperationHandler.java
@@ -35,12 +35,16 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Main default handler for federated operations. Handles delegation to selected
  * graphs and will sub class the operation to a {@link FederatedOutputHandler}
  * if provided operation has output so that it is merged.
  */
 public class FederatedOperationHandler<P extends Operation> implements OperationHandler<P> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FederatedOperationHandler.class);
 
     /**
      * The operation option for the Graph IDs that an operation should be
@@ -59,17 +63,26 @@ public class FederatedOperationHandler<P extends Operation> implements Operation
      */
     public static final String OPT_AGGREGATE_ELEMENTS = "federated.aggregateElements";
 
+    /**
+     * A boolean option to specify if to forward the whole operation chain to the sub graph or not.
+     */
+    public static final String OPT_FORWARD_CHAIN = "federated.forwardChain";
+
     @Override
     public Object doOperation(final P operation, final Context context, final Store store) throws OperationException {
-
+        LOGGER.debug("Running operation: {}", operation);
         // Check inside operation chains in case there are operations that don't require running on sub graphs
         if (operation instanceof OperationChain) {
             Set<Class<? extends Operation>> storeSpecificOps = ((FederatedStore) store).getStoreSpecificOperations();
             List<Class<? extends Operation>> chainOps = ((OperationChain<?>) operation).flatten().stream()
                 .map(Operation::getClass)
                 .collect(Collectors.toList());
-            // If all the operations in the chain can be handled by the store then execute them
-            if (storeSpecificOps.containsAll(chainOps)) {
+
+            // If all the operations in the chain can be handled by the store then execute them.
+            // Or if told not to forward the whole chain process each operation individually.
+            if (storeSpecificOps.containsAll(chainOps) ||
+                    (!Boolean.parseBoolean(operation.getOption(OPT_FORWARD_CHAIN, "true")))) {
+                // Use default handler
                 return new OperationChainHandler<>(store.getOperationChainValidator(), store.getOperationChainOptimisers())
                     .doOperation((OperationChain<Object>) operation, context, store);
             }
@@ -79,7 +92,7 @@ public class FederatedOperationHandler<P extends Operation> implements Operation
             if (!Collections.disjoint(storeSpecificOps, chainOps)) {
                 throw new OperationException(
                     "Chain contains standard Operations alongside federated store specific Operations."
-                        + " Please submit each type separately.");
+                        + " Please submit each type separately or set: '" + OPT_FORWARD_CHAIN + "' to: 'false'.");
             }
         }
 
@@ -129,6 +142,7 @@ public class FederatedOperationHandler<P extends Operation> implements Operation
         try {
             // Get the corresponding graph serialisable
             for (final String id : graphIds) {
+                LOGGER.debug("Will execute on Graph: {}", id);
                 graphsToExecute.add(store.getGraph(id));
             }
         } catch (final CacheOperationException e) {

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
@@ -124,7 +124,7 @@ class FederatedStoreIT {
     }
 
     @Test
-    void shouldPreventMixOfFederatedAndCoreOperationsInChain() throws StoreException {
+    void shouldPreventMixOfFederatedAndCoreOperationsInChainByDefault() throws StoreException {
         // Given
         FederatedStore federatedStore = new FederatedStore();
         federatedStore.initialise("federated", null, new StoreProperties());

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
@@ -59,8 +59,8 @@ class FederatedStoreIT {
         final String graphId1 = "graph1";
         final String graphId2 = "graph2";
 
-        final Graph graph1 = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId1, StoreType.MAP);
-        final Graph graph2 = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId2, StoreType.MAP);
+        final Graph graph1 = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId1, StoreType.ACCUMULO);
+        final Graph graph2 = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId2, StoreType.ACCUMULO);
 
         final String group = "person";
         final String vertex = "1";

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreTest.java
@@ -24,6 +24,7 @@ import uk.gov.gchq.gaffer.cache.exception.CacheOperationException;
 import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils;
 import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils.StoreType;
 import uk.gov.gchq.gaffer.graph.Graph;
+import uk.gov.gchq.gaffer.graph.GraphConfig;
 import uk.gov.gchq.gaffer.graph.GraphSerialisable;
 import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.store.StoreProperties;
@@ -64,17 +65,35 @@ class FederatedStoreTest {
     }
 
     @Test
-    void shouldSetDefaultGraphIds() throws StoreException {
+    void shouldNotSetDefaultGraphIdsIfGraphDoesNotExist() throws StoreException {
         final String graphId = "federated";
         final String graphId1 = "graph1";
         final String graphId2 = "graph2";
         FederatedStoreProperties properties = new FederatedStoreProperties();
+        // Set the defaults to graphs not available to the store
         properties.set(PROP_DEFAULT_GRAPH_IDS, graphId1 + "," + graphId2);
 
         FederatedStore store = new FederatedStore();
         store.initialise(graphId, null, properties);
 
-        assertThat(store.getDefaultGraphIds()).containsExactlyInAnyOrder(graphId1, graphId2);
+        assertThat(store.getDefaultGraphIds()).isEmpty();
+    }
+
+    @Test
+    void shouldSetDefaultGraphIdsIfGraphsExist() throws StoreException {
+        final String graphId = "federated";
+        final String graphId1 = "graph1";
+        final String graphId2 = "graph2";
+        final FederatedStore store = new FederatedStore();
+        final FederatedStoreProperties properties = new FederatedStoreProperties();
+
+        // Set the defaults to graphs and make sure to add them
+        properties.set(PROP_DEFAULT_GRAPH_IDS, graphId1 + "," + graphId2);
+        store.initialise(graphId, null, properties);
+        store.addGraph(new GraphSerialisable(new GraphConfig(graphId1), new Schema(), new StoreProperties()));
+        store.addGraph(new GraphSerialisable(new GraphConfig(graphId2), new Schema(), new StoreProperties()));
+
+        assertThat(store.getDefaultGraphIds()).containsExactly(graphId1, graphId2);
     }
 
     @Test

--- a/store-implementation/simple-federated-store/src/test/resources/modern/schema/schema.json
+++ b/store-implementation/simple-federated-store/src/test/resources/modern/schema/schema.json
@@ -65,25 +65,25 @@
         "property.string": {
             "class": "java.lang.String",
             "aggregateFunction": {
-                "class": "uk.gov.gchq.koryphe.impl.binaryoperator.First"
+                "class": "uk.gov.gchq.koryphe.impl.binaryoperator.Max"
             }
         },
         "property.integer": {
             "class": "java.lang.Integer",
             "aggregateFunction": {
-                "class": "uk.gov.gchq.koryphe.impl.binaryoperator.First"
+                "class": "uk.gov.gchq.koryphe.impl.binaryoperator.Sum"
             }
         },
         "property.double": {
             "class": "java.lang.Double",
             "aggregateFunction": {
-                "class": "uk.gov.gchq.koryphe.impl.binaryoperator.First"
+                "class": "uk.gov.gchq.koryphe.impl.binaryoperator.Sum"
             }
         },
         "property.float": {
             "class": "java.lang.Float",
             "aggregateFunction": {
-                "class": "uk.gov.gchq.koryphe.impl.binaryoperator.First"
+                "class": "uk.gov.gchq.koryphe.impl.binaryoperator.Sum"
             }
         }
     }


### PR DESCRIPTION
There was an issue where the iterators from Accumulo could be exhausted or closed before the merging of elements had completed. There's not a great way around this other than to buffer the data into a set before using for merging. This does of course increase memory usage but might be faster overall.
(Also the previous solution was still technically buffering to memory with a `distict()` call).

# Related issue

- Resolve #3295