### PR TITLE
Fixing two flaky tests in AuthorisationsTest and ViewTest

### DIFF
--- a/core/common-util/src/test/java/uk/gov/gchq/gaffer/commonutil/elementvisibilityutil/AuthorisationsTest.java
+++ b/core/common-util/src/test/java/uk/gov/gchq/gaffer/commonutil/elementvisibilityutil/AuthorisationsTest.java
@@ -113,7 +113,8 @@ class AuthorisationsTest {
     @Test
     void testToString() {
         final Authorisations a = new Authorisations("a", "abcdefg", "hijklmno");
-
-        assertThat(a).hasToString("a,hijklmno,abcdefg");
+        assertThat(a.toString()).contains("a");
+        assertThat(a.toString()).contains("abcdefg");
+        assertThat(a.toString()).contains("hijklmno");
     }
 }

--- a/core/data/src/test/java/uk/gov/gchq/gaffer/data/elementdefinition/view/ViewTest.java
+++ b/core/data/src/test/java/uk/gov/gchq/gaffer/data/elementdefinition/view/ViewTest.java
@@ -16,6 +16,8 @@
 
 package uk.gov.gchq.gaffer.data.elementdefinition.view;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.gaffer.JSONSerialisationTest;
@@ -30,6 +32,7 @@ import uk.gov.gchq.gaffer.function.ExampleTransformFunction;
 import uk.gov.gchq.koryphe.impl.function.Identity;
 import uk.gov.gchq.koryphe.impl.predicate.Exists;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -384,7 +387,7 @@ public class ViewTest extends JSONSerialisationTest<View> {
     }
 
     @Test
-    public void shouldCreateAnIdenticalObjectWhenCloned() {
+    public void shouldCreateAnIdenticalObjectWhenCloned() throws IOException {
         // Given
         final ViewElementDefinition edgeDef1 = new ViewElementDefinition();
         final ViewElementDefinition edgeDef2 = new ViewElementDefinition();
@@ -408,8 +411,11 @@ public class ViewTest extends JSONSerialisationTest<View> {
         final byte[] viewJson = view.toCompactJson();
         final byte[] cloneJson = clone.toCompactJson();
 
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode treeView = objectMapper.readTree(viewJson);
+        JsonNode treeClone = objectMapper.readTree(cloneJson);
         // Check that JSON representations of the objects are equal
-        assertThat(cloneJson).containsExactly(viewJson);
+        assertThat(treeClone).isEqualTo(treeView);
 
         final View viewFromJson = new View.Builder().json(viewJson).build();
         final View cloneFromJson = new View.Builder().json(cloneJson).build();


### PR DESCRIPTION
Two flaky tests were fixed in this pull request-

1. uk.gov.gchq.gaffer.commonutil.elementvisibilityutil.AuthorisationsTest.testToString
2. uk.gov.gchq.gaffer.data.elementdefinition.view.ViewTest.shouldCreateAnIdenticalObjectWhenCloned

### Flakiness in the tests - 
To check for flakiness in the tests, a tool called [nondex](https://github.com/TestingResearchIllinois/NonDex) was used. 

### Steps to reproduce flakiness using nondex - 
**Test 1:**
```
mvn install -pl core/common-util -am -DskipTests
mvn -pl core/common-util test -Dtest=uk.gov.gchq.gaffer.commonutil.elementvisibilityutil.AuthorisationsTest
mvn -pl core/common-util edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=uk.gov.gchq.gaffer.commonutil.elementvisibilityutil.AuthorisationsTest
```

The third command shows us the flakiness in the test. There are test failures due to **differences in the order of elements**
<img width="453" alt="image" src="https://github.com/user-attachments/assets/fc34cab0-1d76-47a3-9dc5-57177270e53a">

**Test 2:**
```
mvn install -pl core/data -am -DskipTests
mvn -pl core/data test -Dtest=uk.gov.gchq.gaffer.data.elementdefinition.view.ViewTest
mvn -pl core/data edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=uk.gov.gchq.gaffer.data.elementdefinition.view.ViewTest
```

The third command shows us the flakiness in the test. There are test failures due to **differences in order of elements**
<img width="455" alt="image" src="https://github.com/user-attachments/assets/b14d74d4-a871-404f-8189-4883f0e345f8">

Source of Flakiness in tests and fixes:
1. AuthorisationsTest.testToString
The Authorisation object created in the test case appends three strings to the **auths member of the class which is a HashSet.** The toString() method of the class then **iterates over this HashSet and builds a String a**fter concatenating the members of the set. Since a **Java HashSet does not store order**, the test case **fails** if the elements of the HashSet are iterated over in any order other than the order in which they were appended during object instantiation. **To fix this, the test was updated to check if all strings in the auths member of the object are a part of the String returned by toString() instead of focusing on the order.**

<img width="427" alt="image" src="https://github.com/user-attachments/assets/0b190584-ca5e-4e08-8bf0-b92d756a30a9">


2. ViewTest.shouldCreateAnIdenticalObjectWhenCloned
In this test case, the source of flakiness is the following lines - 
final byte[] viewJson = view.toCompactJson();
final byte[] cloneJson = clone.toCompactJson();

assertThat(cloneJson).containsExactly(viewJson);

The method toCompactJson() internally uses JSONSerialiser.serialise() to convert the object into a byte stream. This does not preserve the order of attributes. Therefore, the containsExactly() method fails when the order of attributes differs in the two objects. To fix this, an ObjectMapper object was created and two JsonNode objects were created after calling the readTree() method on the two byte arrays. The equality check was then applied on these two JsonNode objects.

Please let me know if you have any questions or need any additional justification/changes from my side.



