### PR TITLE
Gh-3324: Add OperationChainValidator to FedStore POC

### DIFF
--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
@@ -33,6 +33,7 @@ import uk.gov.gchq.gaffer.data.element.id.EntityId;
 import uk.gov.gchq.gaffer.federated.simple.access.GraphAccess;
 import uk.gov.gchq.gaffer.federated.simple.operation.AddGraph;
 import uk.gov.gchq.gaffer.federated.simple.operation.ChangeGraphId;
+import uk.gov.gchq.gaffer.federated.simple.operation.FederatedOperationChainValidator;
 import uk.gov.gchq.gaffer.federated.simple.operation.GetAllGraphIds;
 import uk.gov.gchq.gaffer.federated.simple.operation.GetAllGraphInfo;
 import uk.gov.gchq.gaffer.federated.simple.operation.RemoveGraph;
@@ -63,9 +64,11 @@ import uk.gov.gchq.gaffer.store.StoreTrait;
 import uk.gov.gchq.gaffer.store.operation.DeleteAllData;
 import uk.gov.gchq.gaffer.store.operation.GetSchema;
 import uk.gov.gchq.gaffer.store.operation.GetTraits;
+import uk.gov.gchq.gaffer.store.operation.OperationChainValidator;
 import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.OutputOperationHandler;
 import uk.gov.gchq.gaffer.store.schema.Schema;
+import uk.gov.gchq.gaffer.store.schema.ViewValidator;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
@@ -349,6 +352,11 @@ public class FederatedStore extends Store {
     @Override
     protected OperationHandler<? extends OperationChain<?>> getOperationChainHandler() {
         return new FederatedOperationHandler<>();
+    }
+
+    @Override
+    protected OperationChainValidator createOperationChainValidator() {
+        return new FederatedOperationChainValidator(new ViewValidator());
     }
 
     @Override

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/FederatedOperationChainValidator.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/FederatedOperationChainValidator.java
@@ -1,0 +1,28 @@
+package uk.gov.gchq.gaffer.federated.simple.operation;
+
+import uk.gov.gchq.gaffer.core.exception.GafferRuntimeException;
+import uk.gov.gchq.gaffer.operation.Operation;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.store.Context;
+import uk.gov.gchq.gaffer.store.Store;
+import uk.gov.gchq.gaffer.store.operation.GetSchema;
+import uk.gov.gchq.gaffer.store.operation.OperationChainValidator;
+import uk.gov.gchq.gaffer.store.schema.Schema;
+import uk.gov.gchq.gaffer.store.schema.ViewValidator;
+import uk.gov.gchq.gaffer.user.User;
+
+public class FederatedOperationChainValidator extends OperationChainValidator {
+
+    public FederatedOperationChainValidator(final ViewValidator viewValidator) {
+        super(viewValidator);
+    }
+
+    @Override
+    protected Schema getSchema(final Operation operation, final User user, final Store store) {
+        try {
+            return store.execute(new GetSchema.Builder().options(operation.getOptions()).build(), new Context(user));
+        } catch (final OperationException e) {
+            throw new GafferRuntimeException("Unable to get merged schema for graph " + store.getGraphId(), e);
+        }
+    }
+}

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/FederatedOperationChainValidatorTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/FederatedOperationChainValidatorTest.java
@@ -1,9 +1,7 @@
 package uk.gov.gchq.gaffer.federated.simple.operation;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 
-import uk.gov.gchq.gaffer.core.exception.GafferRuntimeException;
 import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.OperationException;
@@ -14,7 +12,6 @@ import uk.gov.gchq.gaffer.store.schema.ViewValidator;
 import uk.gov.gchq.gaffer.user.User;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/FederatedOperationChainValidatorTest.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/operation/FederatedOperationChainValidatorTest.java
@@ -1,0 +1,43 @@
+package uk.gov.gchq.gaffer.federated.simple.operation;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import uk.gov.gchq.gaffer.core.exception.GafferRuntimeException;
+import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
+import uk.gov.gchq.gaffer.operation.Operation;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.store.Context;
+import uk.gov.gchq.gaffer.store.operation.GetSchema;
+import uk.gov.gchq.gaffer.store.schema.Schema;
+import uk.gov.gchq.gaffer.store.schema.ViewValidator;
+import uk.gov.gchq.gaffer.user.User;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class FederatedOperationChainValidatorTest {
+    final ViewValidator viewValidator = mock(ViewValidator.class);
+    final FederatedOperationChainValidator validator = new FederatedOperationChainValidator(viewValidator);
+    final FederatedStore store = mock(FederatedStore.class);
+    final User user = mock(User.class);
+    final Operation op = mock(Operation.class);
+    final Schema schema = mock(Schema.class);
+
+    @Test
+    void shouldGetMergedSchema() throws OperationException {
+        // Given
+        when(store.execute(any(GetSchema.class), any(Context.class))).thenReturn(schema);
+
+        // When
+        final Schema result = validator.getSchema(op, user, store);
+
+        verify(store).execute(any(GetSchema.class), any(Context.class));
+        // Then
+        assertThat(result).isEqualTo(schema);
+    }
+}


### PR DESCRIPTION
Adds a custom OperationChainValidator that overrides getSchema to use the graph's merged schemas when handling Operation Chains.