### PR TITLE
Gh-3291: Add GetAllGraphInfo operation to POC federated store

### DIFF
--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
@@ -21,11 +21,13 @@ import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.id.EntityId;
 import uk.gov.gchq.gaffer.federated.simple.operation.AddGraph;
 import uk.gov.gchq.gaffer.federated.simple.operation.GetAllGraphIds;
+import uk.gov.gchq.gaffer.federated.simple.operation.GetAllGraphInfo;
 import uk.gov.gchq.gaffer.federated.simple.operation.RemoveGraph;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.FederatedOperationHandler;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.FederatedOutputHandler;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.add.AddGraphHandler;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.get.GetAllGraphIdsHandler;
+import uk.gov.gchq.gaffer.federated.simple.operation.handler.get.GetAllGraphInfoHandler;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.get.GetSchemaHandler;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.misc.RemoveGraphHandler;
 import uk.gov.gchq.gaffer.graph.GraphSerialisable;
@@ -78,6 +80,7 @@ public class FederatedStore extends Store {
             new SimpleEntry<>(AddGraph.class, new AddGraphHandler()),
             new SimpleEntry<>(GetAllGraphIds.class, new GetAllGraphIdsHandler()),
             new SimpleEntry<>(GetSchema.class, new GetSchemaHandler()),
+            new SimpleEntry<>(GetAllGraphInfo.class, new GetAllGraphInfoHandler()),
             new SimpleEntry<>(RemoveGraph.class, new RemoveGraphHandler()))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/GetAllGraphInfo.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/GetAllGraphInfo.java
@@ -16,12 +16,9 @@
 
 package uk.gov.gchq.gaffer.federated.simple.operation;
 
-import java.util.List;
-import java.util.Map;
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import org.apache.commons.lang3.exception.CloneFailedException;
-
-import com.fasterxml.jackson.core.type.TypeReference;
 
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.io.Output;
@@ -29,9 +26,11 @@ import uk.gov.gchq.gaffer.operation.serialisation.TypeReferenceImpl;
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 
+import java.util.Map;
+
 @Since("2.4.0")
 @Summary("Get all the graph info from graphs in a federated store")
-public class GetAllGraphInfo implements Output<Map<String, Object>>{
+public class GetAllGraphInfo implements Output<Map<String, Object>> {
 
     private Map<String, String> options;
 

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/GetAllGraphInfo.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/GetAllGraphInfo.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.operation;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.exception.CloneFailedException;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import uk.gov.gchq.gaffer.operation.Operation;
+import uk.gov.gchq.gaffer.operation.io.Output;
+import uk.gov.gchq.gaffer.operation.serialisation.TypeReferenceImpl;
+import uk.gov.gchq.koryphe.Since;
+import uk.gov.gchq.koryphe.Summary;
+
+@Since("2.4.0")
+@Summary("Get all the graph info from graphs in a federated store")
+public class GetAllGraphInfo implements Output<Map<String, Object>>{
+
+    private Map<String, String> options;
+
+    @Override
+    public Map<String, String> getOptions() {
+       return options;
+    }
+
+    @Override
+    public void setOptions(final Map<String, String> options) {
+        this.options = options;
+    }
+
+    @Override
+    public Operation shallowClone() throws CloneFailedException {
+        return new GetAllGraphInfo();
+    }
+
+    @Override
+    public TypeReference<Map<String, Object>> getOutputTypeReference() {
+        return new TypeReferenceImpl.MapStringObject();
+    }
+
+    public static class Builder extends Operation.BaseBuilder<GetAllGraphInfo, Builder> {
+        public Builder() {
+            super(new GetAllGraphInfo());
+        }
+    }
+
+}

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphInfoHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphInfoHandler.java
@@ -34,14 +34,14 @@ public class GetAllGraphInfoHandler implements OutputOperationHandler<GetAllGrap
  * Simple handler for getting information about the graphs contained in the federated store
  */
     @Override
-    public Map<String, Object> doOperation(GetAllGraphInfo operation, Context context, Store store)
+    public Map<String, Object> doOperation(final GetAllGraphInfo operation, final Context context, final Store store)
         throws OperationException {
             // Get all the graphs in the federated store
             List<GraphSerialisable> graphList = ((FederatedStore) store).getAllGraphs();
 
             Map<String, Object> allGraphInfo = new HashMap<>();
 
-            for(final GraphSerialisable gs : graphList) {
+            for (final GraphSerialisable gs : graphList) {
                 // Get the various properties of the individual federated graphs
                 Map<String, Object> graphInfo = new HashMap<>();
                 graphInfo.put("graphDescription", gs.getConfig().getDescription());

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphInfoHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphInfoHandler.java
@@ -27,11 +27,16 @@ import uk.gov.gchq.gaffer.store.operation.handler.OutputOperationHandler;
 import java.util.HashMap;
 import java.util.Map;
 
-
-public class GetAllGraphInfoHandler implements OutputOperationHandler<GetAllGraphInfo, Map<String, Object>> {
 /**
  * Simple handler for getting information about the graphs contained in the federated store
  */
+public class GetAllGraphInfoHandler implements OutputOperationHandler<GetAllGraphInfo, Map<String, Object>> {
+
+    public static final String DESCRIPTION = "graphDescription";
+    public static final String HOOKS = "graphHooks";
+    public static final String PROPERTIES = "storeProperties";
+    public static final String OP_DECLARATIONS = "operationDeclarations";
+
     @Override
     public Map<String, Object> doOperation(final GetAllGraphInfo operation, final Context context, final Store store)
         throws OperationException {
@@ -43,10 +48,10 @@ public class GetAllGraphInfoHandler implements OutputOperationHandler<GetAllGrap
             for (final GraphSerialisable gs : graphList) {
                 // Get the various properties of the individual federated graphs
                 Map<String, Object> graphInfo = new HashMap<>();
-                graphInfo.put("graphDescription", gs.getConfig().getDescription());
-                graphInfo.put("graphHooks", gs.getConfig().getHooks());
-                graphInfo.put("storeProperties", gs.getStoreProperties().getProperties());
-                graphInfo.put("operationDeclarations", gs.getStoreProperties().getOperationDeclarations().getOperations());
+                graphInfo.put(DESCRIPTION, gs.getConfig().getDescription());
+                graphInfo.put(HOOKS, gs.getConfig().getHooks());
+                graphInfo.put(PROPERTIES, gs.getStoreProperties().getProperties());
+                graphInfo.put(OP_DECLARATIONS, gs.getStoreProperties().getOperationDeclarations().getOperations());
 
                 // Add the Graph ID and all properties associated with it
                 allGraphInfo.put(gs.getConfig().getGraphId(), graphInfo);

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphInfoHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphInfoHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.operation.handler.get;
+
+import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
+import uk.gov.gchq.gaffer.federated.simple.operation.GetAllGraphInfo;
+import uk.gov.gchq.gaffer.graph.GraphSerialisable;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.store.Context;
+import uk.gov.gchq.gaffer.store.Store;
+import uk.gov.gchq.gaffer.store.operation.handler.OutputOperationHandler;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public class GetAllGraphInfoHandler implements OutputOperationHandler<GetAllGraphInfo, Map<String, Object>> {
+/**
+ * Simple handler for getting information about the graphs contained in the federated store
+ */
+    @Override
+    public Map<String, Object> doOperation(GetAllGraphInfo operation, Context context, Store store)
+        throws OperationException {
+            // Get all the graphs in the federated store
+            List<GraphSerialisable> graphList = ((FederatedStore) store).getAllGraphs();
+
+            Map<String, Object> allGraphInfo = new HashMap<>();
+
+            for(final GraphSerialisable gs : graphList) {
+                // Get the various properties of the individual federated graphs
+                Map<String, Object> graphInfo = new HashMap<>();
+                graphInfo.put("graphDescription", gs.getConfig().getDescription());
+                graphInfo.put("graphHooks", gs.getConfig().getHooks());
+                graphInfo.put("storeProperties", gs.getStoreProperties().getProperties());
+                graphInfo.put("operationDeclarations", gs.getStoreProperties().getOperationDeclarations().getOperations());
+
+                // Add the Graph ID and all properties associated with it
+                allGraphInfo.put(gs.getConfig().getGraphId(), graphInfo);
+            }
+
+            return allGraphInfo;
+        }
+}

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphInfoHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphInfoHandler.java
@@ -25,7 +25,6 @@ import uk.gov.gchq.gaffer.store.Store;
 import uk.gov.gchq.gaffer.store.operation.handler.OutputOperationHandler;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 
@@ -37,7 +36,7 @@ public class GetAllGraphInfoHandler implements OutputOperationHandler<GetAllGrap
     public Map<String, Object> doOperation(final GetAllGraphInfo operation, final Context context, final Store store)
         throws OperationException {
             // Get all the graphs in the federated store
-            List<GraphSerialisable> graphList = ((FederatedStore) store).getAllGraphs();
+            Iterable<GraphSerialisable> graphList = ((FederatedStore) store).getAllGraphs();
 
             Map<String, Object> allGraphInfo = new HashMap<>();
 

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
@@ -27,6 +27,7 @@ import uk.gov.gchq.gaffer.federated.simple.operation.AddGraph;
 import uk.gov.gchq.gaffer.federated.simple.operation.GetAllGraphIds;
 import uk.gov.gchq.gaffer.federated.simple.operation.GetAllGraphInfo;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.FederatedOperationHandler;
+import uk.gov.gchq.gaffer.federated.simple.operation.handler.get.GetAllGraphInfoHandler;
 import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils;
 import uk.gov.gchq.gaffer.graph.Graph;
 import uk.gov.gchq.gaffer.graph.GraphConfig;
@@ -195,10 +196,10 @@ class FederatedStoreIT {
 
         // Map of the expected values for the graph
         final Map<String, Object> graph1InfoExpected = Stream.of(
-                new SimpleEntry<>("graphDescription", graph1.getDescription()),
-                new SimpleEntry<>("graphHooks", graph1.getConfig().getHooks()),
-                new SimpleEntry<>("operationDeclarations", graph1.getStoreProperties().getOperationDeclarations().getOperations()),
-                new SimpleEntry<>("storeProperties", graph1.getStoreProperties().getProperties()))
+                new SimpleEntry<>(GetAllGraphInfoHandler.DESCRIPTION, graph1.getDescription()),
+                new SimpleEntry<>(GetAllGraphInfoHandler.HOOKS, graph1.getConfig().getHooks()),
+                new SimpleEntry<>(GetAllGraphInfoHandler.OP_DECLARATIONS, graph1.getStoreProperties().getOperationDeclarations().getOperations()),
+                new SimpleEntry<>(GetAllGraphInfoHandler.PROPERTIES, graph1.getStoreProperties().getProperties()))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         // When

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/util/ModernDatasetUtils.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/util/ModernDatasetUtils.java
@@ -38,6 +38,7 @@ public final class ModernDatasetUtils {
         return new Graph.Builder()
             .config(new GraphConfig.Builder()
                     .graphId(graphId)
+                    .description("Graph using the modern dataset")
                     .build())
             .storeProperties(getStoreProperties(storeType))
             .addSchemas(StreamUtil.openStreams(clazz, "/modern/schema"))


### PR DESCRIPTION
Added a GetAllGraphInfo operation to the POC simple federated store. This can easily be modified to have additional fields within the map, including auths. Operation returns key information about the configuration of the store.

# Related issue

- Resolve #3291