### PR TITLE
Gh-3303: No error reported when Gremlin endpoint fails

### DIFF
--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
@@ -53,7 +53,7 @@ public class OperationChainHandler<OUT> implements OutputOperationHandler<Operat
             // OpenTelemetry hooks
             Span span = OtelUtil.startSpan(this.getClass().getName(), op.getClass().getName());
             span.setAttribute("jobId", context.getJobId());
-            if (op instanceof OperationView) {
+            if (op instanceof OperationView && ((OperationView) op).getView() != null) {
                 span.setAttribute("view", ((OperationView) op).getView().toString());
             }
 

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
@@ -23,6 +23,7 @@ import uk.gov.gchq.gaffer.commonutil.otel.OtelUtil;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.OperationChain;
 import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.operation.graph.OperationView;
 import uk.gov.gchq.gaffer.store.Context;
 import uk.gov.gchq.gaffer.store.Store;
 import uk.gov.gchq.gaffer.store.operation.OperationChainValidator;
@@ -52,6 +53,10 @@ public class OperationChainHandler<OUT> implements OutputOperationHandler<Operat
             // OpenTelemetry hooks
             Span span = OtelUtil.startSpan(this.getClass().getName(), op.getClass().getName());
             span.setAttribute("jobId", context.getJobId());
+            if (op instanceof OperationView) {
+                span.setAttribute("view", ((OperationView) op).getView().toString());
+            }
+
             // Sets the span to current so parent child spans are auto linked
             try (Scope scope = span.makeCurrent()) {
                 updateOperationInput(op, result);

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/GremlinControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/GremlinControllerTest.java
@@ -146,7 +146,7 @@ class GremlinControllerTest {
     }
 
     @Test
-    void shouldRejectMalformedGremlinQuery() throws Exception {
+    void shouldRejectMalformedGremlinQueryFromExplain() throws Exception {
         // Given
         String gremlinString = "g.V().stepDoesNotExist().toList()";
 
@@ -156,6 +156,25 @@ class GremlinControllerTest {
                         .post(GREMLIN_EXPLAIN_ENDPOINT)
                         .content(gremlinString)
                         .contentType(TEXT_PLAIN_VALUE))
+                .andReturn();
+
+        // Then
+        // Expect a server error response
+        assertThat(result.getResponse().getStatus()).isEqualTo(500);
+    }
+
+    @Test
+    void shouldRejectMalformedGremlinQueryFromExecute() throws Exception {
+        // Given
+        String gremlinString = "g.V().stepDoesNotExist().toList()";
+
+        // When
+        MvcResult result = mockMvc
+                .perform(MockMvcRequestBuilders
+                        .post(GREMLIN_EXECUTE_ENDPOINT)
+                        .content(gremlinString)
+                        .contentType(TEXT_PLAIN_VALUE)
+                        .accept(APPLICATION_NDJSON))
                 .andReturn();
 
         // Then
@@ -285,7 +304,7 @@ class GremlinControllerTest {
     }
 
     @Test
-    void shouldRejectMalformedCypherQuery() throws Exception {
+    void shouldRejectMalformedCypherQueryFromExplain() throws Exception {
         // Given
         String cypherString = "MATCH (p:person) WHERE RETURN p";
 
@@ -295,6 +314,25 @@ class GremlinControllerTest {
                         .post(CYPHER_EXPLAIN_ENDPOINT)
                         .content(cypherString)
                         .contentType(TEXT_PLAIN_VALUE))
+                .andReturn();
+
+        // Then
+        // Expect a server error response
+        assertThat(result.getResponse().getStatus()).isEqualTo(500);
+    }
+
+    @Test
+    void shouldRejectMalformedCypherQueryFromExecute() throws Exception {
+        // Given
+        String cypherString = "MATCH (p:person) WHERE RETURN p";
+
+        // When
+        MvcResult result = mockMvc
+                .perform(MockMvcRequestBuilders
+                        .post(CYPHER_EXECUTE_ENDPOINT)
+                        .content(cypherString)
+                        .contentType(TEXT_PLAIN_VALUE)
+                        .accept(APPLICATION_NDJSON))
                 .andReturn();
 
         // Then


### PR DESCRIPTION
Fixes the issue where the status was always reported as 200 on the Gremlin execute endpoints. They now fail with 500 and a message. 

Some misc fixes for open telemetry spans as well.

# Related issue

- Resolve #3303