### PR TITLE
Gh-3322: Cache updates for federated POC

### DIFF
--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/hook/NamedOperationResolver.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/hook/NamedOperationResolver.java
@@ -128,7 +128,8 @@ public class NamedOperationResolver implements GetFromCacheHook {
                         .getOperationChain(namedOperation.getParameters());
                 // Update the operation inputs and add operation chain to the updated list
                 OperationHandlerUtil.updateOperationInput(namedOperationChain, namedOperation.getInput());
-
+                namedOperationChain.setOptions(namedOperation.getOptions());
+                
                 // Run again to resolve any nested operations in the chain before adding
                 namedOperationChain.updateOperations(resolveNamedOperations(namedOperationChain, user, depth + 1));
                 updatedOperations.add(namedOperationChain);

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreProperties.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreProperties.java
@@ -35,6 +35,11 @@ public class FederatedStoreProperties extends StoreProperties {
      */
     public static final String PROP_ALLOW_PUBLIC_GRAPHS = "gaffer.store.federated.allowPublicGraphs";
     /**
+     * Property key for setting a custom name for the graph cache, by default
+     * this will be "federatedGraphCache_" followed by the federated graph ID.
+     */
+    public static final String PROP_GRAPH_CACHE_NAME = "gaffer.store.federated.graphCache.name";
+    /**
      * Property key for the class to use when merging number results
      */
     public static final String PROP_MERGE_CLASS_NUMBER = "gaffer.store.federated.merge.number.class";

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/EitherOperationHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/EitherOperationHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.operation.handler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import uk.gov.gchq.gaffer.operation.Operation;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.store.Context;
+import uk.gov.gchq.gaffer.store.Store;
+import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
+
+/**
+ * Custom handler for operations that could in theory target the federated store
+ * directly or sub graphs.
+ */
+public class EitherOperationHandler<O extends Operation> implements OperationHandler<O> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EitherOperationHandler.class);
+
+    private final OperationHandler<O> standardHandler;
+
+    public EitherOperationHandler(final OperationHandler<O> standardHandler) {
+        this.standardHandler = standardHandler;
+    }
+
+    /**
+     * If graph IDs are in the options the operation will be handled by a
+     * {@link FederatedOperationHandler}, otherwise the original handler will be
+     * used e.g. executed on the federated store directly.
+     */
+    @Override
+    public Object doOperation(final O operation, final Context context, final Store store) throws OperationException {
+        LOGGER.debug("Checking if Operation should be handled locally or on sub graphs: {}", operation);
+
+        // If we have graph IDs then run as a federated operation
+        if (operation.containsOption(FederatedOperationHandler.OPT_GRAPH_IDS) ||
+                operation.containsOption(FederatedOperationHandler.OPT_SHORT_GRAPH_IDS) ||
+                operation.containsOption(FederatedOperationHandler.OPT_EXCLUDE_GRAPH_IDS)) {
+            LOGGER.debug("Operation has specified graph IDs, it will be handled by sub graphs");
+            return new FederatedOperationHandler<>().doOperation(operation, context, store);
+        }
+
+        // No sub graphs involved just run the handler for this operations on the federated store
+        return standardHandler.doOperation(operation, context, store);
+    }
+}

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOutputHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOutputHandler.java
@@ -65,7 +65,7 @@ public class FederatedOutputHandler<P extends Output<O>, O>
         }
 
         // Not expecting any output so exit since we've executed
-        if (operation.getOutputClass().isAssignableFrom(Void.class) || graphResults.isEmpty()) {
+        if (operation.getOutputClass() == Void.class || graphResults.isEmpty()) {
             return null;
         }
 


### PR DESCRIPTION
Few updates to how the federated store uses the cache. This allows users to specify a custom cache name for the graph cache which would enable sharing of graphs between federated stores.

This also addresses the handling of operations that technically could be handled by a federated store or by a sub graph. The overall logic has been simplified so that if an operation has graph IDs specified (or excluded) it will be assumed the operation should be run on those sub graphs.

This change has the added benefit of meaning mixing operations in the same chain e.g. for sub graphs or not, is handled seamlessly. 