### PR TITLE
Gh-2478: JobTracker tracks all operations, not just jobs

### DIFF
--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/Store.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/Store.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Crown Copyright
+ * Copyright 2016-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -386,15 +386,7 @@ public abstract class Store {
     }
 
     protected <O> O execute(final OperationChain<O> operation, final Context context) throws OperationException {
-        try {
-            addOrUpdateJobDetail(operation, context, null, JobStatus.RUNNING);
-            final O result = (O) handleOperation(operation, context);
-            addOrUpdateJobDetail(operation, context, null, JobStatus.FINISHED);
-            return result;
-        } catch (final Throwable t) {
-            addOrUpdateJobDetail(operation, context, t.getMessage(), JobStatus.FAILED);
-            throw t;
-        }
+        return (O) handleOperation(operation, context);
     }
 
     /**

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/StoreTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/StoreTest.java
@@ -170,6 +170,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.gchq.gaffer.jobtracker.JobTracker.JOB_TRACKER_CACHE_SERVICE_NAME;
 import static uk.gov.gchq.gaffer.store.StoreTrait.INGEST_AGGREGATION;
 import static uk.gov.gchq.gaffer.store.StoreTrait.ORDERED;
@@ -257,29 +258,21 @@ public class StoreTest {
     }
 
     @Test
-    public void shouldExecuteOperationWhenJobTrackerCacheIsBroken(@Mock final StoreProperties storeProperties) throws Exception {
+    public void shouldNotCreateJobWhenExecutingOperation(@Mock final StoreProperties storeProperties) throws Exception {
         // Given
         ICache<Object, Object> mockICache = Mockito.mock(ICache.class);
-        doThrow(new CacheOperationException("Stubbed class")).when(mockICache).put(any(), any());
         ICacheService mockICacheService = Mockito.spy(ICacheService.class);
-        given(mockICacheService.getCache(any())).willReturn(mockICache);
-
-        Field field = CacheServiceLoader.class.getDeclaredField("SERVICES");
-        field.setAccessible(true);
-        java.util.Map<String, ICacheService> mockCacheServices = (java.util.Map<String, ICacheService>) field.get(new HashMap<>());
-        mockCacheServices.put(JOB_TRACKER_CACHE_SERVICE_NAME, mockICacheService);
 
         final AddElements addElements = new AddElements();
         final StoreImpl3 store = new StoreImpl3();
         store.initialise("graphId", createSchemaMock(), storeProperties);
 
         // When
-        store.executeJob(addElements, context);
+        store.execute(addElements, context);
 
         // Then
         verify(addElementsHandler).doOperation(addElements, context, store);
-        verify(mockICacheService, Mockito.atLeast(1)).getCache(any());
-        verify(mockICache, Mockito.atLeast(1)).put(any(), any());
+        verifyNoInteractions(mockICacheService, mockICache);
     }
 
     @Test

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/StoreTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/StoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Crown Copyright
+ * Copyright 2016-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -274,7 +274,7 @@ public class StoreTest {
         store.initialise("graphId", createSchemaMock(), storeProperties);
 
         // When
-        store.execute(addElements, context);
+        store.executeJob(addElements, context);
 
         // Then
         verify(addElementsHandler).doOperation(addElements, context, store);

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/StoreTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/StoreTest.java
@@ -31,7 +31,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
 import uk.gov.gchq.gaffer.cache.ICache;
 import uk.gov.gchq.gaffer.cache.ICacheService;
-import uk.gov.gchq.gaffer.cache.exception.CacheOperationException;
 import uk.gov.gchq.gaffer.cache.impl.HashMapCacheService;
 import uk.gov.gchq.gaffer.commonutil.TestGroups;
 import uk.gov.gchq.gaffer.commonutil.TestPropertyNames;
@@ -164,7 +163,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -262,6 +260,11 @@ public class StoreTest {
         // Given
         ICache<Object, Object> mockICache = Mockito.mock(ICache.class);
         ICacheService mockICacheService = Mockito.spy(ICacheService.class);
+
+        Field field = CacheServiceLoader.class.getDeclaredField("SERVICES");
+        field.setAccessible(true);
+        java.util.Map<String, ICacheService> mockCacheServices = (java.util.Map<String, ICacheService>) field.get(new HashMap<>());
+        mockCacheServices.put(JOB_TRACKER_CACHE_SERVICE_NAME, mockICacheService);
 
         final AddElements addElements = new AddElements();
         final StoreImpl3 store = new StoreImpl3();

--- a/core/store/src/test/java/uk/gov/gchq/gaffer/store/StoreTest.java
+++ b/core/store/src/test/java/uk/gov/gchq/gaffer/store/StoreTest.java
@@ -256,7 +256,7 @@ public class StoreTest {
     }
 
     @Test
-    public void shouldNotCreateJobWhenExecutingOperation(@Mock final StoreProperties storeProperties) throws Exception {
+    void shouldNotCreateJobWhenExecutingOperation(@Mock final StoreProperties storeProperties) throws Exception {
         // Given
         ICache<Object, Object> mockICache = Mockito.mock(ICache.class);
         ICacheService mockICacheService = Mockito.spy(ICacheService.class);

--- a/rest-api/common-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/AbstractOperationService.java
+++ b/rest-api/common-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/AbstractOperationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Crown Copyright
+ * Copyright 2020-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package uk.gov.gchq.gaffer.rest.service.v2;
 
 import uk.gov.gchq.gaffer.commonutil.CloseableUtil;
-import uk.gov.gchq.gaffer.commonutil.pair.Pair;
 import uk.gov.gchq.gaffer.core.exception.GafferRuntimeException;
 import uk.gov.gchq.gaffer.core.exception.Status;
 import uk.gov.gchq.gaffer.graph.GraphRequest;
@@ -97,7 +96,7 @@ public abstract class AbstractOperationService {
     }
 
     @SuppressWarnings({"ThrowFromFinallyBlock", "PMD.UseTryWithResources"})
-    protected <O> Pair<O, String> _execute(final Operation operation, final Context context) {
+    protected <O> O _execute(final Operation operation, final Context context) {
 
         OperationChain<O> opChain = (OperationChain<O>) OperationChain.wrap(operation);
 
@@ -119,7 +118,7 @@ public abstract class AbstractOperationService {
             }
         }
 
-        return new Pair<>(result.getResult(), result.getContext().getJobId());
+        return result.getResult();
     }
 
     protected Operation generateExampleJson(final Class<? extends Operation> opClass) throws IllegalAccessException, InstantiationException {

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/IOperationServiceV2.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/IOperationServiceV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 Crown Copyright
+ * Copyright 2016-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,8 +42,6 @@ import static uk.gov.gchq.gaffer.rest.ServiceConstants.FORBIDDEN;
 import static uk.gov.gchq.gaffer.rest.ServiceConstants.GAFFER_MEDIA_TYPE_HEADER;
 import static uk.gov.gchq.gaffer.rest.ServiceConstants.GAFFER_MEDIA_TYPE_HEADER_DESCRIPTION;
 import static uk.gov.gchq.gaffer.rest.ServiceConstants.INTERNAL_SERVER_ERROR;
-import static uk.gov.gchq.gaffer.rest.ServiceConstants.JOB_ID_HEADER;
-import static uk.gov.gchq.gaffer.rest.ServiceConstants.JOB_ID_HEADER_DESCRIPTION;
 import static uk.gov.gchq.gaffer.rest.ServiceConstants.OK;
 import static uk.gov.gchq.gaffer.rest.ServiceConstants.OPERATION_NOT_FOUND;
 import static uk.gov.gchq.gaffer.rest.ServiceConstants.OPERATION_NOT_IMPLEMENTED;
@@ -91,7 +89,6 @@ public interface IOperationServiceV2 {
             produces = (APPLICATION_JSON + "," + TEXT_PLAIN),
             response = Object.class,
             responseHeaders = {
-                    @ResponseHeader(name = JOB_ID_HEADER, description = JOB_ID_HEADER_DESCRIPTION),
                     @ResponseHeader(name = GAFFER_MEDIA_TYPE_HEADER, description = GAFFER_MEDIA_TYPE_HEADER_DESCRIPTION)
             })
     @ApiResponses(value = {@ApiResponse(code = 200, message = OK, response = Object.class),

--- a/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/OperationServiceV2.java
+++ b/rest-api/core-rest/src/main/java/uk/gov/gchq/gaffer/rest/service/v2/OperationServiceV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Crown Copyright
+ * Copyright 2017-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import uk.gov.gchq.gaffer.commonutil.CloseableUtil;
 import uk.gov.gchq.gaffer.commonutil.exception.UnauthorisedException;
-import uk.gov.gchq.gaffer.commonutil.pair.Pair;
 import uk.gov.gchq.gaffer.core.exception.Error;
 import uk.gov.gchq.gaffer.core.exception.Status;
 import uk.gov.gchq.gaffer.operation.Operation;
@@ -45,7 +44,6 @@ import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser.createDefaultMapper;
 import static uk.gov.gchq.gaffer.rest.ServiceConstants.GAFFER_MEDIA_TYPE;
 import static uk.gov.gchq.gaffer.rest.ServiceConstants.GAFFER_MEDIA_TYPE_HEADER;
-import static uk.gov.gchq.gaffer.rest.ServiceConstants.JOB_ID_HEADER;
 
 /**
  * An implementation of {@link IOperationServiceV2}. By default it will use a singleton
@@ -85,10 +83,9 @@ public class OperationServiceV2 extends AbstractOperationService implements IOpe
 
     @Override
     public Response execute(final Operation operation) {
-        final Pair<Object, String> resultAndJobId = _execute(operation, userFactory.createContext());
-        return Response.ok(resultAndJobId.getFirst())
+        final Object result = _execute(operation, userFactory.createContext());
+        return Response.ok(result)
                 .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
-                .header(JOB_ID_HEADER, resultAndJobId.getSecond())
                 .build();
     }
 
@@ -109,7 +106,7 @@ public class OperationServiceV2 extends AbstractOperationService implements IOpe
         // create thread to write chunks to the chunked output object
         Thread thread = new Thread(() -> {
             try {
-                final Object result = _execute(opChain, context).getFirst();
+                final Object result = _execute(opChain, context);
                 chunkResult(result, output);
             } catch (final Exception e) {
                 throw new RuntimeException(e);

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/OperationServiceV2IT.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/OperationServiceV2IT.java
@@ -217,7 +217,7 @@ public class OperationServiceV2IT extends OperationServiceIT {
         // When
         final Response response = ((RestApiV2TestClient) client).executeOperationChainChunkedWithHeaders(opChain, "ListUser");
 
-        // Then]
+        // Then
         assertThat(response.getStatus()).isEqualTo(200);
     }
 

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/OperationServiceV2IT.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/OperationServiceV2IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 Crown Copyright
+ * Copyright 2015-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,25 +51,21 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.gchq.gaffer.core.exception.Status.SERVICE_UNAVAILABLE;
 
 public class OperationServiceV2IT extends OperationServiceIT {
 
     @Test
-    public void shouldReturnJobIdHeader() throws IOException {
+    void shouldReturnNotJobIdHeader() throws IOException {
         // When
         final Response response = client.executeOperation(new GetAllElements());
 
         // Then
-        assertNotNull(response.getHeaderString(ServiceConstants.JOB_ID_HEADER));
+        assertThat(response.getHeaderString(ServiceConstants.JOB_ID_HEADER)).isNull();
     }
 
     @Test
-    public void shouldReturn403WhenUnauthorised() throws IOException {
+    void shouldReturn403WhenUnauthorised() throws IOException {
         // Given
         final Graph graph = new Graph.Builder()
                 .config(StreamUtil.graphConfig(this.getClass()))
@@ -82,11 +78,11 @@ public class OperationServiceV2IT extends OperationServiceIT {
         final Response response = client.executeOperation(new GetAllElements());
 
         // Then
-        assertEquals(403, response.getStatus());
+        assertThat(response.getStatus()).isEqualTo(403);
     }
 
     @Test
-    public void shouldPropagateStatusInformationContainedInOperationExceptionsThrownByOperationHandlers()
+    void shouldPropagateStatusInformationContainedInOperationExceptionsThrownByOperationHandlers()
             throws IOException {
         // Given
         final StoreProperties storeProperties = StoreProperties.loadStoreProperties(StreamUtil.STORE_PROPERTIES);
@@ -103,11 +99,11 @@ public class OperationServiceV2IT extends OperationServiceIT {
         final Response response = client.executeOperation(new GetAllJobDetails());
 
         // Then
-        assertEquals(SERVICE_UNAVAILABLE.getStatusCode(), response.getStatus());
+        assertThat(response.getStatus()).isEqualTo(SERVICE_UNAVAILABLE.getStatusCode());
     }
 
     @Test
-    public void shouldReturnSameJobIdInHeaderAsGetAllJobDetailsOperation() throws IOException {
+    void shouldNotHaveJobIdInHeader() throws IOException {
         // Given
         final Graph graph = new Graph.Builder()
                 .config(StreamUtil.graphConfig(this.getClass()))
@@ -121,11 +117,12 @@ public class OperationServiceV2IT extends OperationServiceIT {
         final Response response = client.executeOperation(new GetAllJobDetails());
 
         // Then
-        assertTrue(response.readEntity(String.class).contains(response.getHeaderString("job-id")));
+        assertThat(response.getHeaders()).isNotEmpty();
+        assertThat(response.readEntity(String.class)).doesNotContain("job-id");
     }
 
     @Test
-    public void shouldReturnAllOperationsAsOperationDetails() throws IOException, ClassNotFoundException {
+    void shouldReturnAllOperationsAsOperationDetails() throws IOException, ClassNotFoundException {
         // Given
         final Set<Class<? extends Operation>> expectedOperations = client.getDefaultGraphFactory().getGraph()
                 .getSupportedOperations();
@@ -146,7 +143,7 @@ public class OperationServiceV2IT extends OperationServiceIT {
     }
 
     @Test
-    public void shouldReturnOperationDetailSummaryOfClass() throws Exception {
+    void shouldReturnOperationDetailSummaryOfClass() throws Exception {
         // Given
         final String expectedSummary = "\"summary\":\"Gets elements related to provided seeds\"";
 
@@ -154,11 +151,11 @@ public class OperationServiceV2IT extends OperationServiceIT {
         final Response response = client.getOperationDetails(GetElements.class);
 
         // Then
-        assertTrue(response.readEntity(String.class).contains(expectedSummary));
+        assertThat(response.readEntity(String.class)).contains(expectedSummary);
     }
 
     @Test
-    public void shouldReturnOutputClassForOperationWithOutput() throws Exception {
+    void shouldReturnOutputClassForOperationWithOutput() throws Exception {
         // Given
         final String expectedOutputString = "\"outputClassName\":\"java.lang.Iterable<uk.gov.gchq.gaffer.data.element.Element>\"";
 
@@ -166,11 +163,11 @@ public class OperationServiceV2IT extends OperationServiceIT {
         final Response response = client.getOperationDetails(GetElements.class);
 
         // Then
-        assertTrue(response.readEntity(String.class).contains(expectedOutputString));
+        assertThat(response.readEntity(String.class)).contains(expectedOutputString);
     }
 
     @Test
-    public void shouldNotIncludeAnyOutputClassForOperationWithoutOutput() throws Exception {
+    void shouldNotIncludeAnyOutputClassForOperationWithoutOutput() throws Exception {
         // Given
         final String outputClassNameString = "\"outputClassName\"";
 
@@ -178,11 +175,11 @@ public class OperationServiceV2IT extends OperationServiceIT {
         final Response response = client.getOperationDetails(DiscardOutput.class);
 
         // Then
-        assertFalse(response.readEntity(String.class).contains(outputClassNameString));
+        assertThat(response.readEntity(String.class)).doesNotContain(outputClassNameString);
     }
 
     @Test
-    public void shouldReturnOptionsAndSummariesForEnumFields() throws Exception {
+    void shouldReturnOptionsAndSummariesForEnumFields() throws Exception {
         // When
         final Response response = client.getOperationDetails(GetElements.class);
 
@@ -197,11 +194,11 @@ public class OperationServiceV2IT extends OperationServiceIT {
                 new OperationFieldPojo("directedType", "java.lang.String", false, "Is the Edge directed?", Sets.newHashSet("DIRECTED", "UNDIRECTED", "EITHER")),
                 new OperationFieldPojo("views", "java.util.List<uk.gov.gchq.gaffer.data.elementdefinition.view.View>", false, null, null)
         );
-        assertEquals(fields, opDetails.getFields());
+        assertThat(opDetails.getFields()).isEqualTo(fields);
     }
 
     @Test
-    public void shouldAllowUserWithAuthThroughHeaders() throws IOException {
+    void shouldAllowUserWithAuthThroughHeaders() throws IOException {
         // Given
         System.setProperty(SystemProperty.USER_FACTORY_CLASS, TestUserFactory.class.getName());
         client.stopServer();
@@ -220,12 +217,12 @@ public class OperationServiceV2IT extends OperationServiceIT {
         // When
         final Response response = ((RestApiV2TestClient) client).executeOperationChainChunkedWithHeaders(opChain, "ListUser");
 
-        // Then
-        assertEquals(200, response.getStatus());
+        // Then]
+        assertThat(response.getStatus()).isEqualTo(200);
     }
 
     @Test
-    public void shouldNotAllowUserWithNoAuthThroughHeaders() throws IOException {
+    void shouldNotAllowUserWithNoAuthThroughHeaders() throws IOException {
         // Given
         System.setProperty(SystemProperty.USER_FACTORY_CLASS, TestUserFactory.class.getName());
         client.stopServer();
@@ -246,7 +243,7 @@ public class OperationServiceV2IT extends OperationServiceIT {
                 "BasicUser");
 
         // Then
-        assertEquals(500, response.getStatus());
+        assertThat(response.getStatus()).isEqualTo(500);
     }
 
     @Override

--- a/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/OperationServiceV2IT.java
+++ b/rest-api/core-rest/src/test/java/uk/gov/gchq/gaffer/rest/service/v2/OperationServiceV2IT.java
@@ -56,7 +56,7 @@ import static uk.gov.gchq.gaffer.core.exception.Status.SERVICE_UNAVAILABLE;
 public class OperationServiceV2IT extends OperationServiceIT {
 
     @Test
-    void shouldReturnNotJobIdHeader() throws IOException {
+    void shouldNotReturnJobIdHeader() throws IOException {
         // When
         final Response response = client.executeOperation(new GetAllElements());
 

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/OperationController.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/controller/OperationController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 Crown Copyright
+ * Copyright 2020-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import uk.gov.gchq.gaffer.commonutil.CloseableUtil;
-import uk.gov.gchq.gaffer.commonutil.pair.Pair;
 import uk.gov.gchq.gaffer.core.exception.GafferRuntimeException;
 import uk.gov.gchq.gaffer.core.exception.Status;
 import uk.gov.gchq.gaffer.operation.Operation;
@@ -56,7 +55,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser.createDefaultMapper;
 import static uk.gov.gchq.gaffer.rest.ServiceConstants.GAFFER_MEDIA_TYPE;
 import static uk.gov.gchq.gaffer.rest.ServiceConstants.GAFFER_MEDIA_TYPE_HEADER;
-import static uk.gov.gchq.gaffer.rest.ServiceConstants.JOB_ID_HEADER;
 
 @RestController
 @Tag(name = "operations")
@@ -211,11 +209,10 @@ public class OperationController extends AbstractOperationService {
             }))
             @RequestBody final Operation operation) {
         userFactory.setHttpHeaders(httpHeaders);
-        final Pair<Object, String> resultAndJobId = _execute(operation, userFactory.createContext());
+        final Object result = _execute(operation, userFactory.createContext());
         return ResponseEntity.ok()
                 .header(GAFFER_MEDIA_TYPE_HEADER, GAFFER_MEDIA_TYPE)
-                .header(JOB_ID_HEADER, resultAndJobId.getSecond())
-                .body(resultAndJobId.getFirst());
+                .body(result);
     }
 
     @PostMapping(path = "/execute/chunked", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
@@ -227,8 +224,7 @@ public class OperationController extends AbstractOperationService {
         userFactory.setHttpHeaders(httpHeaders);
         final StreamingResponseBody responseBody = response -> {
             try {
-                final Pair<Object, String> resultAndJobId = _execute(operation, userFactory.createContext());
-                final Object result = resultAndJobId.getFirst();
+                final Object result = _execute(operation, userFactory.createContext());
                 if (result instanceof Iterable) {
                     final Iterable itr = (Iterable) result;
                     try {

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/integration/controller/OperationControllerIT.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/integration/controller/OperationControllerIT.java
@@ -136,7 +136,7 @@ class OperationControllerIT extends AbstractRestApiIT {
     }
 
     @Test
-    void shouldPropagateStatusInformationContainedInOperationExceptionsThrownByOperationHandlers() throws IOException {
+    void shouldPropagateStatusInformationContainedInOperationExceptionsThrownByOperationHandlers() {
         // Given
         final StoreProperties storeProperties = new MapStoreProperties();
         storeProperties.set(StoreProperties.JOB_TRACKER_ENABLED, Boolean.FALSE.toString());

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/integration/controller/OperationControllerIT.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/integration/controller/OperationControllerIT.java
@@ -45,7 +45,6 @@ import uk.gov.gchq.gaffer.store.schema.TypeDefinition;
 import uk.gov.gchq.koryphe.impl.binaryoperator.StringConcat;
 import uk.gov.gchq.koryphe.util.ReflectionUtil;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/integration/controller/OperationControllerIT.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/integration/controller/OperationControllerIT.java
@@ -52,14 +52,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.gchq.gaffer.core.exception.Status.SERVICE_UNAVAILABLE;
 import static uk.gov.gchq.gaffer.jsonserialisation.JSONSerialiser.createDefaultMapper;
 
-public class OperationControllerIT extends AbstractRestApiIT {
+class OperationControllerIT extends AbstractRestApiIT {
 
     @Autowired
     private GraphFactory graphFactory; // This will be a Mock (see application-test.properties)
@@ -70,7 +67,7 @@ public class OperationControllerIT extends AbstractRestApiIT {
 
 
     @Test
-    public void shouldReturnHelpfulErrorMessageIfJsonIsIncorrect() {
+    void shouldReturnHelpfulErrorMessageIfJsonIsIncorrect() {
         // Given
         Graph graph = new Graph.Builder()
                 .config(StreamUtil.graphConfig(this.getClass()))
@@ -83,7 +80,7 @@ public class OperationControllerIT extends AbstractRestApiIT {
         // When
         String request = "{\"class\"\"GetAllElements\"}";
 
-        LinkedMultiValueMap headers = new LinkedMultiValueMap();
+        LinkedMultiValueMap<String, String> headers = new LinkedMultiValueMap<String, String>();
         headers.add("Content-Type", "application/json;charset=utf-8");
 
         final ResponseEntity<Error> response = post("/graph/operations/execute",
@@ -91,13 +88,13 @@ public class OperationControllerIT extends AbstractRestApiIT {
                 Error.class);
 
         // Then
-        assertEquals(400, response.getStatusCode().value());
-        assertEquals(400, response.getBody().getStatusCode());
-        assertTrue(response.getBody().getSimpleMessage().contains("was expecting a colon to separate field name and value"));
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(response.getBody().getStatusCode()).isEqualTo(400);
+        assertThat(response.getBody().getSimpleMessage()).contains("was expecting a colon to separate field name and value");
     }
 
     @Test
-    public void shouldReturnHelpfulErrorMessageIfOperationIsUnsupported() {
+    void shouldReturnHelpfulErrorMessageIfOperationIsUnsupported() {
         // Given
         Graph graph = new Graph.Builder()
             .config(StreamUtil.graphConfig(this.getClass()))
@@ -113,13 +110,12 @@ public class OperationControllerIT extends AbstractRestApiIT {
             Error.class);
 
         // Then
-
-        assertNotNull(response.getBody().getSimpleMessage());
-        assertTrue(response.getBody().getSimpleMessage().contains("GetAllGraphIds is not supported by the MapStore"));
+        assertThat(response.getBody().getSimpleMessage()).isNotNull();
+        assertThat(response.getBody().getSimpleMessage()).contains("GetAllGraphIds is not supported by the MapStore");
     }
 
     @Test
-    public void shouldReturn403WhenUnauthorised() throws IOException {
+    void shouldReturn403WhenUnauthorised() {
         // Given
         Graph graph = new Graph.Builder()
                 .config(StreamUtil.graphConfig(this.getClass()))
@@ -135,12 +131,12 @@ public class OperationControllerIT extends AbstractRestApiIT {
                 Error.class);
 
         // Then
-        assertEquals(403, response.getStatusCode().value());
-        assertEquals(403, response.getBody().getStatusCode());
+        assertThat(response.getStatusCode().value()).isEqualTo(403);
+        assertThat(response.getBody().getStatusCode()).isEqualTo(403);
     }
 
     @Test
-    public void shouldPropagateStatusInformationContainedInOperationExceptionsThrownByOperationHandlers() throws IOException {
+    void shouldPropagateStatusInformationContainedInOperationExceptionsThrownByOperationHandlers() throws IOException {
         // Given
         final StoreProperties storeProperties = new MapStoreProperties();
         storeProperties.set(StoreProperties.JOB_TRACKER_ENABLED, Boolean.FALSE.toString());
@@ -158,11 +154,11 @@ public class OperationControllerIT extends AbstractRestApiIT {
                 new GetAllJobDetails(),
                 Error.class);
         // Then
-        assertEquals(SERVICE_UNAVAILABLE.getStatusCode(), response.getStatusCode().value());
+        assertThat(response.getStatusCode().value()).isEqualTo(SERVICE_UNAVAILABLE.getStatusCode());
     }
 
     @Test
-    public void shouldReturnSameJobIdInHeaderAsGetAllJobDetailsOperation() throws IOException {
+    void shouldNotReturnJobIdInHeader() {
         // Given
         StoreProperties properties = new MapStoreProperties();
         properties.setJobTrackerEnabled(true);
@@ -182,18 +178,11 @@ public class OperationControllerIT extends AbstractRestApiIT {
                 Set.class);
 
         // Then
-        try {
-            assertTrue(response.getBody().toString().contains(response.getHeaders().get("job-id").get(0)));
-        } catch (final AssertionError e) {
-            System.out.println("Job ID was not found in the Header");
-            System.out.println("Header was: " + response.getHeaders().get("job-id"));
-            System.out.println("Body was: " + response.getBody());
-            throw e;
-        }
+        assertThat(response.getHeaders().toString()).doesNotContain("job-id");
     }
 
     @Test
-    public void shouldCorrectlyStreamExecuteChunked() throws Exception {
+    void shouldCorrectlyStreamExecuteChunked() throws Exception {
         // Given
         final Schema schema =  new Schema.Builder()
                 .entity("g1", new SchemaEntityDefinition.Builder()
@@ -241,11 +230,11 @@ public class OperationControllerIT extends AbstractRestApiIT {
 
         // Then
         String expected = mapper.writeValueAsString(ent1) + "\r\n" + mapper.writeValueAsString(ent2) + "\r\n";
-        assertEquals(expected, response.getBody());
+        assertThat(response.getBody()).isEqualTo(expected);
     }
 
     @Test
-    public void shouldCorrectlySerialiseAllOperationDetails() throws IOException {
+    void shouldCorrectlySerialiseAllOperationDetails() {
         // Given
         final Graph graph = new Graph.Builder()
                 .config(StreamUtil.graphConfig(this.getClass()))

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/integration/controller/OperationControllerIT.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/integration/controller/OperationControllerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 Crown Copyright
+ * Copyright 2020-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Removes the job tracker from the main execute and any returned headers.

# Related issue

- Resolve #2478