### PR TITLE
Gh-3299: Add ChangeGraphId operation to POC simple federated store

### DIFF
--- a/store-implementation/simple-federated-store/pom.xml
+++ b/store-implementation/simple-federated-store/pom.xml
@@ -38,17 +38,16 @@
             <artifactId>graph</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>uk.gov.gchq.gaffer</groupId>
+            <artifactId>accumulo-store</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>
             <groupId>uk.gov.gchq.gaffer</groupId>
             <artifactId>map-store</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>uk.gov.gchq.gaffer</groupId>
-            <artifactId>accumulo-store</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
@@ -198,7 +198,6 @@ public class FederatedStore extends Store {
      *
      * @param graphToUpdateId the graph that is to have its ID updated
      * @param newGraphId the new graph ID
-     * @throws OperationException if the operation fails
      * @throws StoreException if the accumulo tables cannot be renamed
      *
      */

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
@@ -184,7 +184,6 @@ public class FederatedStore extends Store {
      * @param graphToUpdateId the graph that is to have its ID updated
      * @param newGraphId the new graph ID
      * @throws OperationException if accumulo table fails to be renamed
-     * @throws CacheOperationException if graph cannot be retrieved from cache
      *
      */
     public void changeGraphId(final String graphToUpdateId, final String newGraphId) throws OperationException {

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
@@ -202,7 +202,7 @@ public class FederatedStore extends Store {
      * @throws StoreException if the accumulo tables cannot be renamed
      *
      */
-    public void changeGraphId(final String graphToUpdateId, final String newGraphId) throws OperationException, StoreException {
+    public void changeGraphId(final String graphToUpdateId, final String newGraphId) throws StoreException {
         try {
             final GraphSerialisable graphToUpdate = getGraph(graphToUpdateId);
 

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/ChangeGraphId.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/ChangeGraphId.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.operation;
+
+import org.apache.commons.lang3.exception.CloneFailedException;
+
+import uk.gov.gchq.gaffer.operation.Operation;
+import uk.gov.gchq.koryphe.Since;
+import uk.gov.gchq.koryphe.Summary;
+
+import java.util.Map;
+
+@Since("2.4.0")
+@Summary("Changes Graph ID")
+public class ChangeGraphId implements Operation {
+
+    private String graphId;
+    private String newGraphId;
+    private Map<String, String> options;
+
+    // Getters
+    /**
+     * Get the graph ID that will be changed.
+     *
+     * @return the graph ID
+     */
+    public String getGraphId() {
+        return graphId;
+    }
+
+    /**
+     * Get the new ID for the graph.
+     *
+     * @return the new graph ID
+     */
+    public String getNewGraphId() {
+        return newGraphId;
+    }
+
+    // Setters
+    /**
+     * Set the graph ID of the current graph.
+     *
+     * @param graphId the graph ID
+     */
+    public void setGraphId(final String graphId) {
+        this.graphId = graphId;
+    }
+
+     /**
+     * Set the new graph ID of the current graph.
+     *
+     * @param newGraphId the new Graph ID
+     */
+    public void setNewGraphId(final String newGraphId) {
+        this.newGraphId = newGraphId;
+    }
+
+    @Override
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    @Override
+    public void setOptions(final Map<String, String> options) {
+        this.options = options;
+    }
+
+    @Override
+    public Operation shallowClone() throws CloneFailedException {
+        return new ChangeGraphId.Builder()
+            .graphId(graphId)
+            .newGraphId(newGraphId)
+            .options(options)
+            .build();
+    }
+
+    public static class Builder extends Operation.BaseBuilder<ChangeGraphId, Builder> {
+        public Builder() {
+            super(new ChangeGraphId());
+        }
+
+        /**
+         * Set the current graph ID
+         *
+         * @param graphId the graph ID to be changed
+         * @return the builder
+         */
+        public Builder graphId(final String graphId) {
+            _getOp().setGraphId(graphId);
+            return _self();
+        }
+
+        /**
+         * Set the new graph ID
+         *
+         * @param newGraphId the new graph ID
+         * @return the builder
+         */
+        public Builder newGraphId(final String newGraphId) {
+            _getOp().setNewGraphId(newGraphId);
+            return _self();
+        }
+    }
+}

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/ChangeGraphIdHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/ChangeGraphIdHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.operation.handler.misc;
+
+import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
+import uk.gov.gchq.gaffer.federated.simple.operation.ChangeGraphId;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.store.Context;
+import uk.gov.gchq.gaffer.store.Store;
+import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
+
+public class ChangeGraphIdHandler implements OperationHandler<ChangeGraphId> {
+
+    @Override
+    public Object doOperation(final ChangeGraphId operation, final Context context, final Store store) throws OperationException {
+        ((FederatedStore) store).changeGraphId(operation.getGraphId(), operation.getNewGraphId());
+        // Nothing to return
+        return null;
+    }
+}

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/ChangeGraphIdHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/ChangeGraphIdHandler.java
@@ -27,10 +27,10 @@ import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
 public class ChangeGraphIdHandler implements OperationHandler<ChangeGraphId> {
 
     @Override
-    public Object doOperation(final ChangeGraphId operation, final Context context, final Store store) {
+    public Object doOperation(final ChangeGraphId operation, final Context context, final Store store) throws OperationException {
         try {
             ((FederatedStore) store).changeGraphId(operation.getGraphId(), operation.getNewGraphId());
-        } catch (final OperationException | StoreException e) {
+        } catch (final StoreException e) {
             throw new OperationException("Error changing graph ID", e);
         }
 

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/ChangeGraphIdHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/ChangeGraphIdHandler.java
@@ -30,7 +30,7 @@ public class ChangeGraphIdHandler implements OperationHandler<ChangeGraphId> {
     public Object doOperation(final ChangeGraphId operation, final Context context, final Store store) throws OperationException {
         try {
             ((FederatedStore) store).changeGraphId(operation.getGraphId(), operation.getNewGraphId());
-        } catch (OperationException | StoreException e) {
+        } catch (final OperationException | StoreException e) {
             throw new OperationException("Error changing graph ID", e);
         }
 

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/ChangeGraphIdHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/ChangeGraphIdHandler.java
@@ -21,13 +21,19 @@ import uk.gov.gchq.gaffer.federated.simple.operation.ChangeGraphId;
 import uk.gov.gchq.gaffer.operation.OperationException;
 import uk.gov.gchq.gaffer.store.Context;
 import uk.gov.gchq.gaffer.store.Store;
+import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
 
 public class ChangeGraphIdHandler implements OperationHandler<ChangeGraphId> {
 
     @Override
     public Object doOperation(final ChangeGraphId operation, final Context context, final Store store) throws OperationException {
-        ((FederatedStore) store).changeGraphId(operation.getGraphId(), operation.getNewGraphId());
+        try {
+            ((FederatedStore) store).changeGraphId(operation.getGraphId(), operation.getNewGraphId());
+        } catch (OperationException | StoreException e) {
+            throw new OperationException("Error changing graph ID", e);
+        }
+
         // Nothing to return
         return null;
     }

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/ChangeGraphIdHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/ChangeGraphIdHandler.java
@@ -27,7 +27,7 @@ import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
 public class ChangeGraphIdHandler implements OperationHandler<ChangeGraphId> {
 
     @Override
-    public Object doOperation(final ChangeGraphId operation, final Context context, final Store store) throws OperationException {
+    public Object doOperation(final ChangeGraphId operation, final Context context, final Store store) {
         try {
             ((FederatedStore) store).changeGraphId(operation.getGraphId(), operation.getNewGraphId());
         } catch (final OperationException | StoreException e) {

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/ChangeGraphIdTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/ChangeGraphIdTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
 import uk.gov.gchq.gaffer.cache.exception.CacheOperationException;
@@ -30,7 +29,6 @@ import uk.gov.gchq.gaffer.data.element.Properties;
 import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.FederatedOperationHandler;
 import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils;
-import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils.StoreType;
 import uk.gov.gchq.gaffer.graph.Graph;
 import uk.gov.gchq.gaffer.graph.GraphSerialisable;
 import uk.gov.gchq.gaffer.operation.OperationChain;

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/ChangeGraphIdTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/ChangeGraphIdTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.operation;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
+import uk.gov.gchq.gaffer.cache.exception.CacheOperationException;
+import uk.gov.gchq.gaffer.data.element.Element;
+import uk.gov.gchq.gaffer.data.element.Entity;
+import uk.gov.gchq.gaffer.data.element.Properties;
+import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
+import uk.gov.gchq.gaffer.federated.simple.operation.handler.FederatedOperationHandler;
+import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils;
+import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils.StoreType;
+import uk.gov.gchq.gaffer.graph.Graph;
+import uk.gov.gchq.gaffer.graph.GraphSerialisable;
+import uk.gov.gchq.gaffer.operation.OperationChain;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
+import uk.gov.gchq.gaffer.operation.impl.get.GetAllElements;
+import uk.gov.gchq.gaffer.store.Context;
+import uk.gov.gchq.gaffer.store.StoreException;
+import uk.gov.gchq.gaffer.store.StoreProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class ChangeGraphIdTest {
+    private static final String FED_STORE_ID = "federated";
+    private static final String NEW_GRAPH_ID = "newGraphId";
+    private static final String GRAPH_ID_ERROR = "Graph with Graph ID: %s is not available to this federated store";
+
+    @AfterEach
+    void reset() {
+        CacheServiceLoader.shutdown();
+    }
+
+    @Test
+    void shouldChangeGraphIdAndPreserveData() throws StoreException, OperationException, CacheOperationException {
+        // Given
+        final String graphId = "shouldChangeGraphIdAndPreserveData";
+        final Graph originalGraph = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId, StoreType.ACCUMULO);
+
+        // Elements to add to the graph
+        final Properties graphEntityProps = new Properties();
+        graphEntityProps.put("name", "marko");
+        final Entity graphEntity = new Entity("person", "1", graphEntityProps);
+
+        // When
+        final FederatedStore federatedStore = new FederatedStore();
+        federatedStore.initialise(FED_STORE_ID, null, new StoreProperties());
+        // Add elements to the graph
+        addGraphWithElements(federatedStore, originalGraph, graphEntity);
+        GraphSerialisable expectedGraphSerialisable = federatedStore.getGraph(graphId);
+
+        // Change graph ID operation
+        final ChangeGraphId changeGraphId = new ChangeGraphId.Builder()
+            .graphId(graphId)
+            .newGraphId(NEW_GRAPH_ID)
+            .build();
+        federatedStore.execute(changeGraphId, new Context());
+
+        // Check that the config + properties remains the same
+        assertThat(federatedStore.getGraph(NEW_GRAPH_ID))
+            .satisfies(gs -> {
+                assertThat(gs.getConfig())
+                    .usingRecursiveComparison()
+                    .ignoringFields("graphId")
+                    .isEqualTo(expectedGraphSerialisable.getConfig());
+
+                assertThat(gs.getStoreProperties())
+                    .isEqualTo(expectedGraphSerialisable.getStoreProperties());
+            });
+
+        // Ensure that there are no references to the 'old' graph ID
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> federatedStore.getGraph(graphId))
+            .withMessage(String.format(GRAPH_ID_ERROR, graphId));
+
+        // See if the graph data still exists in the cluster
+        OperationChain<Iterable<? extends Element>> getAllElements = new OperationChain.Builder()
+            .first(new GetAllElements.Builder()
+                    .build())
+            .option(FederatedOperationHandler.OPT_GRAPH_IDS, NEW_GRAPH_ID)
+            .build();
+        Iterable<? extends Element> resultGetAll = federatedStore.execute(getAllElements, new Context());
+
+        assertThat(resultGetAll).extracting(e -> (Element) e).containsExactly(graphEntity);
+    }
+
+    @Test
+    void shouldThrowErrorChangingIdIfGraphDoesntExist() throws StoreException {
+        // Given
+        final String graphId = "shouldThrowErrorChangingIdIfGraphDoesntExist";
+        final ChangeGraphId changeGraphId = new ChangeGraphId.Builder()
+            .graphId(graphId)
+            .newGraphId(NEW_GRAPH_ID)
+            .build();
+        final Context context = new Context();
+
+        // When
+        final FederatedStore federatedStore = new FederatedStore();
+        federatedStore.initialise(FED_STORE_ID, null, new StoreProperties());
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> federatedStore.execute(changeGraphId, context))
+                .withMessageContaining(String.format(GRAPH_ID_ERROR, graphId));
+    }
+
+     /**
+     * Adds a given graph and elements to a federated store.
+     *
+     * @param store The federated store
+     * @param graph The graph to add
+     * @param elements The elements to add to the graph
+     *
+     * @throws OperationException If fails
+     */
+    private void addGraphWithElements(FederatedStore store, Graph graph, Element... elements) throws OperationException {
+        // Add Graph operation
+        final AddGraph addGraph = new AddGraph.Builder()
+                .graphConfig(graph.getConfig())
+                .schema(graph.getSchema())
+                .properties(graph.getStoreProperties().getProperties())
+                .build();
+
+        // Add elements operation
+        final AddElements addGraphElements = new AddElements.Builder()
+                .input(elements)
+                .option(FederatedOperationHandler.OPT_GRAPH_IDS, graph.getGraphId())
+                .build();
+
+        // Add the graph and its elements
+        store.execute(addGraph, new Context());
+        store.execute(addGraphElements, new Context());
+    }
+}

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/ChangeGraphIdTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/ChangeGraphIdTest.java
@@ -18,6 +18,9 @@ package uk.gov.gchq.gaffer.federated.simple.operation;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
 import uk.gov.gchq.gaffer.cache.exception.CacheOperationException;
@@ -51,11 +54,12 @@ class ChangeGraphIdTest {
         CacheServiceLoader.shutdown();
     }
 
-    @Test
-    void shouldChangeGraphIdAndPreserveData() throws StoreException, OperationException, CacheOperationException {
+    @ParameterizedTest
+    @EnumSource(ModernDatasetUtils.StoreType.class)
+    void shouldChangeGraphIdAndPreserveData(ModernDatasetUtils.StoreType store) throws StoreException, OperationException, CacheOperationException {
         // Given
         final String graphId = "shouldChangeGraphIdAndPreserveData";
-        final Graph originalGraph = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId, StoreType.ACCUMULO);
+        final Graph originalGraph = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId, store);
 
         // Elements to add to the graph
         final Properties graphEntityProps = new Properties();

--- a/store-implementation/simple-federated-store/src/test/resources/accumulo-store.properties
+++ b/store-implementation/simple-federated-store/src/test/resources/accumulo-store.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-gaffer.store.class=uk.gov.gchq.gaffer.accumulostore.SingleUseMiniAccumuloStore
+gaffer.store.class=uk.gov.gchq.gaffer.accumulostore.MiniAccumuloStore
 accumulo.instance=federatedTestInstance
 accumulo.zookeepers=localhost
 accumulo.user=user01


### PR DESCRIPTION
PR adds a ChangeGraphId, mainly for accumulo stores, to the POC federated store. 

# Related issue

- Resolve #3299