### PR TITLE
Gh-3300: Graph access controls for federated POC

### DIFF
--- a/library/tinkerpop/src/test/resources/federatedStore/simple-fed-store.properties
+++ b/library/tinkerpop/src/test/resources/federatedStore/simple-fed-store.properties
@@ -16,6 +16,6 @@
 
 gaffer.store.class=uk.gov.gchq.gaffer.federated.simple.FederatedStore
 gaffer.store.properties.class=uk.gov.gchq.gaffer.federated.simple.FederatedStoreProperties
-gaffer.store.federated.default.mergeElements=true
+gaffer.store.federated.default.aggregateElements=true
 gaffer.store.federated.default.graphIds=knowsGraph,createdGraph
 gaffer.cache.service.default.class=uk.gov.gchq.gaffer.cache.impl.HashMapCacheService

--- a/store-implementation/simple-federated-store/pom.xml
+++ b/store-implementation/simple-federated-store/pom.xml
@@ -65,6 +65,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>uk.gov.gchq.gaffer</groupId>
+            <artifactId>hdfs-library</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
             <scope>test</scope>

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
@@ -115,7 +115,7 @@ public class FederatedStore extends Store {
      *
      * @throws IllegalArgumentException If there is already a graph with the supplied ID
      */
-    public void addGraph(final GraphSerialisable graph, GraphAccess graphAccess) {
+    public void addGraph(final GraphSerialisable graph, final GraphAccess graphAccess) {
         // Pair the graph with its access in the cache
         Pair<GraphSerialisable, GraphAccess> graphAndAccessPair = new ImmutablePair<>(graph, graphAccess);
         try {
@@ -159,11 +159,11 @@ public class FederatedStore extends Store {
     }
 
     /**
-     * Gets the {@link GraphSerialisable} and {@link GraphAccess} {@Pair} from a
-     * given graph ID.
+     * Gets the {@link Pair} of {@link GraphSerialisable} and
+     * {@link GraphAccess} from a given graph ID.
      *
      * @param graphId The graph ID
-     * @return The {@Pair} relating to the graph ID.
+     * @return The {@link Pair} relating to the graph ID.
      * @throws CacheOperationException  If issue getting from cache.
      * @throws IllegalArgumentException If graph not found.
      */

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
@@ -165,6 +165,19 @@ public class FederatedStore extends Store {
     }
 
     /**
+     * Get the {@link GraphAccess} from the given graph ID. The graph
+     * must obviously be known to this federated store to be returned.
+     *
+     * @param graphId The graph ID
+     * @return The {@link GraphAccess} relating to the ID.
+     * @throws CacheOperationException  If issue getting from cache.
+     * @throws IllegalArgumentException If graph not found.
+     */
+    public GraphAccess getGraphAccess(final String graphId) throws CacheOperationException {
+        return getGraphAccessPair(graphId).getRight();
+    }
+
+    /**
      * Gets the {@link Pair} of {@link GraphSerialisable} and
      * {@link GraphAccess} from a given graph ID.
      *
@@ -230,6 +243,7 @@ public class FederatedStore extends Store {
         // Get existing graph and access
         final Pair<GraphSerialisable, GraphAccess> graphPairToUpdate = getGraphAccessPair(graphToUpdateId);
         final GraphSerialisable graphToUpdate = graphPairToUpdate.getLeft();
+        final GraphAccess graphAccess = graphPairToUpdate.getRight();
 
         // Remove from cache
         removeGraph(graphToUpdateId);
@@ -245,11 +259,11 @@ public class FederatedStore extends Store {
                 .config(graphToUpdate.getConfig())
                 .build();
             // Add graph with new id back to cache
-            addGraph(updatedGraphSerialisable, graphPairToUpdate.getRight());
+            addGraph(updatedGraphSerialisable, graphAccess);
         } else {
             // For other stores just re-add with new graph ID
             graphToUpdate.getConfig().setGraphId(newGraphId);
-            addGraph(graphToUpdate, graphPairToUpdate.getRight());
+            addGraph(graphToUpdate, graphAccess);
         }
     }
 

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
@@ -73,7 +73,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import static uk.gov.gchq.gaffer.cache.CacheServiceLoader.DEFAULT_SERVICE_NAME;
 import static uk.gov.gchq.gaffer.federated.simple.FederatedStoreProperties.PROP_DEFAULT_GRAPH_IDS;
@@ -177,14 +176,13 @@ public class FederatedStore extends Store {
     }
 
     /**
-     * Returns all the graphs available to this store.
+     * Returns all the graphs and their access available to this store.
      *
-     * @return Iterable of {@link GraphSerialisable}s
+     * @return Iterable of {@link Pair}s containing the {@link GraphSerialisable}
+     *         and {@link GraphAccess}
      */
-    public Iterable<GraphSerialisable> getAllGraphs() {
-        return StreamSupport.stream(graphCache.getCache().getAllValues().spliterator(), false)
-            .map(Pair::getLeft)
-            .collect(Collectors.toList());
+    public Iterable<Pair<GraphSerialisable, GraphAccess>> getAllGraphsAndAccess() {
+        return graphCache.getCache().getAllValues();
     }
 
     /**

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreProperties.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreProperties.java
@@ -27,9 +27,13 @@ public class FederatedStoreProperties extends StoreProperties {
      */
     public static final String PROP_DEFAULT_GRAPH_IDS = "gaffer.store.federated.default.graphIds";
     /**
-     * Property key for setting if the default is to apply element merging or not
+     * Property key for setting if the default is to apply element aggregation or not
      */
-    public static final String PROP_DEFAULT_MERGE_ELEMENTS = "gaffer.store.federated.default.mergeElements";
+    public static final String PROP_DEFAULT_MERGE_ELEMENTS = "gaffer.store.federated.default.aggregateElements";
+    /**
+     * Property key for setting if public graphs can be added to the store or not
+     */
+    public static final String PROP_ALLOW_PUBLIC_GRAPHS = "gaffer.store.federated.allowPublicGraphs";
     /**
      * Property key for the class to use when merging number results
      */

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/access/GraphAccess.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/access/GraphAccess.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.access;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import uk.gov.gchq.gaffer.access.AccessControlledResource;
+import uk.gov.gchq.gaffer.access.ResourceType;
+import uk.gov.gchq.gaffer.access.predicate.AccessPredicate;
+import uk.gov.gchq.gaffer.access.predicate.UnrestrictedAccessPredicate;
+import uk.gov.gchq.gaffer.user.User;
+
+import static uk.gov.gchq.gaffer.federated.simple.FederatedStore.FEDERATED_STORE_SYSTEM_USER;
+
+/**
+ * Access control for a Graph that as been added through a federated store.
+ */
+public class GraphAccess implements AccessControlledResource  {
+    // Default accesses applied to a graph can be overridden using builder
+    private boolean isPublic = false;
+    private Set<String> graphAuths = new HashSet<>();
+    private String owner = User.UNKNOWN_USER_ID;
+    private AccessPredicate readAccessPredicate = new UnrestrictedAccessPredicate();
+    private AccessPredicate writeAccessPredicate = new UnrestrictedAccessPredicate();
+
+
+    public boolean isPublic() {
+        return isPublic;
+    }
+
+    public Set<String> getGraphAuths() {
+        return graphAuths;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    @Override
+    public ResourceType getResourceType() {
+        return ResourceType.FederatedStoreGraph;
+    }
+
+    @Override
+    public boolean hasReadAccess(User user, String adminAuth) {
+        return isPublic()
+            || user.getUserId().equals(FEDERATED_STORE_SYSTEM_USER)
+            || readAccessPredicate.test(user, adminAuth);
+    }
+
+    @Override
+    public boolean hasWriteAccess(User user, String adminAuth) {
+        return user.getUserId().equals(FEDERATED_STORE_SYSTEM_USER)
+            || writeAccessPredicate.test(user, adminAuth);
+    }
+
+    public static class Builder {
+        GraphAccess graphAccess = new GraphAccess();
+
+        public GraphAccess build() {
+            return graphAccess;
+        }
+
+        public Builder isPublic(boolean isPublic) {
+            graphAccess.isPublic = isPublic;
+            return this;
+        }
+
+        public Builder graphAuths(Set<String> graphAuths) {
+            graphAccess.graphAuths = graphAuths;
+            return this;
+        }
+
+        public Builder owner(String owner) {
+            graphAccess.owner = owner;
+            return this;
+        }
+
+        public Builder readAccessPredicate(AccessPredicate readAccessPredicate) {
+            graphAccess.readAccessPredicate = readAccessPredicate;
+            return this;
+        }
+
+        public Builder writeAccessPredicate(AccessPredicate writeAccessPredicate) {
+            graphAccess.readAccessPredicate = writeAccessPredicate;
+            return this;
+        }
+    }
+
+}

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/access/GraphAccess.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/access/GraphAccess.java
@@ -16,9 +16,6 @@
 
 package uk.gov.gchq.gaffer.federated.simple.access;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import uk.gov.gchq.gaffer.access.AccessControlledResource;
 import uk.gov.gchq.gaffer.access.ResourceType;
 import uk.gov.gchq.gaffer.access.predicate.AccessPredicate;
@@ -32,23 +29,25 @@ import static uk.gov.gchq.gaffer.federated.simple.FederatedStore.FEDERATED_STORE
  */
 public class GraphAccess implements AccessControlledResource  {
     // Default accesses applied to a graph can be overridden using builder
-    private boolean isPublic = false;
-    private Set<String> graphAuths = new HashSet<>();
+    private boolean isPublic = true;
     private String owner = User.UNKNOWN_USER_ID;
     private AccessPredicate readAccessPredicate = new UnrestrictedAccessPredicate();
     private AccessPredicate writeAccessPredicate = new UnrestrictedAccessPredicate();
-
 
     public boolean isPublic() {
         return isPublic;
     }
 
-    public Set<String> getGraphAuths() {
-        return graphAuths;
-    }
-
     public String getOwner() {
         return owner;
+    }
+
+    public AccessPredicate getReadAccessPredicate() {
+        return readAccessPredicate;
+    }
+
+    public AccessPredicate getWriteAccessPredicate() {
+        return writeAccessPredicate;
     }
 
     @Override
@@ -57,14 +56,14 @@ public class GraphAccess implements AccessControlledResource  {
     }
 
     @Override
-    public boolean hasReadAccess(User user, String adminAuth) {
+    public boolean hasReadAccess(final User user, final String adminAuth) {
         return isPublic()
             || user.getUserId().equals(FEDERATED_STORE_SYSTEM_USER)
             || readAccessPredicate.test(user, adminAuth);
     }
 
     @Override
-    public boolean hasWriteAccess(User user, String adminAuth) {
+    public boolean hasWriteAccess(final User user, final String adminAuth) {
         return user.getUserId().equals(FEDERATED_STORE_SYSTEM_USER)
             || writeAccessPredicate.test(user, adminAuth);
     }
@@ -76,28 +75,23 @@ public class GraphAccess implements AccessControlledResource  {
             return graphAccess;
         }
 
-        public Builder isPublic(boolean isPublic) {
+        public Builder isPublic(final boolean isPublic) {
             graphAccess.isPublic = isPublic;
             return this;
         }
 
-        public Builder graphAuths(Set<String> graphAuths) {
-            graphAccess.graphAuths = graphAuths;
-            return this;
-        }
-
-        public Builder owner(String owner) {
+        public Builder owner(final String owner) {
             graphAccess.owner = owner;
             return this;
         }
 
-        public Builder readAccessPredicate(AccessPredicate readAccessPredicate) {
+        public Builder readAccessPredicate(final AccessPredicate readAccessPredicate) {
             graphAccess.readAccessPredicate = readAccessPredicate;
             return this;
         }
 
-        public Builder writeAccessPredicate(AccessPredicate writeAccessPredicate) {
-            graphAccess.readAccessPredicate = writeAccessPredicate;
+        public Builder writeAccessPredicate(final AccessPredicate writeAccessPredicate) {
+            graphAccess.writeAccessPredicate = writeAccessPredicate;
             return this;
         }
     }

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraph.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraph.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.commons.lang3.exception.CloneFailedException;
 
 import uk.gov.gchq.gaffer.commonutil.Required;
+import uk.gov.gchq.gaffer.federated.simple.access.GraphAccess;
 import uk.gov.gchq.gaffer.graph.GraphConfig;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.store.schema.Schema;
@@ -39,6 +40,7 @@ public class AddGraph implements Operation {
     private GraphConfig graphConfig;
     private Schema schema;
     private Properties properties;
+    private GraphAccess graphAccess;
     private Map<String, String> options;
 
     // Getters
@@ -70,6 +72,15 @@ public class AddGraph implements Operation {
         return properties;
     }
 
+    /**
+     * Get the current set {@link GraphAccess}.
+     *
+     * @return The Graph access.
+     */
+    public GraphAccess getGraphAccess() {
+        return graphAccess;
+    }
+
     // Setters
 
     /**
@@ -99,6 +110,15 @@ public class AddGraph implements Operation {
         this.properties = properties;
     }
 
+    /**
+     * Set the {@link GraphAccess} for the graph.
+     *
+     * @param graphAccess The graph access to set.
+     */
+    public void setGraphAccess(final GraphAccess graphAccess) {
+        this.graphAccess = graphAccess;
+    }
+
     @Override
     public Map<String, String> getOptions() {
         return options;
@@ -115,6 +135,7 @@ public class AddGraph implements Operation {
                 .graphConfig(graphConfig)
                 .schema(schema)
                 .properties(properties)
+                .graphAccess(graphAccess)
                 .options(options)
                 .build();
     }
@@ -154,6 +175,17 @@ public class AddGraph implements Operation {
          */
         public Builder properties(final Properties properties) {
             _getOp().setProperties(properties);
+            return _self();
+        }
+
+        /**
+         * Set the {@link GraphAccess}.
+         *
+         * @param graphAccess The graph access to set.
+         * @return The builder.
+         */
+        public Builder graphAccess(final GraphAccess graphAccess) {
+            _getOp().setGraphAccess(graphAccess);
             return _self();
         }
     }

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraph.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraph.java
@@ -20,8 +20,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import org.apache.commons.lang3.exception.CloneFailedException;
 
+import uk.gov.gchq.gaffer.access.predicate.AccessPredicate;
 import uk.gov.gchq.gaffer.commonutil.Required;
-import uk.gov.gchq.gaffer.federated.simple.access.GraphAccess;
 import uk.gov.gchq.gaffer.graph.GraphConfig;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.store.schema.Schema;
@@ -40,7 +40,10 @@ public class AddGraph implements Operation {
     private GraphConfig graphConfig;
     private Schema schema;
     private Properties properties;
-    private GraphAccess graphAccess;
+    private String owner;
+    private Boolean isPublic;
+    private AccessPredicate readPredicate;
+    private AccessPredicate writePredicate;
     private Map<String, String> options;
 
     // Getters
@@ -72,13 +75,20 @@ public class AddGraph implements Operation {
         return properties;
     }
 
-    /**
-     * Get the current set {@link GraphAccess}.
-     *
-     * @return The Graph access.
-     */
-    public GraphAccess getGraphAccess() {
-        return graphAccess;
+    public String getOwner() {
+        return owner;
+    }
+
+    public Boolean isPublic() {
+        return isPublic;
+    }
+
+    public AccessPredicate getReadPredicate() {
+        return readPredicate;
+    }
+
+    public AccessPredicate getWritePredicate() {
+        return writePredicate;
     }
 
     // Setters
@@ -110,13 +120,20 @@ public class AddGraph implements Operation {
         this.properties = properties;
     }
 
-    /**
-     * Set the {@link GraphAccess} for the graph.
-     *
-     * @param graphAccess The graph access to set.
-     */
-    public void setGraphAccess(final GraphAccess graphAccess) {
-        this.graphAccess = graphAccess;
+    public void setOwner(final String owner) {
+        this.owner = owner;
+    }
+
+    public void setIsPublic(final Boolean isPublic) {
+        this.isPublic = isPublic;
+    }
+
+    public void setReadPredicate(final AccessPredicate readPredicate) {
+        this.readPredicate = readPredicate;
+    }
+
+    public void setWritePredicate(final AccessPredicate writePredicate) {
+        this.writePredicate = writePredicate;
     }
 
     @Override
@@ -135,7 +152,8 @@ public class AddGraph implements Operation {
                 .graphConfig(graphConfig)
                 .schema(schema)
                 .properties(properties)
-                .graphAccess(graphAccess)
+                .readPredicate(readPredicate)
+                .writePredicate(writePredicate)
                 .options(options)
                 .build();
     }
@@ -178,14 +196,23 @@ public class AddGraph implements Operation {
             return _self();
         }
 
-        /**
-         * Set the {@link GraphAccess}.
-         *
-         * @param graphAccess The graph access to set.
-         * @return The builder.
-         */
-        public Builder graphAccess(final GraphAccess graphAccess) {
-            _getOp().setGraphAccess(graphAccess);
+        public Builder owner(final String owner) {
+            _getOp().setOwner(owner);
+            return _self();
+        }
+
+        public Builder isPublic(final Boolean isPublic) {
+            _getOp().setIsPublic(isPublic);
+            return _self();
+        }
+
+        public Builder readPredicate(final AccessPredicate readPredicate) {
+            _getOp().setReadPredicate(readPredicate);
+            return _self();
+        }
+
+        public Builder writePredicate(final AccessPredicate writePredicate) {
+            _getOp().setWritePredicate(writePredicate);
             return _self();
         }
     }

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOperationHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOperationHandler.java
@@ -169,7 +169,8 @@ public class FederatedOperationHandler<P extends Operation> implements Operation
         // If a user has specified to just exclude some graphs then run all but them
         if (operation.containsOption(OPT_EXCLUDE_GRAPH_IDS)) {
             // Get all the IDs
-            graphIds = StreamSupport.stream(store.getAllGraphs().spliterator(), false)
+            graphIds = StreamSupport.stream(store.getAllGraphsAndAccess().spliterator(), false)
+                .map(Pair::getLeft)
                 .map(GraphSerialisable::getGraphId)
                 .collect(Collectors.toList());
 

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOperationHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOperationHandler.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.federated.simple.operation.handler;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,8 +39,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * Main default handler for federated operations. Handles delegation to selected

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOutputHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOutputHandler.java
@@ -40,7 +40,7 @@ public class FederatedOutputHandler<P extends Output<O>, O>
 
     @Override
     public O doOperation(final P operation, final Context context, final Store store) throws OperationException {
-        List<GraphSerialisable> graphsToExecute = this.getGraphsToExecuteOn((FederatedStore) store, operation);
+        List<GraphSerialisable> graphsToExecute = this.getGraphsToExecuteOn(operation, context, (FederatedStore) store);
 
         if (graphsToExecute.isEmpty()) {
             return null;

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/add/AddGraphHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/add/AddGraphHandler.java
@@ -36,12 +36,22 @@ public class AddGraphHandler implements OperationHandler<AddGraph> {
                 .properties(operation.getProperties())
                 .build();
 
-        GraphAccess access = operation.getGraphAccess() != null
-            ? operation.getGraphAccess()
-            : new GraphAccess.Builder().owner(context.getUser().getUserId()).build();
+        // Init the builder with the owner if set
+        GraphAccess.Builder accessBuilder = new GraphAccess.Builder()
+            .owner(operation.getOwner() != null ? operation.getOwner() : context.getUser().getUserId());
+        // Add options to the graph access
+        if (operation.isPublic() != null) {
+            accessBuilder.isPublic(operation.isPublic());
+        }
+        if (operation.getReadPredicate() != null) {
+            accessBuilder.readAccessPredicate(operation.getReadPredicate());
+        }
+        if (operation.getWritePredicate() != null) {
+            accessBuilder.writeAccessPredicate(operation.getWritePredicate());
+        }
 
         // Add the graph
-        ((FederatedStore) store).addGraph(newGraph, access);
+        ((FederatedStore) store).addGraph(newGraph, accessBuilder.build());
 
         return null;
     }

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/add/AddGraphHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/add/AddGraphHandler.java
@@ -17,6 +17,7 @@
 package uk.gov.gchq.gaffer.federated.simple.operation.handler.add;
 
 import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
+import uk.gov.gchq.gaffer.federated.simple.access.GraphAccess;
 import uk.gov.gchq.gaffer.federated.simple.operation.AddGraph;
 import uk.gov.gchq.gaffer.graph.GraphSerialisable;
 import uk.gov.gchq.gaffer.operation.OperationException;
@@ -35,8 +36,12 @@ public class AddGraphHandler implements OperationHandler<AddGraph> {
                 .properties(operation.getProperties())
                 .build();
 
+        GraphAccess access = operation.getGraphAccess() != null
+            ? operation.getGraphAccess()
+            : new GraphAccess.Builder().owner(context.getUser().getUserId()).build();
+
         // Add the graph
-        ((FederatedStore) store).addGraph(newGraph);
+        ((FederatedStore) store).addGraph(newGraph, access);
 
         return null;
     }

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/add/AddGraphHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/add/AddGraphHandler.java
@@ -25,6 +25,8 @@ import uk.gov.gchq.gaffer.store.Context;
 import uk.gov.gchq.gaffer.store.Store;
 import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
 
+import static uk.gov.gchq.gaffer.federated.simple.FederatedStoreProperties.PROP_ALLOW_PUBLIC_GRAPHS;
+
 public class AddGraphHandler implements OperationHandler<AddGraph> {
 
     @Override
@@ -49,9 +51,15 @@ public class AddGraphHandler implements OperationHandler<AddGraph> {
         if (operation.getWritePredicate() != null) {
             accessBuilder.writeAccessPredicate(operation.getWritePredicate());
         }
+        GraphAccess access = accessBuilder.build();
+
+        // Check if public graphs can be added
+        if (access.isPublic() && !Boolean.parseBoolean(store.getProperties().get(PROP_ALLOW_PUBLIC_GRAPHS, "true"))) {
+            throw new OperationException("Public graphs are not allowed to be added to this store");
+        }
 
         // Add the graph
-        ((FederatedStore) store).addGraph(newGraph, accessBuilder.build());
+        ((FederatedStore) store).addGraph(newGraph, access);
 
         return null;
     }

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphIdsHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphIdsHandler.java
@@ -16,6 +16,8 @@
 
 package uk.gov.gchq.gaffer.federated.simple.operation.handler.get;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
 import uk.gov.gchq.gaffer.federated.simple.operation.GetAllGraphIds;
 import uk.gov.gchq.gaffer.graph.GraphSerialisable;
@@ -33,7 +35,8 @@ public class GetAllGraphIdsHandler implements OutputOperationHandler<GetAllGraph
     @Override
     public Set<String> doOperation(final GetAllGraphIds operation, final Context context, final Store store) throws OperationException {
         // Get all the graphs and convert to a set of just IDs
-        return StreamSupport.stream(((FederatedStore) store).getAllGraphs().spliterator(), false)
+        return StreamSupport.stream(((FederatedStore) store).getAllGraphsAndAccess().spliterator(), false)
+            .map(Pair::getLeft)
             .map(GraphSerialisable::getGraphId)
             .collect(Collectors.toSet());
     }

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphInfoHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphInfoHandler.java
@@ -35,6 +35,7 @@ public class GetAllGraphInfoHandler implements OutputOperationHandler<GetAllGrap
 
     public static final String DESCRIPTION = "graphDescription";
     public static final String HOOKS = "graphHooks";
+    public static final String STORE_CLASS = "storeClass";
     public static final String PROPERTIES = "storeProperties";
     public static final String OP_DECLARATIONS = "operationDeclarations";
     public static final String OWNER = "owner";
@@ -54,13 +55,13 @@ public class GetAllGraphInfoHandler implements OutputOperationHandler<GetAllGrap
                 // Get the various properties of the individual federated graphs
                 graphInfo.put(DESCRIPTION, graph.getConfig().getDescription());
                 graphInfo.put(HOOKS, graph.getConfig().getHooks());
-                graphInfo.put(PROPERTIES, graph.getStoreProperties().getStoreClass());
+                graphInfo.put(STORE_CLASS, graph.getStoreProperties().getStoreClass());
                 graphInfo.put(OP_DECLARATIONS, graph.getStoreProperties().getOperationDeclarations().getOperations());
                 // Get the access properties
                 graphInfo.put(OWNER, access.getOwner());
                 graphInfo.put(IS_PUBLIC, access.isPublic());
 
-                // Add the full properties if user has write access
+                // Only add the full properties if user has write access
                 if (access.hasWriteAccess(context.getUser(), store.getProperties().getAdminAuth())) {
                     graphInfo.put(PROPERTIES, graph.getStoreProperties().getProperties());
                 }

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphInfoHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphInfoHandler.java
@@ -54,11 +54,16 @@ public class GetAllGraphInfoHandler implements OutputOperationHandler<GetAllGrap
                 // Get the various properties of the individual federated graphs
                 graphInfo.put(DESCRIPTION, graph.getConfig().getDescription());
                 graphInfo.put(HOOKS, graph.getConfig().getHooks());
-                graphInfo.put(PROPERTIES, graph.getStoreProperties().getProperties());
+                graphInfo.put(PROPERTIES, graph.getStoreProperties().getStoreClass());
                 graphInfo.put(OP_DECLARATIONS, graph.getStoreProperties().getOperationDeclarations().getOperations());
                 // Get the access properties
                 graphInfo.put(OWNER, access.getOwner());
                 graphInfo.put(IS_PUBLIC, access.isPublic());
+
+                // Add the full properties if user has write access
+                if (access.hasWriteAccess(context.getUser(), store.getProperties().getAdminAuth())) {
+                    graphInfo.put(PROPERTIES, graph.getStoreProperties().getProperties());
+                }
 
                 // Add the Graph ID and all properties associated with it
                 allGraphInfo.put(graph.getConfig().getGraphId(), graphInfo);

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphInfoHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetAllGraphInfoHandler.java
@@ -17,6 +17,7 @@
 package uk.gov.gchq.gaffer.federated.simple.operation.handler.get;
 
 import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
+import uk.gov.gchq.gaffer.federated.simple.access.GraphAccess;
 import uk.gov.gchq.gaffer.federated.simple.operation.GetAllGraphInfo;
 import uk.gov.gchq.gaffer.graph.GraphSerialisable;
 import uk.gov.gchq.gaffer.operation.OperationException;
@@ -36,26 +37,32 @@ public class GetAllGraphInfoHandler implements OutputOperationHandler<GetAllGrap
     public static final String HOOKS = "graphHooks";
     public static final String PROPERTIES = "storeProperties";
     public static final String OP_DECLARATIONS = "operationDeclarations";
+    public static final String OWNER = "owner";
+    public static final String IS_PUBLIC = "isPublic";
 
     @Override
     public Map<String, Object> doOperation(final GetAllGraphInfo operation, final Context context, final Store store)
         throws OperationException {
-            // Get all the graphs in the federated store
-            Iterable<GraphSerialisable> graphList = ((FederatedStore) store).getAllGraphs();
-
             Map<String, Object> allGraphInfo = new HashMap<>();
 
-            for (final GraphSerialisable gs : graphList) {
-                // Get the various properties of the individual federated graphs
+            // Get all the graphs in the federated store
+            ((FederatedStore) store).getAllGraphsAndAccess().forEach(pair -> {
                 Map<String, Object> graphInfo = new HashMap<>();
-                graphInfo.put(DESCRIPTION, gs.getConfig().getDescription());
-                graphInfo.put(HOOKS, gs.getConfig().getHooks());
-                graphInfo.put(PROPERTIES, gs.getStoreProperties().getProperties());
-                graphInfo.put(OP_DECLARATIONS, gs.getStoreProperties().getOperationDeclarations().getOperations());
+                GraphSerialisable graph = pair.getLeft();
+                GraphAccess access = pair.getRight();
+
+                // Get the various properties of the individual federated graphs
+                graphInfo.put(DESCRIPTION, graph.getConfig().getDescription());
+                graphInfo.put(HOOKS, graph.getConfig().getHooks());
+                graphInfo.put(PROPERTIES, graph.getStoreProperties().getProperties());
+                graphInfo.put(OP_DECLARATIONS, graph.getStoreProperties().getOperationDeclarations().getOperations());
+                // Get the access properties
+                graphInfo.put(OWNER, access.getOwner());
+                graphInfo.put(IS_PUBLIC, access.isPublic());
 
                 // Add the Graph ID and all properties associated with it
-                allGraphInfo.put(gs.getConfig().getGraphId(), graphInfo);
-            }
+                allGraphInfo.put(graph.getConfig().getGraphId(), graphInfo);
+            });
 
             return allGraphInfo;
         }

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetSchemaHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetSchemaHandler.java
@@ -35,7 +35,7 @@ public class GetSchemaHandler extends FederatedOutputHandler<GetSchema, Schema> 
 
     @Override
     public Schema doOperation(final GetSchema operation, final Context context, final Store store) throws OperationException {
-        List<GraphSerialisable> graphsToExecute = this.getGraphsToExecuteOn((FederatedStore) store, operation);
+        List<GraphSerialisable> graphsToExecute = this.getGraphsToExecuteOn(operation, context, (FederatedStore) store);
 
         if (graphsToExecute.isEmpty()) {
             return new Schema();

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/ChangeGraphIdHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/ChangeGraphIdHandler.java
@@ -32,7 +32,7 @@ public class ChangeGraphIdHandler implements OperationHandler<ChangeGraphId> {
     public Object doOperation(final ChangeGraphId operation, final Context context, final Store store) throws OperationException {
         try {
             // Check user for write access as we're modifying the graph
-            GraphAccess access = ((FederatedStore) store).getGraphAccessPair(operation.getGraphId()).getRight();
+            GraphAccess access = ((FederatedStore) store).getGraphAccess(operation.getGraphId());
             if (!access.hasWriteAccess(context.getUser(), store.getProperties().getAdminAuth())) {
                 throw new OperationException(
                     "User: '" + context.getUser().getUserId() + "' does not have write permissions for Graph: " + operation.getGraphId());

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/RemoveGraphHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/RemoveGraphHandler.java
@@ -33,7 +33,7 @@ public class RemoveGraphHandler implements OperationHandler<RemoveGraph> {
     public Object doOperation(final RemoveGraph operation, final Context context, final Store store) throws OperationException {
         try {
             // Check user for write access as we're modifying the graph
-            GraphAccess access = ((FederatedStore) store).getGraphAccessPair(operation.getGraphId()).getRight();
+            GraphAccess access = ((FederatedStore) store).getGraphAccess(operation.getGraphId());
             if (!access.hasWriteAccess(context.getUser(), store.getProperties().getAdminAuth())) {
                 throw new OperationException(
                     "User: '" + context.getUser().getUserId() + "' does not have write permissions for Graph: " + operation.getGraphId());

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/RemoveGraphHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/RemoveGraphHandler.java
@@ -36,7 +36,7 @@ public class RemoveGraphHandler implements OperationHandler<RemoveGraph> {
             GraphAccess access = ((FederatedStore) store).getGraphAccessPair(operation.getGraphId()).getRight();
             if (!access.hasWriteAccess(context.getUser(), store.getProperties().getAdminAuth())) {
                 throw new OperationException(
-                    "User: " + context.getUser() + " does not have write permissions for Graph: " + operation.getGraphId());
+                    "User: '" + context.getUser().getUserId() + "' does not have write permissions for Graph: " + operation.getGraphId());
             }
         } catch (final CacheOperationException e) {
             throw new OperationException(e);

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
@@ -29,7 +29,7 @@ import uk.gov.gchq.gaffer.federated.simple.operation.GetAllGraphIds;
 import uk.gov.gchq.gaffer.federated.simple.operation.GetAllGraphInfo;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.FederatedOperationHandler;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.get.GetAllGraphInfoHandler;
-import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils;
+import uk.gov.gchq.gaffer.federated.simple.util.FederatedTestUtils;
 import uk.gov.gchq.gaffer.graph.Graph;
 import uk.gov.gchq.gaffer.graph.GraphConfig;
 import uk.gov.gchq.gaffer.operation.OperationChain;
@@ -43,7 +43,7 @@ import uk.gov.gchq.gaffer.store.schema.Schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils.StoreType;
+import static uk.gov.gchq.gaffer.federated.simple.util.FederatedTestUtils.StoreType;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Map;
@@ -66,8 +66,8 @@ class FederatedStoreIT {
         final String graphId1 = "graph1";
         final String graphId2 = "graph2";
 
-        final Graph graph1 = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId1, StoreType.ACCUMULO);
-        final Graph graph2 = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId2, StoreType.ACCUMULO);
+        final Graph graph1 = FederatedTestUtils.getBlankGraphWithModernSchema(this.getClass(), graphId1, StoreType.ACCUMULO);
+        final Graph graph2 = FederatedTestUtils.getBlankGraphWithModernSchema(this.getClass(), graphId2, StoreType.ACCUMULO);
 
         final String group = "person";
         final String vertex = "1";
@@ -184,7 +184,7 @@ class FederatedStoreIT {
         // Given
         FederatedStore store = new FederatedStore();
         final String graphId1 = "graph1";
-        final Graph graph1 = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId1, StoreType.MAP);
+        final Graph graph1 = FederatedTestUtils.getBlankGraphWithModernSchema(this.getClass(), graphId1, StoreType.MAP);
         final GraphAccess access = new GraphAccess();
 
         // Init store and add graph

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
@@ -23,6 +23,7 @@ import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
 import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.Entity;
 import uk.gov.gchq.gaffer.data.element.Properties;
+import uk.gov.gchq.gaffer.federated.simple.access.GraphAccess;
 import uk.gov.gchq.gaffer.federated.simple.operation.AddGraph;
 import uk.gov.gchq.gaffer.federated.simple.operation.GetAllGraphIds;
 import uk.gov.gchq.gaffer.federated.simple.operation.GetAllGraphInfo;
@@ -184,6 +185,7 @@ class FederatedStoreIT {
         FederatedStore store = new FederatedStore();
         final String graphId1 = "graph1";
         final Graph graph1 = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId1, StoreType.MAP);
+        final GraphAccess access = new GraphAccess();
 
         // Init store and add graph
         store.initialise("federated", null, new StoreProperties());
@@ -199,7 +201,9 @@ class FederatedStoreIT {
                 new SimpleEntry<>(GetAllGraphInfoHandler.DESCRIPTION, graph1.getDescription()),
                 new SimpleEntry<>(GetAllGraphInfoHandler.HOOKS, graph1.getConfig().getHooks()),
                 new SimpleEntry<>(GetAllGraphInfoHandler.OP_DECLARATIONS, graph1.getStoreProperties().getOperationDeclarations().getOperations()),
-                new SimpleEntry<>(GetAllGraphInfoHandler.PROPERTIES, graph1.getStoreProperties().getProperties()))
+                new SimpleEntry<>(GetAllGraphInfoHandler.PROPERTIES, graph1.getStoreProperties().getProperties()),
+                new SimpleEntry<>(GetAllGraphInfoHandler.OWNER, access.getOwner()),
+                new SimpleEntry<>(GetAllGraphInfoHandler.IS_PUBLIC, access.isPublic()))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         // When

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
@@ -237,6 +237,7 @@ class FederatedStoreIT {
                 new SimpleEntry<>(GetAllGraphInfoHandler.DESCRIPTION, graph1.getDescription()),
                 new SimpleEntry<>(GetAllGraphInfoHandler.HOOKS, graph1.getConfig().getHooks()),
                 new SimpleEntry<>(GetAllGraphInfoHandler.OP_DECLARATIONS, graph1.getStoreProperties().getOperationDeclarations().getOperations()),
+                new SimpleEntry<>(GetAllGraphInfoHandler.STORE_CLASS, graph1.getStoreProperties().getStoreClass()),
                 new SimpleEntry<>(GetAllGraphInfoHandler.PROPERTIES, graph1.getStoreProperties().getProperties()),
                 new SimpleEntry<>(GetAllGraphInfoHandler.OWNER, access.getOwner()),
                 new SimpleEntry<>(GetAllGraphInfoHandler.IS_PUBLIC, access.isPublic()))

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
 import uk.gov.gchq.gaffer.cache.exception.CacheOperationException;
+import uk.gov.gchq.gaffer.federated.simple.access.GraphAccess;
 import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils;
 import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils.StoreType;
 import uk.gov.gchq.gaffer.graph.Graph;
@@ -90,8 +91,10 @@ class FederatedStoreTest {
         // Set the defaults to graphs and make sure to add them
         properties.set(PROP_DEFAULT_GRAPH_IDS, graphId1 + "," + graphId2);
         store.initialise(graphId, null, properties);
-        store.addGraph(new GraphSerialisable(new GraphConfig(graphId1), new Schema(), new StoreProperties()));
-        store.addGraph(new GraphSerialisable(new GraphConfig(graphId2), new Schema(), new StoreProperties()));
+        store.addGraph(new GraphSerialisable(new GraphConfig(graphId1), new Schema(), new StoreProperties()),
+                new GraphAccess());
+        store.addGraph(new GraphSerialisable(new GraphConfig(graphId2), new Schema(), new StoreProperties()),
+                new GraphAccess());
 
         assertThat(store.getDefaultGraphIds()).containsExactly(graphId1, graphId2);
     }
@@ -115,8 +118,8 @@ class FederatedStoreTest {
         // When
         FederatedStore store = new FederatedStore();
         store.initialise(federatedGraphId, null, new StoreProperties());
-        store.addGraph(graph1Serialisable);
-        store.addGraph(graph2Serialisable);
+        store.addGraph(graph1Serialisable, new GraphAccess());
+        store.addGraph(graph2Serialisable, new GraphAccess());
 
         // Then
         assertThat(store.getGraph(graphId1)).isEqualTo(

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreTest.java
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.Test;
 import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
 import uk.gov.gchq.gaffer.cache.exception.CacheOperationException;
 import uk.gov.gchq.gaffer.federated.simple.access.GraphAccess;
-import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils;
-import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils.StoreType;
+import uk.gov.gchq.gaffer.federated.simple.util.FederatedTestUtils;
+import uk.gov.gchq.gaffer.federated.simple.util.FederatedTestUtils.StoreType;
 import uk.gov.gchq.gaffer.graph.Graph;
 import uk.gov.gchq.gaffer.graph.GraphConfig;
 import uk.gov.gchq.gaffer.graph.GraphSerialisable;
@@ -107,14 +107,14 @@ class FederatedStoreTest {
         final String graphId1 = "graph1";
         final String graphId2 = "graph2";
 
-        final Graph graph1 = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId1, StoreType.MAP);
-        final Graph graph2 = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId2, StoreType.MAP);
+        final Graph graph1 = FederatedTestUtils.getBlankGraphWithModernSchema(this.getClass(), graphId1, StoreType.MAP);
+        final Graph graph2 = FederatedTestUtils.getBlankGraphWithModernSchema(this.getClass(), graphId2, StoreType.MAP);
 
         final GraphSerialisable graph1Serialisable = new GraphSerialisable(graph1.getConfig(), graph1.getSchema(), graph1.getStoreProperties());
         final GraphSerialisable graph2Serialisable = new GraphSerialisable(graph2.getConfig(), graph2.getSchema(), graph2.getStoreProperties());
 
-        final Graph expectedGraph1 = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId1, StoreType.MAP);
-        final Graph expectedGraph2 = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId2, StoreType.MAP);
+        final Graph expectedGraph1 = FederatedTestUtils.getBlankGraphWithModernSchema(this.getClass(), graphId1, StoreType.MAP);
+        final Graph expectedGraph2 = FederatedTestUtils.getBlankGraphWithModernSchema(this.getClass(), graphId2, StoreType.MAP);
 
         // When
         FederatedStore store = new FederatedStore();

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreTest.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.federated.simple;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -132,11 +133,13 @@ class FederatedStoreTest {
                 expectedGraph2.getConfig(),
                 expectedGraph2.getSchema(),
                 expectedGraph2.getStoreProperties()));
-        assertThat(store.getAllGraphs()).containsExactlyInAnyOrder(
-            new GraphSerialisable(
-                expectedGraph1.getConfig(),
-                expectedGraph1.getSchema(),
-                expectedGraph1.getStoreProperties()),
+        assertThat(store.getAllGraphsAndAccess())
+            .extracting(Pair::getLeft)
+            .containsExactlyInAnyOrder(
+                new GraphSerialisable(
+                    expectedGraph1.getConfig(),
+                    expectedGraph1.getSchema(),
+                    expectedGraph1.getStoreProperties()),
             new GraphSerialisable(
                 expectedGraph2.getConfig(),
                 expectedGraph2.getSchema(),

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/access/GraphAccessTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/access/GraphAccessTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.access;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.gaffer.access.predicate.AccessPredicate;
+import uk.gov.gchq.gaffer.access.predicate.NoAccessPredicate;
+import uk.gov.gchq.gaffer.access.predicate.user.DefaultUserPredicate;
+import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
+import uk.gov.gchq.gaffer.user.User;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GraphAccessTest {
+
+    @Test
+    void shouldPreventNonAdminReadIfGraphIsPrivate() {
+        // Given
+        // Private graph with a non admin user
+        GraphAccess access = new GraphAccess.Builder()
+            .isPublic(false)
+            .readAccessPredicate(new NoAccessPredicate()).build();
+        User testUser = new User("test");
+
+        // Then
+        assertThat(access.hasReadAccess(testUser)).isFalse();
+        assertThat(access.hasReadAccess(testUser, "adminAuth")).isFalse();
+    }
+
+    @Test
+    void shouldAllowAdminUserToReadPrivateGraphs() {
+        // Given
+        String adminAuth = "admin";
+        // Private graph with admin user
+        GraphAccess access = new GraphAccess.Builder()
+            .isPublic(false)
+            .readAccessPredicate(new AccessPredicate(new DefaultUserPredicate(User.UNKNOWN_USER_ID, null)))
+            .build();
+        User adminUser = new User.Builder()
+            .opAuth(adminAuth)
+            .userId("adminUser").build();
+
+        // Then
+        // Pass in admin auth to check
+        assertThat(access.hasReadAccess(adminUser, adminAuth)).isTrue();
+    }
+
+    @Test
+    void shouldAllowSystemUserToReadPrivateGraphs() {
+        // Given
+        // Private graph with no read access
+        GraphAccess access = new GraphAccess.Builder()
+            .isPublic(false)
+            .readAccessPredicate(new NoAccessPredicate()).build();
+
+        // System user for federated stores
+        User systemUser = new User(FederatedStore.FEDERATED_STORE_SYSTEM_USER);
+
+        // Then
+        assertThat(access.hasReadAccess(systemUser)).isTrue();
+    }
+
+    @Test
+    void shouldAllowAnyUserToReadPublicGraphs() {
+        // Given
+        // Public graph with restricted read access predicate
+        GraphAccess access = new GraphAccess.Builder()
+            .isPublic(true)
+            .readAccessPredicate(new NoAccessPredicate()).build();
+
+        User unknownUser = new User(User.UNKNOWN_USER_ID);
+
+        // Then
+        assertThat(access.hasReadAccess(unknownUser)).isTrue();
+    }
+
+    @Test
+    void shouldPreventWritingToGraphViaPredicate() {
+        // Given
+        // Graph that does not allow writing
+        GraphAccess access = new GraphAccess.Builder()
+            .writeAccessPredicate(new NoAccessPredicate()).build();
+
+        User testUser = new User("test");
+
+        // When
+        assertThat(access.hasWriteAccess(testUser)).isFalse();
+    }
+
+
+    @Test
+    void shouldAllowSystemUserToWriteToGraphs() {
+        // Given
+        // Graph that does not allow writing
+        GraphAccess access = new GraphAccess.Builder()
+                .writeAccessPredicate(new NoAccessPredicate()).build();
+
+        // System user for federated stores
+        User systemUser = new User(FederatedStore.FEDERATED_STORE_SYSTEM_USER);
+
+        // Then
+        assertThat(access.hasWriteAccess(systemUser)).isTrue();
+    }
+
+}

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraphTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraphTest.java
@@ -203,7 +203,7 @@ class AddGraphTest {
         System.out.print(operation.getReadPredicate());
         federatedStore.execute(operation, new Context());
 
-        final GraphAccess addedAccess = federatedStore.getGraphAccessPair(graphId).getRight();
+        final GraphAccess addedAccess = federatedStore.getGraphAccess(graphId);
 
         // Then
         // Check the access that was added

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraphTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraphTest.java
@@ -16,14 +16,20 @@
 
 package uk.gov.gchq.gaffer.federated.simple.operation;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import uk.gov.gchq.gaffer.access.ResourceType;
+import uk.gov.gchq.gaffer.access.predicate.AccessPredicate;
+import uk.gov.gchq.gaffer.access.predicate.UnrestrictedAccessPredicate;
+import uk.gov.gchq.gaffer.access.predicate.user.DefaultUserPredicate;
 import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
 import uk.gov.gchq.gaffer.cache.exception.CacheOperationException;
 import uk.gov.gchq.gaffer.exception.SerialisationException;
 import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
+import uk.gov.gchq.gaffer.federated.simple.access.GraphAccess;
 import uk.gov.gchq.gaffer.graph.GraphConfig;
 import uk.gov.gchq.gaffer.graph.GraphSerialisable;
 import uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser;
@@ -33,11 +39,12 @@ import uk.gov.gchq.gaffer.store.Context;
 import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.store.StoreProperties;
 import uk.gov.gchq.gaffer.store.schema.Schema;
+import uk.gov.gchq.gaffer.user.User;
+
+import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-
-import java.util.Properties;
 
 class AddGraphTest {
 
@@ -83,7 +90,8 @@ class AddGraphTest {
     }
 
     @Test
-    void shouldAddGraphUsingJSONSerialisation() throws StoreException, OperationException, SerialisationException, CacheOperationException {
+    void shouldAddGraphUsingJSONSerialisation()
+            throws StoreException, OperationException, SerialisationException, CacheOperationException {
         // Given
         final String federatedGraphId = "federated";
         final String graphId = "newGraph";
@@ -159,6 +167,55 @@ class AddGraphTest {
                 .isThrownBy(() -> federatedStore.execute(operation, context))
                 .withMessageContaining("already been added to this store");
 
+    }
+
+    @Test
+    void shouldAddGraphAndAccessUsingJSONSerialisation()
+            throws StoreException, OperationException, SerialisationException, CacheOperationException {
+        // Given
+        final String federatedGraphId = "federated";
+        final String graphId = "newGraph";
+        final StoreProperties storeProperties = new MapStoreProperties();
+        storeProperties.set("gaffer.store.class", "uk.gov.gchq.gaffer.mapstore.MapStore");
+
+        // JSON version of the operation
+        final JSONObject jsonOperation = new JSONObject()
+                .put("class", "uk.gov.gchq.gaffer.federated.simple.operation.AddGraph")
+                .put("graphConfig", new JSONObject()
+                        .put("graphId", graphId))
+                .put("properties", new JSONObject()
+                        .put("gaffer.store.class", "uk.gov.gchq.gaffer.mapstore.MapStore")
+                        .put("gaffer.store.properties.class", "uk.gov.gchq.gaffer.mapstore.MapStoreProperties"))
+                .put("owner", User.UNKNOWN_USER_ID)
+                .put("isPublic", true)
+                .put("readPredicate", new JSONObject()
+                    .put("class", "uk.gov.gchq.gaffer.access.predicate.AccessPredicate")
+                    .put("userPredicate", new JSONObject()
+                        .put("class", "uk.gov.gchq.gaffer.access.predicate.user.DefaultUserPredicate")
+                        .put("auths", new JSONArray()
+                            .put("test"))));
+
+        final FederatedStore federatedStore = new FederatedStore();
+        federatedStore.initialise(federatedGraphId, null, new StoreProperties());
+
+        // When
+        final AddGraph operation = JSONSerialiser.deserialise(jsonOperation.toString(), AddGraph.class);
+        System.out.print(operation.getReadPredicate());
+        federatedStore.execute(operation, new Context());
+
+        final GraphAccess addedAccess = federatedStore.getGraphAccessPair(graphId).getRight();
+
+        // Then
+        // Check the access that was added
+        assertThat(addedAccess.getOwner()).isEqualTo(User.UNKNOWN_USER_ID);
+        assertThat(addedAccess.isPublic()).isTrue();
+        assertThat(addedAccess.getResourceType()).isEqualTo(ResourceType.FederatedStoreGraph);
+        assertThat(addedAccess.getReadAccessPredicate())
+            .isExactlyInstanceOf(AccessPredicate.class);
+        assertThat(addedAccess.getReadAccessPredicate().getUserPredicate())
+            .isExactlyInstanceOf(DefaultUserPredicate.class);
+        assertThat(addedAccess.getWriteAccessPredicate())
+            .isExactlyInstanceOf(UnrestrictedAccessPredicate.class);
     }
 
 }

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraphTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/AddGraphTest.java
@@ -170,7 +170,7 @@ class AddGraphTest {
     }
 
     @Test
-    void shouldAddGraphAndAccessUsingJSONSerialisation()
+    void shouldAddGraphWithAccessUsingJSONSerialisation()
             throws StoreException, OperationException, SerialisationException, CacheOperationException {
         // Given
         final String federatedGraphId = "federated";

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/ChangeGraphIdTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/ChangeGraphIdTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import uk.gov.gchq.gaffer.access.predicate.NoAccessPredicate;
 import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
 import uk.gov.gchq.gaffer.cache.exception.CacheOperationException;
 import uk.gov.gchq.gaffer.data.element.Element;
@@ -28,19 +29,22 @@ import uk.gov.gchq.gaffer.data.element.Entity;
 import uk.gov.gchq.gaffer.data.element.Properties;
 import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.FederatedOperationHandler;
-import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils;
+import uk.gov.gchq.gaffer.federated.simple.util.FederatedTestUtils;
 import uk.gov.gchq.gaffer.graph.Graph;
+import uk.gov.gchq.gaffer.graph.GraphConfig;
 import uk.gov.gchq.gaffer.graph.GraphSerialisable;
 import uk.gov.gchq.gaffer.operation.OperationChain;
 import uk.gov.gchq.gaffer.operation.OperationException;
-import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
 import uk.gov.gchq.gaffer.operation.impl.get.GetAllElements;
 import uk.gov.gchq.gaffer.store.Context;
 import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.store.StoreProperties;
+import uk.gov.gchq.gaffer.store.schema.Schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import static uk.gov.gchq.gaffer.federated.simple.util.FederatedTestUtils.StoreType;
 
 class ChangeGraphIdTest {
     private static final String FED_STORE_ID = "federated";
@@ -53,11 +57,11 @@ class ChangeGraphIdTest {
     }
 
     @ParameterizedTest
-    @EnumSource(ModernDatasetUtils.StoreType.class)
-    void shouldChangeGraphIdAndPreserveData(ModernDatasetUtils.StoreType store) throws StoreException, OperationException, CacheOperationException {
+    @EnumSource(StoreType.class)
+    void shouldChangeGraphIdAndPreserveData(StoreType store) throws StoreException, OperationException, CacheOperationException {
         // Given
         final String graphId = "shouldChangeGraphIdAndPreserveData";
-        final Graph originalGraph = ModernDatasetUtils.getBlankGraphWithModernSchema(this.getClass(), graphId, store);
+        final Graph originalGraph = FederatedTestUtils.getBlankGraphWithModernSchema(this.getClass(), graphId, store);
 
         // Elements to add to the graph
         final Properties graphEntityProps = new Properties();
@@ -68,7 +72,7 @@ class ChangeGraphIdTest {
         final FederatedStore federatedStore = new FederatedStore();
         federatedStore.initialise(FED_STORE_ID, null, new StoreProperties());
         // Add elements to the graph
-        addGraphWithElements(federatedStore, originalGraph, graphEntity);
+        FederatedTestUtils.addGraphWithElements(federatedStore, originalGraph, graphEntity);
         GraphSerialisable expectedGraphSerialisable = federatedStore.getGraph(graphId);
 
         // Change graph ID operation
@@ -125,31 +129,33 @@ class ChangeGraphIdTest {
                 .withMessageContaining(String.format(GRAPH_ID_ERROR, graphId));
     }
 
-     /**
-     * Adds a given graph and elements to a federated store.
-     *
-     * @param store The federated store
-     * @param graph The graph to add
-     * @param elements The elements to add to the graph
-     *
-     * @throws OperationException If fails
-     */
-    private void addGraphWithElements(FederatedStore store, Graph graph, Element... elements) throws OperationException {
-        // Add Graph operation
+    @Test
+    void shouldNotChangeIdOfAccessControlledGraph() throws StoreException, OperationException {
+        final String federatedGraphId = "federated";
+        final String graphId = "shouldNotChangeIdOfAccessControlledGraph";
+
+        final FederatedStore federatedStore = new FederatedStore();
+        federatedStore.initialise(federatedGraphId, null, new StoreProperties());
+
+        // Add a graph that no one can edit
         final AddGraph addGraph = new AddGraph.Builder()
-                .graphConfig(graph.getConfig())
-                .schema(graph.getSchema())
-                .properties(graph.getStoreProperties().getProperties())
+                .graphConfig(new GraphConfig(graphId))
+                .schema(new Schema())
+                .properties(new StoreProperties().getProperties())
+                .writePredicate(new NoAccessPredicate())
                 .build();
 
-        // Add elements operation
-        final AddElements addGraphElements = new AddElements.Builder()
-                .input(elements)
-                .option(FederatedOperationHandler.OPT_GRAPH_IDS, graph.getGraphId())
-                .build();
+        final ChangeGraphId changeGraphId = new ChangeGraphId.Builder()
+            .graphId(graphId)
+            .newGraphId("dontDoThis")
+            .build();
 
-        // Add the graph and its elements
-        store.execute(addGraph, new Context());
-        store.execute(addGraphElements, new Context());
+        // When
+        federatedStore.execute(addGraph, new Context());
+
+        // Then
+        assertThatExceptionOfType(OperationException.class)
+                .isThrownBy(() -> federatedStore.execute(changeGraphId, new Context()))
+                .withMessageContaining("does not have write permissions");
     }
 }

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/util/FederatedTestUtils.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/util/FederatedTestUtils.java
@@ -18,14 +18,21 @@ package uk.gov.gchq.gaffer.federated.simple.util;
 
 import uk.gov.gchq.gaffer.accumulostore.AccumuloProperties;
 import uk.gov.gchq.gaffer.commonutil.StreamUtil;
+import uk.gov.gchq.gaffer.data.element.Element;
+import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
+import uk.gov.gchq.gaffer.federated.simple.operation.AddGraph;
+import uk.gov.gchq.gaffer.federated.simple.operation.handler.FederatedOperationHandler;
 import uk.gov.gchq.gaffer.graph.Graph;
 import uk.gov.gchq.gaffer.graph.GraphConfig;
 import uk.gov.gchq.gaffer.mapstore.MapStoreProperties;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
+import uk.gov.gchq.gaffer.store.Context;
 import uk.gov.gchq.gaffer.store.StoreProperties;
 
-public final class ModernDatasetUtils {
+public final class FederatedTestUtils {
 
-    private ModernDatasetUtils() {
+    private FederatedTestUtils() {
         // utility class
     }
 
@@ -61,5 +68,37 @@ public final class ModernDatasetUtils {
             default:
                 throw new IllegalArgumentException("Unknown StoreType: " + storeType);
         }
+    }
+
+    /**
+     * Adds a given graph and elements to a federated store.
+     *
+     * @param store The federated store
+     * @param graph The graph to add
+     * @param elements The elements to add to the graph
+     *
+     * @throws OperationException If fails
+     */
+    public static void addGraphWithElements(FederatedStore store, Graph graph, Element... elements) throws OperationException {
+        // Add Graph operation
+        final AddGraph addGraph = new AddGraph.Builder()
+                .graphConfig(graph.getConfig())
+                .schema(graph.getSchema())
+                .properties(graph.getStoreProperties().getProperties())
+                .build();
+
+        // Add the graph
+        store.execute(addGraph, new Context());
+
+        // Add elements if required
+        if (elements.length > 0) {
+            final AddElements addGraphElements = new AddElements.Builder()
+                    .input(elements)
+                    .option(FederatedOperationHandler.OPT_GRAPH_IDS, graph.getGraphId())
+                    .build();
+
+            store.execute(addGraphElements, new Context());
+        }
+
     }
 }


### PR DESCRIPTION
Adds optional access controls for graphs added to federated stores to prevent users having visibility or modifying graphs they don't have access to.

Follows a similar concept to the old federated store by using the existing `AccessControlledResource` class and associated framework already in place. One main difference is `graphAuths` no longer exist they can instead be defined inside the `DefaultUserPredicate` or custom predicate, this would look something like the following if done via JSON:

```JSON
{
    "readPredicate": {
        "class": "uk.gov.gchq.gaffer.access.predicate.AccessPredicate",
         "userPredicate": {
             "class": "uk.gov.gchq.gaffer.access.predicate.user.DefaultUserPredicate",
             "auths": [ "auth1", "auth2" ]
        }
    }
}

```

# Related issue

- Resolve #3300