### PR TITLE
Gh-3340: Misleading vertices in Gremlin

### DIFF
--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -198,7 +198,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
     public static final String HAS_STEP_FILTER_STAGE = "gaffer.elements.hasstepfilterstage";
 
     /**
-     * COnfiguration key to set if orphaned vertices (e.g. vertices without an entity)
+     * Configuration key to set if orphaned vertices (e.g. vertices without an entity)
      * should be included in the result by default
      */
     public static final String INCLUDE_ORPHANED_VERTICES = "gaffer.includeOrphanedVertices";

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -52,6 +52,7 @@ import uk.gov.gchq.gaffer.operation.impl.get.GetAdjacentIds;
 import uk.gov.gchq.gaffer.operation.impl.get.GetAllElements;
 import uk.gov.gchq.gaffer.operation.impl.get.GetElements;
 import uk.gov.gchq.gaffer.operation.io.Input;
+import uk.gov.gchq.gaffer.operation.io.Output;
 import uk.gov.gchq.gaffer.store.operation.GetSchema;
 import uk.gov.gchq.gaffer.store.schema.Schema;
 import uk.gov.gchq.gaffer.tinkerpop.generator.GafferEdgeGenerator;
@@ -85,6 +86,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import static uk.gov.gchq.gaffer.tinkerpop.GafferPopGraphVariables.DEFAULT_GET_ELEMENTS_LIMIT;
+import static uk.gov.gchq.gaffer.tinkerpop.GafferPopGraphVariables.DEFAULT_HAS_STEP_FILTER_STAGE;
+
 
 /**
  * A <code>GafferPopGraph</code> is an implementation of
@@ -188,28 +193,24 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
     public static final String GET_ELEMENTS_LIMIT = "gaffer.elements.getlimit";
 
     /**
-     * Default value for the max number of elements returned by getElements
-     */
-    public static final int DEFAULT_GET_ELEMENTS_LIMIT = 5000;
-
-    /**
      * Configuration key for when to apply HasStep filtering
      */
     public static final String HAS_STEP_FILTER_STAGE = "gaffer.elements.hasstepfilterstage";
 
-    public enum HasStepFilterStage {
-        PRE_AGGREGATION,
-        POST_AGGREGATION,
-        POST_TRANSFORM
-    }
+    /**
+     * COnfiguration key to set if orphaned vertices (e.g. vertices without an entity)
+     * should be included in the result by default
+     */
+    public static final String INCLUDE_ORPHANED_VERTICES = "gaffer.includeOrphanedVertices";
 
     /**
-     * Default to pre-aggregation filtering for HasStep predicates
+     * Set default user ID to use if not set by the user factory.
      */
-    public static final HasStepFilterStage DEFAULT_HAS_STEP_FILTER_STAGE = HasStepFilterStage.PRE_AGGREGATION;
-
     public static final String USER_ID = "gaffer.userId";
 
+    /**
+     * Set default data auths if not set by the user factory.
+     */
     public static final String DATA_AUTHS = "gaffer.dataAuths";
 
     /**
@@ -410,27 +411,41 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      */
     @Override
     public Iterator<Vertex> vertices(final Object... vertexIds) {
-        final boolean getAll = null == vertexIds || 0 == vertexIds.length;
-        final OperationChain<Iterable<? extends Element>> getOperation;
-
         LOGGER.debug(GET_DEBUG_MSG, variables.getElementsLimit());
+        final boolean getAll = null == vertexIds || 0 == vertexIds.length;
+        final Output<Iterable<? extends Element>> getOperation;
+
         if (getAll) {
-            getOperation = new Builder()
-                    .first(new GetAllElements.Builder()
-                            .view(createAllEntitiesView())
-                            .build())
-                    .then(new Limit<Element>(variables.getElementsLimit(), true))
-                    .build();
+            final GetAllElements.Builder builder = new GetAllElements.Builder();
+            // If we are not including orphans then apply the all entities view
+            if (!variables.getIncludeOrphanedVertices()) {
+                builder.view(createAllEntitiesView());
+            }
+            getOperation = builder.build();
+
         } else {
-            getOperation = new Builder()
-                .first(new GetElements.Builder()
-                    .input(getElementSeeds(Arrays.asList(vertexIds)))
-                    .build())
-                .then(new Limit<Element>(variables.getElementsLimit(), true))
-                .build();
+            final GetElements.Builder builder = new GetElements.Builder()
+                .input(getElementSeeds(Arrays.asList(vertexIds)));
+            // If we are not including orphans then apply the all entities view
+            if (!variables.getIncludeOrphanedVertices()) {
+                builder.view(createAllEntitiesView());
+            }
+            getOperation = builder.build();
         }
+
         // Run requested chain on the graph and buffer result to set to avoid reusing iterator
-        final Set<Element> result = new HashSet<>(IterableUtils.toList(execute(getOperation)));
+        final OperationChain<Iterable<? extends Element>> chain = new Builder()
+                .first(getOperation)
+                .then(new Limit<>(variables.getElementsLimit(), true))
+                .build();
+        final Set<Element> result = new HashSet<>(IterableUtils.toList(execute(chain)));
+
+        // Warn of truncation
+        if (result.size() >= variables.getElementsLimit()) {
+            LOGGER.warn(
+                "Result size is greater than or equal to configured limit ({}). Results may have been truncated",
+                variables.getElementsLimit());
+        }
 
         // Translate results to Gafferpop elements
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(this);
@@ -438,17 +453,12 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 .map(generator::_apply)
                 .filter(Vertex.class::isInstance)
                 .map(e -> (Vertex) e)
-                .limit(variables.getElementsLimit())
                 .collect(Collectors.toSet());
 
-        if (translatedResults.size() >= variables.getElementsLimit()) {
-            LOGGER.warn(
-                "Result size is greater than or equal to configured limit ({}). Results may have been truncated",
-                variables.getElementsLimit());
-        }
-
         // Check for seeds that are not entities but are vertices on an edge (orphan vertices)
-        translatedResults.addAll(GafferVertexUtils.getOrphanVertices(result, this, vertexIds));
+        if (variables.getIncludeOrphanedVertices()) {
+            translatedResults.addAll(GafferVertexUtils.getOrphanVertices(result, this, vertexIds));
+        }
 
         return translatedResults.iterator();
     }
@@ -756,6 +766,8 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 configuration().getInteger(GET_ELEMENTS_LIMIT, DEFAULT_GET_ELEMENTS_LIMIT));
         variables.set(GafferPopGraphVariables.HAS_STEP_FILTER_STAGE,
                 configuration().getString(HAS_STEP_FILTER_STAGE, DEFAULT_HAS_STEP_FILTER_STAGE.toString()));
+        variables.set(GafferPopGraphVariables.INCLUDE_ORPHANED_VERTICES,
+                configuration().getBoolean(INCLUDE_ORPHANED_VERTICES, false));
         variables.set(GafferPopGraphVariables.LAST_OPERATION_CHAIN, new OperationChain<Object>());
     }
 
@@ -782,24 +794,15 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                     .build();
         }
 
-        final OperationChain<Iterable<? extends Element>> getOperation;
+        final Output<Iterable<? extends Element>> getOperation;
         LOGGER.debug(GET_DEBUG_MSG, variables.getElementsLimit());
         if (getAll) {
-            getOperation = new Builder()
-                    .first(new GetAllElements.Builder()
-                            .view(entitiesView)
-                            .build())
-                    .then(new Limit<>(variables.getElementsLimit(), true))
-                    .build();
+            getOperation = new GetAllElements.Builder().view(entitiesView).build();
         } else {
-            getOperation = new Builder()
-                    .first(new GetElements.Builder()
-                            .input(seeds)
-                            .view(entitiesView)
-                            .build())
-                    .then(new Limit<>(variables.getElementsLimit(), true))
-                    .build();
-
+            getOperation = new GetElements.Builder()
+                .input(seeds)
+                .view(entitiesView)
+                .build();
             if (null == entitiesView || entitiesView.getEntityGroups().contains(ID_LABEL)) {
                 seeds.forEach(seed -> {
                     if (seed instanceof EntitySeed) {
@@ -810,7 +813,11 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         }
 
         // Run operation on graph buffer to set to avoid reusing iterator
-        final Set<Element> result = new HashSet<>(IterableUtils.toList(execute(getOperation)));
+        final OperationChain<Iterable<? extends Element>> chain = new Builder()
+                .first(getOperation)
+                .then(new Limit<>(variables.getElementsLimit(), true))
+                .build();
+        final Set<Element> result = new HashSet<>(IterableUtils.toList(execute(chain)));
 
         // Translate results to Gafferpop elements
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(this);
@@ -818,7 +825,6 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 .map(generator::_apply)
                 .filter(GafferPopVertex.class::isInstance)
                 .map(e -> (GafferPopVertex) e)
-                .limit(variables.getElementsLimit())
                 .collect(Collectors.toSet());
 
         return translatedResults.iterator();
@@ -829,7 +835,8 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
             throw new UnsupportedOperationException("There could be a lot of vertices, so please add some seeds");
         }
 
-        final Iterable<? extends EntityId> getAdjEntitySeeds = execute(new OperationChain.Builder()
+        final Iterable<? extends EntityId> getAdjEntitySeeds = execute(
+            new OperationChain.Builder()
                 .first(new GetAdjacentIds.Builder()
                     .input(seeds)
                     .view(view)
@@ -839,13 +846,15 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
         List<? extends EntityId> seedList = IterableUtils.toList(getAdjEntitySeeds);
 
+        final GetElements.Builder builder = new GetElements.Builder().input(seedList);
+        // If we are not including orphans then apply the all entities view
+        if (!variables.getIncludeOrphanedVertices()) {
+            builder.view(createAllEntitiesView());
+        }
+
         // GetAdjacentIds provides list of entity seeds so run a GetElements to get the actual Entities
         final Set<Element> result = new HashSet<>(IterableUtils.toList(
-            execute(new OperationChain.Builder()
-                    .first(new GetElements.Builder()
-                        .input(seedList)
-                        .build())
-                    .build())));
+            execute(new OperationChain.Builder().first(builder.build()).build())));
 
         // Translate results to Gafferpop elements
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(this);
@@ -856,9 +865,11 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 .collect(Collectors.toSet());
 
         // Check for seeds that are not entities but are vertices on an edge (orphan vertices)
-        for (final EntityId seed : seedList) {
-            translatedResults.addAll(GafferVertexUtils.getOrphanVertices(result, this, seed.getVertex()));
+        if (variables.getIncludeOrphanedVertices()) {
+            translatedResults.addAll(
+                GafferVertexUtils.getOrphanVertices(result, this, seedList.stream().map(EntityId::getVertex).toArray(Object[]::new)));
         }
+
         return translatedResults.iterator();
     }
 

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphVariables.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphVariables.java
@@ -33,6 +33,8 @@ public final class GafferPopGraphVariables implements Graph.Variables {
     private static final Logger LOGGER = LoggerFactory.getLogger(GafferPopGraphVariables.class);
     private static final String VAR_UPDATE_ERROR_STRING = "Ignoring update variable: {}, incorrect value type: {}";
 
+    // KEYS
+
     /**
      * Variable key for the {@link Map} of Gaffer operation options.
      */
@@ -54,7 +56,8 @@ public final class GafferPopGraphVariables implements Graph.Variables {
     public static final String USER = "user";
 
     /**
-     * The max number of elements that can be returned by GetElements
+     * The max number of elements that can be returned by a single GetElements
+     * or GetAllElements
      */
     public static final String GET_ELEMENTS_LIMIT = "getElementsLimit";
 
@@ -73,6 +76,29 @@ public final class GafferPopGraphVariables implements Graph.Variables {
      */
     public static final String LAST_OPERATION_CHAIN = "lastOperation";
 
+    /**
+     * The key to set if orphaned vertices (e.g. vertices without an entity)
+     * should be included in the result
+     */
+    public static final String INCLUDE_ORPHANED_VERTICES = "includeOrphanedVertices";
+
+    // DEFAULTS
+
+    /**
+     * Default value for the max number of elements returned by getElements
+     */
+    public static final int DEFAULT_GET_ELEMENTS_LIMIT = 20000;
+
+    /**
+     * Default to pre-aggregation filtering for HasStep predicates
+     */
+    public static final HasStepFilterStage DEFAULT_HAS_STEP_FILTER_STAGE = HasStepFilterStage.PRE_AGGREGATION;
+
+    public enum HasStepFilterStage {
+        PRE_AGGREGATION,
+        POST_AGGREGATION,
+        POST_TRANSFORM
+    }
 
     private final Map<String, Object> variables;
 
@@ -121,6 +147,10 @@ public final class GafferPopGraphVariables implements Graph.Variables {
                 }
                 break;
 
+            case INCLUDE_ORPHANED_VERTICES:
+                variables.put(key, Boolean.valueOf(value.toString()));
+                break;
+
             default:
                 variables.put(key, value);
                 break;
@@ -167,6 +197,10 @@ public final class GafferPopGraphVariables implements Graph.Variables {
 
     public OperationChain<?> getLastOperationChain() {
         return (OperationChain) variables.get(LAST_OPERATION_CHAIN);
+    }
+
+    public Boolean getIncludeOrphanedVertices() {
+        return Boolean.parseBoolean(variables.get(INCLUDE_ORPHANED_VERTICES).toString());
     }
 
     public String toString() {

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphVariables.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphVariables.java
@@ -199,7 +199,7 @@ public final class GafferPopGraphVariables implements Graph.Variables {
         return (OperationChain) variables.get(LAST_OPERATION_CHAIN);
     }
 
-    public Boolean getIncludeOrphanedVertices() {
+    public boolean getIncludeOrphanedVertices() {
         return Boolean.parseBoolean(variables.get(INCLUDE_ORPHANED_VERTICES).toString());
     }
 

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopGraphStep.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopGraphStep.java
@@ -36,8 +36,8 @@ import uk.gov.gchq.gaffer.data.elementdefinition.view.GlobalViewElementDefinitio
 import uk.gov.gchq.gaffer.data.elementdefinition.view.View;
 import uk.gov.gchq.gaffer.data.elementdefinition.view.ViewElementDefinition;
 import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph;
-import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph.HasStepFilterStage;
 import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraphVariables;
+import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraphVariables.HasStepFilterStage;
 import uk.gov.gchq.gaffer.tinkerpop.process.traversal.step.util.GafferPopHasContainer;
 import uk.gov.gchq.koryphe.impl.predicate.Exists;
 
@@ -248,8 +248,8 @@ public class GafferPopGraphStep<S, E extends Element> extends GraphStep<S, E> im
             hasStepFilterStage = HasStepFilterStage.valueOf(filterStage);
         } catch (final IllegalArgumentException e) {
             LOGGER.warn("Unknown hasStepFilterStage: {}. Defaulting to {}",
-                filterStage, GafferPopGraph.DEFAULT_HAS_STEP_FILTER_STAGE);
-            hasStepFilterStage = GafferPopGraph.DEFAULT_HAS_STEP_FILTER_STAGE;
+                filterStage, GafferPopGraphVariables.DEFAULT_HAS_STEP_FILTER_STAGE);
+            hasStepFilterStage = GafferPopGraphVariables.DEFAULT_HAS_STEP_FILTER_STAGE;
         }
 
         switch (hasStepFilterStage) {

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederationTests.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopFederationTests.java
@@ -292,7 +292,8 @@ public abstract class GafferPopFederationTests {
         // Edge has a vertex but not an entity in the graph - Gaffer only feature
         getGraph().addEdge(new GafferPopEdge("knows", GafferPopModernTestUtils.MARKO.getId(), "7", getGraph()));
 
-        List<Vertex> result = g.V("7").toList();
+        // Need to enable orphaned vertices on the query
+        List<Vertex> result = g.with(GafferPopGraphVariables.INCLUDE_ORPHANED_VERTICES, "true").V("7").toList();
         assertThat(result)
             .extracting(r -> r.id())
             .contains("7");
@@ -305,9 +306,12 @@ public abstract class GafferPopFederationTests {
         // Edge has a vertex but not an entity in the graph - Gaffer only feature
         getGraph().addEdge(new GafferPopEdge("knows", GafferPopModernTestUtils.MARKO.getId(), "7", getGraph()));
 
-        List<Map<Object, Object>> result = g.V("7").inE().outV().elementMap().toList();
-        assertThat(result)
-            .containsExactly(MARKO.getPropertyMap());
+        // Need to enable orphaned vertices on the query
+        List<Map<Object, Object>> result = g.with(GafferPopGraphVariables.INCLUDE_ORPHANED_VERTICES, "true")
+            .V("7").inE().outV().elementMap().toList();
+
+        assertThat(result).containsExactly(MARKO.getPropertyMap());
+
         reset();
     }
 

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
@@ -308,7 +308,8 @@ class GafferPopGraphIT {
         mapStore.addEdge(new GafferPopEdge("knows", GafferPopModernTestUtils.MARKO.getId(), VERTEX_ONLY_ID_STRING, mapStore));
         accumuloStore.addEdge(new GafferPopEdge("knows", GafferPopModernTestUtils.MARKO.getId(), VERTEX_ONLY_ID_STRING, accumuloStore));
 
-        List<Vertex> result = g.V(VERTEX_ONLY_ID_STRING).toList();
+        // Must enable orphaned vertices for this traversal
+        List<Vertex> result = g.with(GafferPopGraphVariables.INCLUDE_ORPHANED_VERTICES, "true").V(VERTEX_ONLY_ID_STRING).toList();
         assertThat(result)
             .extracting(r -> r.id())
             .contains(VERTEX_ONLY_ID_STRING);
@@ -318,28 +319,31 @@ class GafferPopGraphIT {
     @ParameterizedTest(name = TEST_NAME_FORMAT)
     @MethodSource("provideTraversals")
     void shouldTraverseEdgeWithVertexOnlyEdge(String graph, GraphTraversalSource g) {
+        // Must enable orphaned vertices for this traversal
+        GraphTraversalSource gWithOption = g.with(GafferPopGraphVariables.INCLUDE_ORPHANED_VERTICES, "true");
         // Edge has a two vertices with no entities in the graph - Gaffer only feature
         // [8 - knows -> 7]
         mapStore.addEdge(new GafferPopEdge("knows", "8", VERTEX_ONLY_ID_STRING, mapStore));
         accumuloStore.addEdge(new GafferPopEdge("knows", "8", VERTEX_ONLY_ID_STRING, accumuloStore));
 
-        List<Vertex> result = g.V(VERTEX_ONLY_ID_STRING).inE().inV().toList();
+
+        List<Vertex> result = gWithOption.V(VERTEX_ONLY_ID_STRING).inE().inV().toList();
         assertThat(result)
             .extracting(r -> r.id())
             .contains(VERTEX_ONLY_ID_STRING);
-        List<Vertex> result2 = g.V(VERTEX_ONLY_ID_STRING).inE().outV().toList();
+        List<Vertex> result2 = gWithOption.V(VERTEX_ONLY_ID_STRING).inE().outV().toList();
         assertThat(result2)
             .extracting(r -> r.id())
             .contains("8");
-        List<Vertex> result3 = g.V("8").outE().inV().toList();
+        List<Vertex> result3 = gWithOption.V("8").outE().inV().toList();
         assertThat(result3)
             .extracting(r -> r.id())
             .contains(VERTEX_ONLY_ID_STRING);
-        List<Vertex> result4 = g.V("8").outE().outV().toList();
+        List<Vertex> result4 = gWithOption.V("8").outE().outV().toList();
         assertThat(result4)
             .extracting(r -> r.id())
             .contains("8");
-        List<Vertex> resultLabel = g.V("8").out("knows").toList();
+        List<Vertex> resultLabel = gWithOption.V("8").out("knows").toList();
         assertThat(resultLabel)
             .extracting(r -> r.id())
             .containsOnly(VERTEX_ONLY_ID_STRING);

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphTest.java
@@ -30,7 +30,7 @@ import uk.gov.gchq.gaffer.graph.Graph;
 import uk.gov.gchq.gaffer.operation.OperationChain;
 import uk.gov.gchq.gaffer.operation.impl.add.AddElementsFromSocket;
 import uk.gov.gchq.gaffer.operation.impl.get.GetElements;
-import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph.HasStepFilterStage;
+import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraphVariables.HasStepFilterStage;
 import uk.gov.gchq.gaffer.tinkerpop.util.GafferPopTestUtil;
 import uk.gov.gchq.gaffer.tinkerpop.util.GafferPopTstvTestUtils;
 import uk.gov.gchq.gaffer.user.User;
@@ -129,9 +129,9 @@ class GafferPopGraphTest {
             .hasSize(5)
             .containsEntry(GafferPopGraphVariables.USER, expectedUser)
             .containsEntry(GafferPopGraphVariables.GET_ELEMENTS_LIMIT,
-                    GafferPopGraph.DEFAULT_GET_ELEMENTS_LIMIT)
+                    GafferPopGraphVariables.DEFAULT_GET_ELEMENTS_LIMIT)
             .containsEntry(GafferPopGraphVariables.HAS_STEP_FILTER_STAGE,
-                    GafferPopGraph.DEFAULT_HAS_STEP_FILTER_STAGE.toString())
+                    GafferPopGraphVariables.DEFAULT_HAS_STEP_FILTER_STAGE.toString())
             .containsKey(GafferPopGraphVariables.OP_OPTIONS);
 
 

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphTest.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphTest.java
@@ -77,10 +77,11 @@ class GafferPopGraphTest {
         // Then
         final Map<String, Object> variables = graph.variables().asMap();
         assertThat(variables)
-            .hasSize(5)
+            .hasSize(6)
             .containsEntry(GafferPopGraphVariables.USER, expectedUser)
             .containsEntry(GafferPopGraphVariables.GET_ELEMENTS_LIMIT, 1)
             .containsEntry(GafferPopGraphVariables.HAS_STEP_FILTER_STAGE, HasStepFilterStage.POST_TRANSFORM.toString())
+            .containsEntry(GafferPopGraphVariables.INCLUDE_ORPHANED_VERTICES, false)
             .containsKey(GafferPopGraphVariables.OP_OPTIONS);
 
         final Map<String, String> opOptions = (Map<String, String>) variables.get(GafferPopGraphVariables.OP_OPTIONS);
@@ -102,10 +103,11 @@ class GafferPopGraphTest {
         // Then
         final Map<String, Object> variables = graph.variables().asMap();
         assertThat(variables)
-            .hasSize(5)
+            .hasSize(6)
             .containsEntry(GafferPopGraphVariables.USER, expectedUser)
             .containsEntry(GafferPopGraphVariables.GET_ELEMENTS_LIMIT, 2)
             .containsEntry(GafferPopGraphVariables.HAS_STEP_FILTER_STAGE, HasStepFilterStage.POST_AGGREGATION.toString())
+            .containsEntry(GafferPopGraphVariables.INCLUDE_ORPHANED_VERTICES, true)
             .containsKey(GafferPopGraphVariables.OP_OPTIONS);
 
         final Map<String, String> opOptions = (Map<String, String>) variables.get(GafferPopGraphVariables.OP_OPTIONS);
@@ -126,10 +128,11 @@ class GafferPopGraphTest {
         // Then
         final Map<String, Object> variables = graph.variables().asMap();
         assertThat(variables)
-            .hasSize(5)
+            .hasSize(6)
             .containsEntry(GafferPopGraphVariables.USER, expectedUser)
             .containsEntry(GafferPopGraphVariables.GET_ELEMENTS_LIMIT,
                     GafferPopGraphVariables.DEFAULT_GET_ELEMENTS_LIMIT)
+            .containsEntry(GafferPopGraphVariables.INCLUDE_ORPHANED_VERTICES, false)
             .containsEntry(GafferPopGraphVariables.HAS_STEP_FILTER_STAGE,
                     GafferPopGraphVariables.DEFAULT_HAS_STEP_FILTER_STAGE.toString())
             .containsKey(GafferPopGraphVariables.OP_OPTIONS);

--- a/library/tinkerpop/src/test/resources/gafferpop-test.properties
+++ b/library/tinkerpop/src/test/resources/gafferpop-test.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2023 Crown Copyright
+# Copyright 2016-2024 Crown Copyright
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,4 +21,5 @@ gaffer.userId=user01
 gaffer.operation.options=key1:value1
 gaffer.elements.getlimit=2
 gaffer.elements.hasstepfilterstage=POST_AGGREGATION
+gaffer.includeOrphanedVertices=true
 


### PR DESCRIPTION
Fixes issue of odd number of vertices being returned if lots of edges are in the Gaffer result. This is primarily due them not being filtered out in the view as they are used in the orphaned vertex check. To fix this the orphan check has been made optional and opt in so the user should be aware of the potential side effects. Also increased default limit as it was quite low.

# Related issue

- Resolve #3340