### PR TITLE
Gh-3308: Specify merge classes federated POC

### DIFF
--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreProperties.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreProperties.java
@@ -33,23 +33,23 @@ public class FederatedStoreProperties extends StoreProperties {
     /**
      * Property key for the class to use when merging number results
      */
-    public static final String PROP_MERGE_CLASS_NUMBER = "gaffer.store.federated.mergeClass.number";
+    public static final String PROP_MERGE_CLASS_NUMBER = "gaffer.store.federated.merge.number.class";
     /**
      * Property key for the class to use when merging string results
      */
-    public static final String PROP_MERGE_CLASS_STRING = "gaffer.store.federated.mergeClass.string";
+    public static final String PROP_MERGE_CLASS_STRING = "gaffer.store.federated.merge.string.class";
     /**
      * Property key for the class to use when merging boolean results
      */
-    public static final String PROP_MERGE_CLASS_BOOLEAN = "gaffer.store.federated.mergeClass.boolean";
+    public static final String PROP_MERGE_CLASS_BOOLEAN = "gaffer.store.federated.merge.boolean.class";
     /**
      * Property key for the class to use when merging collection results
      */
-    public static final String PROP_MERGE_CLASS_COLLECTION = "gaffer.store.federated.mergeClass.collection";
+    public static final String PROP_MERGE_CLASS_COLLECTION = "gaffer.store.federated.merge.collection.class";
     /**
      * Property key for the class to use when merging elements
      */
-    public static final String PROP_MERGE_CLASS_ELEMENTS = "gaffer.store.federated.mergeClass.elements";
+    public static final String PROP_MERGE_CLASS_ELEMENTS = "gaffer.store.federated.merge.elements.class";
 
     public FederatedStoreProperties() {
         super(FederatedStore.class);

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreProperties.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreProperties.java
@@ -47,6 +47,10 @@ public class FederatedStoreProperties extends StoreProperties {
      */
     public static final String PROP_MERGE_CLASS_COLLECTION = "gaffer.store.federated.merge.collection.class";
     /**
+     * Property key for the class to use when merging values of a Map result
+     */
+    public static final String PROP_MERGE_CLASS_MAP = "gaffer.store.federated.merge.map.class";
+    /**
      * Property key for the class to use when merging elements
      */
     public static final String PROP_MERGE_CLASS_ELEMENTS = "gaffer.store.federated.merge.elements.class";

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/merge/DefaultResultAccumulator.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/merge/DefaultResultAccumulator.java
@@ -19,9 +19,9 @@ package uk.gov.gchq.gaffer.federated.simple.merge;
 import org.apache.commons.collections4.IterableUtils;
 
 import uk.gov.gchq.gaffer.data.element.Element;
-import uk.gov.gchq.gaffer.federated.simple.FederatedStoreProperties;
 
 import java.util.Collection;
+import java.util.Properties;
 
 /**
  * The default result accumulator for merging results from multiple graphs into one.
@@ -32,7 +32,7 @@ public class DefaultResultAccumulator<T> extends FederatedResultAccumulator<T> {
         super();
     }
 
-    public DefaultResultAccumulator(final FederatedStoreProperties properties) {
+    public DefaultResultAccumulator(final Properties properties) {
         super(properties);
     }
 

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/merge/DefaultResultAccumulator.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/merge/DefaultResultAccumulator.java
@@ -21,6 +21,7 @@ import org.apache.commons.collections4.IterableUtils;
 import uk.gov.gchq.gaffer.data.element.Element;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -70,6 +71,11 @@ public class DefaultResultAccumulator<T> extends FederatedResultAccumulator<T> {
             return (T) this.collectionMergeOperator.apply((Collection<Object>) update, (Collection<Object>) state);
         }
 
+        // Use configured merger for maps
+        if (update instanceof Map) {
+            return (T) this.mapMergeOperator.apply((Map<Object, Object>) update, (Map<Object, Object>) state);
+        }
+
         // If an iterable try merge them
         if (update instanceof Iterable<?>) {
             Iterable<?> updateIterable = (Iterable<?>) update;
@@ -89,6 +95,7 @@ public class DefaultResultAccumulator<T> extends FederatedResultAccumulator<T> {
             return (T) chained;
         }
 
+        // Fallback just return the update
         return update;
     }
 }

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/merge/FederatedResultAccumulator.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/merge/FederatedResultAccumulator.java
@@ -20,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import uk.gov.gchq.gaffer.data.element.Element;
-import uk.gov.gchq.gaffer.federated.simple.FederatedStoreProperties;
 import uk.gov.gchq.gaffer.federated.simple.merge.operator.ElementAggregateOperator;
 import uk.gov.gchq.gaffer.store.schema.Schema;
 import uk.gov.gchq.koryphe.impl.binaryoperator.And;
@@ -29,6 +28,7 @@ import uk.gov.gchq.koryphe.impl.binaryoperator.StringConcat;
 import uk.gov.gchq.koryphe.impl.binaryoperator.Sum;
 
 import java.util.Collection;
+import java.util.Properties;
 import java.util.function.BinaryOperator;
 
 import static uk.gov.gchq.gaffer.federated.simple.FederatedStoreProperties.PROP_DEFAULT_MERGE_ELEMENTS;
@@ -59,7 +59,7 @@ public abstract class FederatedResultAccumulator<T> implements BinaryOperator<T>
         // Construct with defaults
     }
 
-    protected FederatedResultAccumulator(final FederatedStoreProperties properties) {
+    protected FederatedResultAccumulator(final Properties properties) {
         // Use the store properties to configure the merging
         if (properties.containsKey(PROP_MERGE_CLASS_NUMBER)) {
             numberMergeOperator = loadMergeClass(numberMergeOperator, properties.get(PROP_MERGE_CLASS_NUMBER));
@@ -78,7 +78,7 @@ public abstract class FederatedResultAccumulator<T> implements BinaryOperator<T>
         }
         // Should we do element aggregation by default
         if (properties.containsKey(PROP_DEFAULT_MERGE_ELEMENTS)) {
-            setAggregateElements(Boolean.parseBoolean(properties.get(PROP_DEFAULT_MERGE_ELEMENTS)));
+            setAggregateElements(Boolean.parseBoolean((String) properties.get(PROP_DEFAULT_MERGE_ELEMENTS)));
         }
     }
 
@@ -112,10 +112,10 @@ public abstract class FederatedResultAccumulator<T> implements BinaryOperator<T>
     }
 
     @SuppressWarnings("unchecked")
-    private <I> BinaryOperator<I> loadMergeClass(final BinaryOperator<I> originalOperator, final String clazzName) {
+    private <I> BinaryOperator<I> loadMergeClass(final BinaryOperator<I> originalOperator, final Object clazzName) {
         BinaryOperator<I> mergeOperator = originalOperator;
         try {
-            Class<?> clazz = Class.forName(clazzName);
+            Class<?> clazz = Class.forName((String) clazzName);
             mergeOperator = (BinaryOperator<I>) clazz.newInstance();
         } catch (final ClassCastException | ClassNotFoundException | InstantiationException | IllegalAccessException e) {
             LOGGER.warn("Failed to load alternative merge function: {} The default will be used instead.", clazzName);

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOperationHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOperationHandler.java
@@ -149,7 +149,6 @@ public class FederatedOperationHandler<P extends Operation> implements Operation
             throw new OperationException("Failed to get Graphs from cache", e);
         }
 
-
         // Keep graphs sorted so results returned are predictable between runs
         Collections.sort(graphsToExecute, (g1, g2) -> g1.getGraphId().compareTo(g2.getGraphId()));
 

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOperationHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOperationHandler.java
@@ -37,6 +37,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * Main default handler for federated operations. Handles delegation to selected
@@ -57,6 +58,12 @@ public class FederatedOperationHandler<P extends Operation> implements Operation
      * operation should be executed on.
      */
     public static final String OPT_SHORT_GRAPH_IDS = "federated.graphIds";
+
+    /**
+     * Graph IDs to exclude from the execution. If this option is set all graphs
+     * except the ones specified are executed on.
+     */
+    public static final String OPT_EXCLUDE_GRAPH_IDS = "federated.excludeGraphIds";
 
     /**
      * The boolean operation option to specify if element merging should be applied or not.
@@ -137,6 +144,17 @@ public class FederatedOperationHandler<P extends Operation> implements Operation
             graphIds = Arrays.asList(operation.getOption(OPT_GRAPH_IDS).split(","));
         } else if (operation.containsOption(OPT_SHORT_GRAPH_IDS)) {
             graphIds = Arrays.asList(operation.getOption(OPT_SHORT_GRAPH_IDS).split(","));
+        }
+
+        // If a user has specified to just exclude some graphs then run all but them
+        if (operation.containsOption(OPT_EXCLUDE_GRAPH_IDS)) {
+            // Get all the IDs
+            graphIds = StreamSupport.stream(store.getAllGraphs().spliterator(), false)
+                .map(GraphSerialisable::getGraphId)
+                .collect(Collectors.toList());
+
+            // Exclude the ones the user has specified
+            Arrays.asList(operation.getOption(OPT_EXCLUDE_GRAPH_IDS).split(",")).forEach(graphIds::remove);
         }
 
         try {

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOutputHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOutputHandler.java
@@ -17,7 +17,6 @@
 package uk.gov.gchq.gaffer.federated.simple.operation.handler;
 
 import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
-import uk.gov.gchq.gaffer.federated.simple.FederatedStoreProperties;
 import uk.gov.gchq.gaffer.federated.simple.merge.DefaultResultAccumulator;
 import uk.gov.gchq.gaffer.federated.simple.merge.FederatedResultAccumulator;
 import uk.gov.gchq.gaffer.graph.GraphSerialisable;
@@ -29,6 +28,7 @@ import uk.gov.gchq.gaffer.store.operation.handler.OutputOperationHandler;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 
 /**
  * A sub class operation handler for federation that can process operations that have an
@@ -57,9 +57,12 @@ public class FederatedOutputHandler<P extends Output<O>, O>
             return null;
         }
 
+        // Merge the store props with the operation options for setting up the accumulator
+        Properties combinedProps = store.getProperties().getProperties();
+        combinedProps.putAll(operation.getOptions());
+
         // Set up the result accumulator
-        FederatedResultAccumulator<O> resultAccumulator =
-            new DefaultResultAccumulator<>((FederatedStoreProperties) store.getProperties());
+        FederatedResultAccumulator<O> resultAccumulator = new DefaultResultAccumulator<>(combinedProps);
         resultAccumulator.setSchema(((FederatedStore) store).getSchema(graphsToExecute));
 
         if (operation.containsOption(OPT_AGGREGATE_ELEMENTS)) {

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
@@ -31,10 +31,12 @@ import uk.gov.gchq.gaffer.federated.simple.operation.handler.get.GetAllGraphInfo
 import uk.gov.gchq.gaffer.federated.simple.util.ModernDatasetUtils;
 import uk.gov.gchq.gaffer.graph.Graph;
 import uk.gov.gchq.gaffer.graph.GraphConfig;
+import uk.gov.gchq.gaffer.mapstore.MapStoreProperties;
 import uk.gov.gchq.gaffer.operation.OperationChain;
 import uk.gov.gchq.gaffer.operation.OperationException;
 import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
 import uk.gov.gchq.gaffer.operation.impl.get.GetAllElements;
+import uk.gov.gchq.gaffer.operation.impl.get.GetGraphCreatedTime;
 import uk.gov.gchq.gaffer.store.Context;
 import uk.gov.gchq.gaffer.store.StoreException;
 import uk.gov.gchq.gaffer.store.StoreProperties;
@@ -175,7 +177,46 @@ class FederatedStoreIT {
         final Set<String> graphIds = federatedStore.execute(getAllGraphIds, new Context());
 
         assertThat(graphIds).containsExactly(graphId);
+    }
 
+    @Test
+    void shouldExecuteOnAllGraphsExceptExcludedOnes() throws StoreException, OperationException {
+        final String federatedGraphId = "federated";
+        final String graphId1 = "newGraph1";
+        final String graphId2 = "newGraph2";
+        final String graphId3 = "newGraph3";
+
+        // When
+        final FederatedStore federatedStore = new FederatedStore();
+        federatedStore.initialise(federatedGraphId, null, new StoreProperties());
+
+        // AddGraph operations
+        final AddGraph addGraph1 = new AddGraph.Builder()
+                .graphConfig(new GraphConfig(graphId1))
+                .schema(new Schema())
+                .properties(new MapStoreProperties().getProperties())
+                .build();
+        final AddGraph addGraph2 = new AddGraph.Builder()
+                .graphConfig(new GraphConfig(graphId2))
+                .schema(new Schema())
+                .properties(new MapStoreProperties().getProperties())
+                .build();
+        final AddGraph addGraph3 = new AddGraph.Builder()
+                .graphConfig(new GraphConfig(graphId3))
+                .schema(new Schema())
+                .properties(new MapStoreProperties().getProperties())
+                .build();
+
+        federatedStore.execute(addGraph1, new Context());
+        federatedStore.execute(addGraph2, new Context());
+        federatedStore.execute(addGraph3, new Context());
+
+        final GetGraphCreatedTime operation = new GetGraphCreatedTime.Builder()
+            .option(FederatedOperationHandler.OPT_EXCLUDE_GRAPH_IDS, graphId2)
+            .build();
+
+        Map<String, String> result = federatedStore.execute(operation, new Context());
+        assertThat(result).containsOnlyKeys(graphId1, graphId3);
     }
 
     @Test

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/merge/DefaultResultAccumulatorTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/merge/DefaultResultAccumulatorTest.java
@@ -83,11 +83,11 @@ class DefaultResultAccumulatorTest {
     @MethodSource("customMergeDataArgs")
     <T> void shouldAllowCustomOperatorsForPrimitiveData(T result1, T result2, T expected) {
         // Set properties to update the operators
-        FederatedStoreProperties properties = new FederatedStoreProperties();
-        properties.set(PROP_MERGE_CLASS_NUMBER, Product.class.getName());
-        properties.set(PROP_MERGE_CLASS_STRING, StringDeduplicateConcat.class.getName());
-        properties.set(PROP_MERGE_CLASS_BOOLEAN, Or.class.getName());
-        properties.set(PROP_MERGE_CLASS_COLLECTION, CollectionIntersect.class.getName());
+        java.util.Properties properties = new java.util.Properties();
+        properties.setProperty(PROP_MERGE_CLASS_NUMBER, Product.class.getName());
+        properties.setProperty(PROP_MERGE_CLASS_STRING, StringDeduplicateConcat.class.getName());
+        properties.setProperty(PROP_MERGE_CLASS_BOOLEAN, Or.class.getName());
+        properties.setProperty(PROP_MERGE_CLASS_COLLECTION, CollectionIntersect.class.getName());
 
         // Init the accumulator with custom properties
         FederatedResultAccumulator<T> accumulator = new DefaultResultAccumulator<>(properties);
@@ -113,7 +113,7 @@ class DefaultResultAccumulatorTest {
         properties.set(PROP_DEFAULT_MERGE_ELEMENTS, "true");
 
         // When/Then
-        FederatedResultAccumulator<?> accumulator = new DefaultResultAccumulator<>(properties);
+        FederatedResultAccumulator<?> accumulator = new DefaultResultAccumulator<>(properties.getProperties());
         assertThat(accumulator.aggregateElements()).isTrue();
     }
 

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/util/ModernDatasetUtils.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/util/ModernDatasetUtils.java
@@ -32,7 +32,7 @@ public final class ModernDatasetUtils {
     public static final MapStoreProperties MAP_STORE_PROPERTIES = MapStoreProperties
         .loadStoreProperties("/map-store.properties");
     public static final AccumuloProperties ACCUMULO_STORE_PROPERTIES = AccumuloProperties
-            .loadStoreProperties("/accumulo-store.properties");
+        .loadStoreProperties("/accumulo-store.properties");
 
     public static Graph getBlankGraphWithModernSchema(Class<?> clazz, String graphId, StoreType storeType) {
         return new Graph.Builder()


### PR DESCRIPTION
Adds ability to set the merge classes via the operation options using the same property keys as you would through the store properties. 

This also added merge configuration for Map types along with, ability to add an exception list of graphs so a user can specify to run on all graphs except a defined list (this is the feature from #3224).

# Related issue

- Resolve #3308