### PR TITLE
Gh-3319: Fixes ability to get orphan vertices from edges

### DIFF
--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -529,7 +529,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * This method will not return 'id' vertices, only vertices that exist as entities in Gaffer.
      *
      * @param vertexId  the vertex id to start at.
-     * @param direction the direcMARKO.getId()tion along edges to travel
+     * @param direction the direction along edges to travel
      * @param view      a Gaffer {@link View} containing edge and entity groups.
      * @return iterator of {@link GafferPopVertex}
      */
@@ -834,20 +834,20 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
         final Iterable<? extends EntityId> getAdjEntitySeeds = execute(new OperationChain.Builder()
                 .first(new GetAdjacentIds.Builder()
-                        .input(seeds)
-                        .view(view)
-                        .inOutType(getInOutType(direction))
-                        .build())
-                    .build());
+                    .input(seeds)
+                    .view(view)
+                    .inOutType(getInOutType(direction))
+                    .build())
+                .build());
 
         List<EntityId> seedList = StreamSupport.stream(getAdjEntitySeeds.spliterator(), false).collect(Collectors.toList());
 
         // GetAdjacentIds provides list of entity seeds so run a GetElements to get the actual Entities
         final Iterable<? extends Element> result = execute(new OperationChain.Builder()
                 .first(new GetElements.Builder()
-                        .input(seedList)
-                        .build())
-                    .build());
+                    .input(seedList)
+                    .build())
+                .build());
 
         // Translate results to Gafferpop elements
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(this);

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import uk.gov.gchq.gaffer.data.element.Element;
+import uk.gov.gchq.gaffer.data.element.id.EntityId;
 import uk.gov.gchq.gaffer.data.elementdefinition.view.View;
 import uk.gov.gchq.gaffer.graph.Graph;
 import uk.gov.gchq.gaffer.graph.GraphConfig;
@@ -51,6 +52,7 @@ import uk.gov.gchq.gaffer.operation.impl.get.GetAdjacentIds;
 import uk.gov.gchq.gaffer.operation.impl.get.GetAllElements;
 import uk.gov.gchq.gaffer.operation.impl.get.GetElements;
 import uk.gov.gchq.gaffer.operation.io.Input;
+import uk.gov.gchq.gaffer.store.operation.GetSchema;
 import uk.gov.gchq.gaffer.store.schema.Schema;
 import uk.gov.gchq.gaffer.tinkerpop.generator.GafferEdgeGenerator;
 import uk.gov.gchq.gaffer.tinkerpop.generator.GafferEntityGenerator;
@@ -80,6 +82,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -526,7 +529,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * This method will not return 'id' vertices, only vertices that exist as entities in Gaffer.
      *
      * @param vertexId  the vertex id to start at.
-     * @param direction the direction along edges to travel
+     * @param direction the direcMARKO.getId()tion along edges to travel
      * @param view      a Gaffer {@link View} containing edge and entity groups.
      * @return iterator of {@link GafferPopVertex}
      */
@@ -540,7 +543,6 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * Given an iterable of vertex ids, adjacent vertices will be returned.
      * If you provide any optional labels then you must provide edge labels and the vertex
      * labels - any missing labels will cause the elements to be filtered out.
-     * This method will not return 'id' vertices, only vertices that exist as entities in Gaffer.
      *
      * @param vertexIds the iterable of vertex ids to start at.
      * @param direction the direction along edges to travel
@@ -830,17 +832,22 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
             throw new UnsupportedOperationException("There could be a lot of vertices, so please add some seeds");
         }
 
-        final Iterable<? extends Element> result = execute(new OperationChain.Builder()
+        final Iterable<? extends EntityId> getAdjEntitySeeds = execute(new OperationChain.Builder()
                 .first(new GetAdjacentIds.Builder()
                         .input(seeds)
                         .view(view)
                         .inOutType(getInOutType(direction))
                         .build())
-                // GetAdjacentIds provides list of entity seeds so run a GetElements to get the actual Entities
-                .then(new GetElements.Builder()
-                        .view(createAllEntitiesView())
+                    .build());
+
+        List<EntityId> seedList = StreamSupport.stream(getAdjEntitySeeds.spliterator(), false).collect(Collectors.toList());
+
+        // GetAdjacentIds provides list of entity seeds so run a GetElements to get the actual Entities
+        final Iterable<? extends Element> result = execute(new OperationChain.Builder()
+                .first(new GetElements.Builder()
+                        .input(seedList)
                         .build())
-                .build());
+                    .build());
 
         // Translate results to Gafferpop elements
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(this);
@@ -850,7 +857,13 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 .map(e -> (Vertex) e)
                 .iterator();
 
-        return translatedResults.iterator();
+        // Check for seeds that are not entities but are vertices on an edge (orphan vertices)
+        Iterable<Vertex> chainedIterable = translatedResults;
+        for (EntityId seed : seedList) {
+            Iterable<Vertex> orphanVertices = GafferVertexUtils.getOrphanVertices(result, this, seed.getVertex());
+            chainedIterable = IterableUtils.chainedIterable(chainedIterable, orphanVertices);
+        }
+        return chainedIterable.iterator();
     }
 
     private Iterator<Edge> edgesWithSeedsAndView(final List<ElementSeed> seeds, final Direction direction, final View view) {
@@ -922,7 +935,12 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         View view = null;
         if (null != labels && 0 < labels.length) {
             final View.Builder viewBuilder = new View.Builder();
-            final Schema schema = graph.getSchema();
+            final Schema schema = execute(new OperationChain.Builder()
+                .first(new GetSchema.Builder()
+                    .compact(true)
+                    .build())
+                .options(opOptions)
+                .build());
             for (final String label : labels) {
                 if (schema.isEntity(label)) {
                     viewBuilder.entity(label);

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -859,7 +859,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
         // Check for seeds that are not entities but are vertices on an edge (orphan vertices)
         Iterable<Vertex> chainedIterable = translatedResults;
-        for (EntityId seed : seedList) {
+        for (final EntityId seed : seedList) {
             Iterable<Vertex> orphanVertices = GafferVertexUtils.getOrphanVertices(result, this, seed.getVertex());
             chainedIterable = IterableUtils.chainedIterable(chainedIterable, orphanVertices);
         }

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/util/GafferVertexUtils.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/util/GafferVertexUtils.java
@@ -16,10 +16,10 @@
 
 package uk.gov.gchq.gaffer.tinkerpop.process.traversal.util;
 
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import uk.gov.gchq.gaffer.data.element.Edge;
 import uk.gov.gchq.gaffer.data.element.Element;

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
@@ -308,7 +308,7 @@ class GafferPopGraphIT {
         mapStore.addEdge(new GafferPopEdge("knows", GafferPopModernTestUtils.MARKO.getId(), VERTEX_ONLY_ID_STRING, mapStore));
         accumuloStore.addEdge(new GafferPopEdge("knows", GafferPopModernTestUtils.MARKO.getId(), VERTEX_ONLY_ID_STRING, accumuloStore));
 
-        List<Vertex> result = g.V("7").toList();
+        List<Vertex> result = g.V(VERTEX_ONLY_ID_STRING).toList();
         assertThat(result)
             .extracting(r -> r.id())
             .contains(VERTEX_ONLY_ID_STRING);

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
@@ -54,6 +54,7 @@ import static uk.gov.gchq.gaffer.tinkerpop.util.modern.GafferPopModernTestUtils.
  */
 class GafferPopGraphIT {
     private static final String TEST_NAME_FORMAT = "({0}) {displayName}";
+    private static final String VERTEX_ONLY_ID_STRING = "7";
     private static GafferPopGraph mapStore;
     private static GafferPopGraph accumuloStore;
 
@@ -303,28 +304,45 @@ class GafferPopGraphIT {
     @MethodSource("provideTraversals")
     void shouldSeedWithVertexOnlyEdge(String graph, GraphTraversalSource g) {
         // Edge has a vertex but not an entity in the graph - Gaffer only feature
-        String vertexOnlyId = "7";
-        mapStore.addEdge(new GafferPopEdge("knows", GafferPopModernTestUtils.MARKO.getId(), vertexOnlyId, mapStore));
-        accumuloStore.addEdge(new GafferPopEdge("knows", GafferPopModernTestUtils.MARKO.getId(), vertexOnlyId, accumuloStore));
+        // [1 - knows -> 7]
+        mapStore.addEdge(new GafferPopEdge("knows", GafferPopModernTestUtils.MARKO.getId(), VERTEX_ONLY_ID_STRING, mapStore));
+        accumuloStore.addEdge(new GafferPopEdge("knows", GafferPopModernTestUtils.MARKO.getId(), VERTEX_ONLY_ID_STRING, accumuloStore));
 
         List<Vertex> result = g.V("7").toList();
         assertThat(result)
             .extracting(r -> r.id())
-            .contains(vertexOnlyId);
+            .contains(VERTEX_ONLY_ID_STRING);
         reset();
     }
 
     @ParameterizedTest(name = TEST_NAME_FORMAT)
     @MethodSource("provideTraversals")
-    void shouldTraverseEdgeWithVertexOnlySeed(String graph, GraphTraversalSource g) {
-        // Edge has a vertex but not an entity in the graph - Gaffer only feature
-        String vertexOnlyId = "7";
-        mapStore.addEdge(new GafferPopEdge("knows", GafferPopModernTestUtils.MARKO.getId(), vertexOnlyId, mapStore));
-        accumuloStore.addEdge(new GafferPopEdge("knows", GafferPopModernTestUtils.MARKO.getId(), vertexOnlyId, accumuloStore));
+    void shouldTraverseEdgeWithVertexOnlyEdge(String graph, GraphTraversalSource g) {
+        // Edge has a two vertices with no entities in the graph - Gaffer only feature
+        // [8 - knows -> 7]
+        mapStore.addEdge(new GafferPopEdge("knows", "8", VERTEX_ONLY_ID_STRING, mapStore));
+        accumuloStore.addEdge(new GafferPopEdge("knows", "8", VERTEX_ONLY_ID_STRING, accumuloStore));
 
-        List<Map<Object, Object>> result = g.V("7").inE().outV().elementMap().toList();
+        List<Vertex> result = g.V(VERTEX_ONLY_ID_STRING).inE().inV().toList();
         assertThat(result)
-            .containsExactly(MARKO.getPropertyMap());
+            .extracting(r -> r.id())
+            .contains(VERTEX_ONLY_ID_STRING);
+        List<Vertex> result2 = g.V(VERTEX_ONLY_ID_STRING).inE().outV().toList();
+        assertThat(result2)
+            .extracting(r -> r.id())
+            .contains("8");
+        List<Vertex> result3 = g.V("8").outE().inV().toList();
+        assertThat(result3)
+            .extracting(r -> r.id())
+            .contains(VERTEX_ONLY_ID_STRING);
+        List<Vertex> result4 = g.V("8").outE().outV().toList();
+        assertThat(result4)
+            .extracting(r -> r.id())
+            .contains("8");
+        List<Vertex> resultLabel = g.V("8").out("knows").toList();
+        assertThat(resultLabel)
+            .extracting(r -> r.id())
+            .containsOnly(VERTEX_ONLY_ID_STRING);
         reset();
     }
 


### PR DESCRIPTION
Fix that allows users to get the 'orphan' vertices from edges that have no associated entities. 
Also change to GetSchema op when creating a view to allow use of opOperations in GafferPop.

# Related issue

- Resolve #3319