### PR TITLE
Gh-3305: Fix to apply OpOptions at OpChain level

### DIFF
--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -708,6 +708,8 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
     }
 
     public <T> T execute(final OperationChain<T> opChain) {
+        // Set options at opChain level
+        opChain.setOptions(variables.getOperationOptions());
         for (final Operation operation : opChain.getOperations()) {
             // Set options on operations
             operation.setOptions(variables.getOperationOptions());


### PR DESCRIPTION
Teeny fix - applies operation options at opChain and operation level for simple fed store and current fed store.

# Related issue

- Resolve #3305