### PR TITLE
Gh-3351: Better GetWalks support on federated POC

### DIFF
--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/GetWalks.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/GetWalks.java
@@ -41,6 +41,7 @@ import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.ValidationResult;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -151,6 +152,11 @@ public class GetWalks implements
         }
 
         return result;
+    }
+
+    @Override
+    public List<Operation> flatten() {
+        return Arrays.asList(this);
     }
 
     @JsonIgnore

--- a/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/GetWalks.java
+++ b/core/operation/src/main/java/uk/gov/gchq/gaffer/operation/impl/GetWalks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Crown Copyright
+ * Copyright 2017-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -172,7 +172,7 @@ public class GetWalks implements
             hops += getNumberOfGetEdgeOperations(((Operations<?>) op).getOperations());
         } else if (op instanceof GetElements) {
             final GetElements getElements = (GetElements) op;
-            if (null != getElements.getView() && getElements.getView().hasEdges()) {
+            if (null != getElements.getView() && (getElements.getView().hasEdges() || getElements.getView().isAllEdges())) {
                 hops += 1;
             }
         }
@@ -193,7 +193,7 @@ public class GetWalks implements
             hops += getNumberOfGetEdgeOperationsWithoutRepeats(((Operations<?>) op).getOperations());
         } else if (op instanceof GetElements) {
             final GetElements getElements = (GetElements) op;
-            if (null != getElements.getView() && getElements.getView().hasEdges()) {
+            if (null != getElements.getView() && (getElements.getView().hasEdges() || getElements.getView().isAllEdges())) {
                 hops += 1;
             }
         }

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/GetWalksHandler.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/GetWalksHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Crown Copyright
+ * Copyright 2017-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 Crown Copyright
+ * Copyright 2017-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
@@ -75,6 +75,12 @@ public class OperationChainHandler<OUT> implements OutputOperationHandler<Operat
     }
 
     public <O> OperationChain<O> prepareOperationChain(final OperationChain<O> operationChain, final Context context, final Store store) {
+        // Optionally apply the chain level options to all sub operations too
+        if (context.getVariable(APPLY_CHAIN_OPS_TO_ALL) != null) {
+            Map<String, String> options = operationChain.getOptions();
+            operationChain.getOperations().forEach(op -> op.setOptions(options));
+        }
+
         final ValidationResult validationResult = opChainValidator.validate(operationChain, context
                 .getUser(), store);
         if (!validationResult.isValid()) {
@@ -86,11 +92,7 @@ public class OperationChainHandler<OUT> implements OutputOperationHandler<Operat
         for (final OperationChainOptimiser opChainOptimiser : opChainOptimisers) {
             optimisedOperationChain = opChainOptimiser.optimise(optimisedOperationChain);
         }
-        // Optionally apply the chain level options to all sub operations too
-        if (context.getVariable(APPLY_CHAIN_OPS_TO_ALL) != null) {
-            Map<String, String> options = operationChain.getOptions();
-            optimisedOperationChain.getOperations().forEach(op -> op.setOptions(options));
-        }
+
         return optimisedOperationChain;
     }
 

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
@@ -75,12 +75,7 @@ public class OperationChainHandler<OUT> implements OutputOperationHandler<Operat
     }
 
     public <O> OperationChain<O> prepareOperationChain(final OperationChain<O> operationChain, final Context context, final Store store) {
-        // Optionally apply the chain level options to all sub operations too
-        if (context.getVariable(APPLY_CHAIN_OPS_TO_ALL) != null) {
-            Map<String, String> options = operationChain.getOptions();
-            operationChain.getOperations().forEach(op -> op.setOptions(options));
-        }
-
+        Map<String, String> options = operationChain.getOptions();
         final ValidationResult validationResult = opChainValidator.validate(operationChain, context
                 .getUser(), store);
         if (!validationResult.isValid()) {
@@ -91,6 +86,11 @@ public class OperationChainHandler<OUT> implements OutputOperationHandler<Operat
         OperationChain<O> optimisedOperationChain = operationChain;
         for (final OperationChainOptimiser opChainOptimiser : opChainOptimisers) {
             optimisedOperationChain = opChainOptimiser.optimise(optimisedOperationChain);
+        }
+
+        // Optionally re-apply the chain level options to all sub operations too
+        if (context.getVariable(APPLY_CHAIN_OPS_TO_ALL) != null) {
+            optimisedOperationChain.getOperations().forEach(op -> op.setOptions(options));
         }
 
         return optimisedOperationChain;

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
@@ -31,6 +31,7 @@ import uk.gov.gchq.gaffer.store.optimiser.OperationChainOptimiser;
 import uk.gov.gchq.koryphe.ValidationResult;
 
 import java.util.List;
+import java.util.Map;
 
 import static uk.gov.gchq.gaffer.store.operation.handler.util.OperationHandlerUtil.updateOperationInput;
 
@@ -40,6 +41,7 @@ import static uk.gov.gchq.gaffer.store.operation.handler.util.OperationHandlerUt
  * @param <OUT> the output type of the operation chain
  */
 public class OperationChainHandler<OUT> implements OutputOperationHandler<OperationChain<OUT>, OUT> {
+    public static final String APPLY_CHAIN_OPS_TO_ALL = "applyChainOptionsToAll";
     private final OperationChainValidator opChainValidator;
     private final List<OperationChainOptimiser> opChainOptimisers;
 
@@ -80,6 +82,11 @@ public class OperationChainHandler<OUT> implements OutputOperationHandler<Operat
         OperationChain<O> optimisedOperationChain = operationChain;
         for (final OperationChainOptimiser opChainOptimiser : opChainOptimisers) {
             optimisedOperationChain = opChainOptimiser.optimise(optimisedOperationChain);
+        }
+        // Optionally apply the chain level options to all sub operations too
+        if(Boolean.parseBoolean(context.getVariable(APPLY_CHAIN_OPS_TO_ALL).toString())) {
+            Map<String, String> options = operationChain.getOptions();
+            operationChain.getOperations().forEach(op -> op.setOptions(options));
         }
         return optimisedOperationChain;
     }

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
@@ -89,7 +89,7 @@ public class OperationChainHandler<OUT> implements OutputOperationHandler<Operat
         // Optionally apply the chain level options to all sub operations too
         if (context.getVariable(APPLY_CHAIN_OPS_TO_ALL) != null) {
             Map<String, String> options = operationChain.getOptions();
-            operationChain.getOperations().forEach(op -> op.setOptions(options));
+            optimisedOperationChain.getOperations().forEach(op -> op.setOptions(options));
         }
         return optimisedOperationChain;
     }

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
@@ -41,6 +41,9 @@ import static uk.gov.gchq.gaffer.store.operation.handler.util.OperationHandlerUt
  * @param <OUT> the output type of the operation chain
  */
 public class OperationChainHandler<OUT> implements OutputOperationHandler<OperationChain<OUT>, OUT> {
+    /**
+     * Context variable to apply the operation options on the chain to all sub operations
+     */
     public static final String APPLY_CHAIN_OPS_TO_ALL = "applyChainOptionsToAll";
     private final OperationChainValidator opChainValidator;
     private final List<OperationChainOptimiser> opChainOptimisers;
@@ -84,7 +87,7 @@ public class OperationChainHandler<OUT> implements OutputOperationHandler<Operat
             optimisedOperationChain = opChainOptimiser.optimise(optimisedOperationChain);
         }
         // Optionally apply the chain level options to all sub operations too
-        if(Boolean.parseBoolean(context.getVariable(APPLY_CHAIN_OPS_TO_ALL).toString())) {
+        if (context.getVariable(APPLY_CHAIN_OPS_TO_ALL) != null) {
             Map<String, String> options = operationChain.getOptions();
             operationChain.getOperations().forEach(op -> op.setOptions(options));
         }

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Crown Copyright
+ * Copyright 2024-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
@@ -59,6 +59,7 @@ import uk.gov.gchq.gaffer.named.view.GetAllNamedViews;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.OperationChain;
 import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.operation.impl.GetWalks;
 import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
 import uk.gov.gchq.gaffer.operation.impl.delete.DeleteElements;
 import uk.gov.gchq.gaffer.operation.impl.get.GetAdjacentIds;
@@ -77,6 +78,7 @@ import uk.gov.gchq.gaffer.store.operation.GetSchema;
 import uk.gov.gchq.gaffer.store.operation.GetTraits;
 import uk.gov.gchq.gaffer.store.operation.OperationChainValidator;
 import uk.gov.gchq.gaffer.store.operation.handler.GetGraphCreatedTimeHandler;
+import uk.gov.gchq.gaffer.store.operation.handler.GetWalksHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.OperationChainHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.OutputOperationHandler;
@@ -135,7 +137,8 @@ public class FederatedStore extends Store {
             new SimpleEntry<>(ChangeGraphId.class, new ChangeGraphIdHandler()),
             new SimpleEntry<>(GetAllGraphInfo.class, new GetAllGraphInfoHandler()),
             new SimpleEntry<>(RemoveGraph.class, new RemoveGraphHandler()),
-            new SimpleEntry<>(ChangeGraphAccess.class, new ChangeGraphAccessHandler()))
+            new SimpleEntry<>(ChangeGraphAccess.class, new ChangeGraphAccessHandler()),
+            new SimpleEntry<>(GetWalks.class, new GetWalksHandler()))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     /**

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/access/GraphAccess.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/access/GraphAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Crown Copyright
+ * Copyright 2024-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/access/GraphAccess.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/access/GraphAccess.java
@@ -24,10 +24,12 @@ import uk.gov.gchq.gaffer.user.User;
 
 import static uk.gov.gchq.gaffer.federated.simple.FederatedStore.FEDERATED_STORE_SYSTEM_USER;
 
+import java.io.Serializable;
+
 /**
  * Access control for a Graph that as been added through a federated store.
  */
-public class GraphAccess implements AccessControlledResource  {
+public class GraphAccess implements AccessControlledResource, Serializable {
     // Default accesses applied to a graph can be overridden using builder
     private boolean isPublic = true;
     private String owner = User.UNKNOWN_USER_ID;

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/EitherOperationHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/EitherOperationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Crown Copyright
+ * Copyright 2024-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/EitherOperationHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/EitherOperationHandler.java
@@ -65,8 +65,9 @@ public class EitherOperationHandler<O extends Operation> implements AddToCacheHa
                 .collect(Collectors.toList());
             // Use default chain handler to handle each operation rather than forwarding the whole chain
             if (!Collections.disjoint(storeSpecificOps, chainOps)) {
-                return new OperationChainHandler<>(store.getOperationChainValidator(), store.getOperationChainOptimisers())
-                    .doOperation((OperationChain<Object>) operation, context, store);
+                LOGGER.debug("Operation chain contains some operations that should not be forwarded");
+                context.setVariable(OperationChainHandler.APPLY_CHAIN_OPS_TO_ALL, true);
+                return standardHandler.doOperation(operation, context, store);
             }
         }
 

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/EitherOperationHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/EitherOperationHandler.java
@@ -29,6 +29,7 @@ import uk.gov.gchq.gaffer.store.operation.handler.OperationChainHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.named.AddToCacheHandler;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -56,13 +57,14 @@ public class EitherOperationHandler<O extends Operation> implements AddToCacheHa
     public Object doOperation(final O operation, final Context context, final Store store) throws OperationException {
         LOGGER.debug("Checking if Operation should be handled locally or on sub graphs: {}", operation);
 
-        // Check inside operation chain for if all the operations are handled by a federated store
+        // Check inside operation chain for if any operations are handled locally by a federated store
         if (operation instanceof OperationChain) {
             Set<Class<? extends Operation>> storeSpecificOps = ((FederatedStore) store).getStoreSpecificOperations();
             List<Class<? extends Operation>> chainOps = ((OperationChain<?>) operation).flatten().stream()
                 .map(Operation::getClass)
                 .collect(Collectors.toList());
-            if (storeSpecificOps.containsAll(chainOps)) {
+            // Use default chain handler to handle each operation rather than forwarding the whole chain
+            if (!Collections.disjoint(storeSpecificOps, chainOps)) {
                 return new OperationChainHandler<>(store.getOperationChainValidator(), store.getOperationChainOptimisers())
                     .doOperation((OperationChain<Object>) operation, context, store);
             }

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/FederatedStoreIT.java
@@ -488,7 +488,7 @@ class FederatedStoreIT {
         for (final Walk walk : res) {
             walkList.add(walk.getVerticesOrdered().stream().map(Object::toString).collect(Collectors.joining("")));
         }
-        assertThat(walkList).containsExactly("143", "145");
+        assertThat(walkList).containsExactlyInAnyOrder("143", "145");
     }
 
     @Test
@@ -519,7 +519,7 @@ class FederatedStoreIT {
         for (final Walk walk : res) {
             walkList.add(walk.getVerticesOrdered().stream().map(Object::toString).collect(Collectors.joining("")));
         }
-        assertThat(walkList).containsExactly("143", "145");
+        assertThat(walkList).containsExactlyInAnyOrder("143", "145");
     }
 
 }

--- a/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/util/FederatedModernTestUtils.java
+++ b/store-implementation/simple-federated-store/src/test/java/uk/gov/gchq/gaffer/federated/simple/util/FederatedModernTestUtils.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2025 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.util;
+
+import uk.gov.gchq.gaffer.commonutil.StreamUtil;
+import uk.gov.gchq.gaffer.data.element.Edge;
+import uk.gov.gchq.gaffer.data.element.Element;
+import uk.gov.gchq.gaffer.data.element.Entity;
+import uk.gov.gchq.gaffer.federated.simple.FederatedStoreProperties;
+import uk.gov.gchq.gaffer.federated.simple.operation.AddGraph;
+import uk.gov.gchq.gaffer.federated.simple.operation.handler.FederatedOperationHandler;
+import uk.gov.gchq.gaffer.graph.Graph;
+import uk.gov.gchq.gaffer.graph.GraphConfig;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.operation.impl.add.AddElements;
+import uk.gov.gchq.gaffer.store.Context;
+import uk.gov.gchq.gaffer.store.StoreProperties;
+import uk.gov.gchq.gaffer.store.schema.Schema;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static uk.gov.gchq.gaffer.federated.simple.FederatedStoreProperties.PROP_DEFAULT_GRAPH_IDS;
+import static uk.gov.gchq.gaffer.federated.simple.FederatedStoreProperties.PROP_DEFAULT_MERGE_ELEMENTS;
+
+public final class FederatedModernTestUtils {
+    public static final String FEDERATED_GRAPH_ID = "simpleFederatedGraph";
+    public static final String CREATED_GRAPH_ID = "createdGraph";
+    public static final String KNOWS_GRAPH_ID = "knowsGraph";
+    private static final Context CONTEXT = new Context();
+
+    private FederatedModernTestUtils() {
+        // utility class
+    }
+
+    public static Graph setUpSimpleFederatedGraph(Class<?> clazz, StoreProperties properties)
+            throws OperationException {
+        FederatedStoreProperties fedProperties = new FederatedStoreProperties();
+        fedProperties.set(PROP_DEFAULT_GRAPH_IDS, CREATED_GRAPH_ID + "," + KNOWS_GRAPH_ID);
+        fedProperties.set(PROP_DEFAULT_MERGE_ELEMENTS, "true");
+        final Graph federatedGraph = new Graph.Builder()
+                .config(new GraphConfig.Builder()
+                        .graphId(FEDERATED_GRAPH_ID)
+                        .build())
+                .addStoreProperties(fedProperties)
+                .build();
+
+        federatedGraph.execute(
+                new AddGraph.Builder()
+                        .graphConfig(new GraphConfig(KNOWS_GRAPH_ID))
+                        .schema(Schema.fromJson(StreamUtil.openStreams(clazz, "/modern/schema")))
+                        .properties(properties.getProperties())
+                        .build(),
+                CONTEXT);
+
+        federatedGraph.execute(
+                new AddGraph.Builder()
+                        .graphConfig(new GraphConfig(CREATED_GRAPH_ID))
+                        .schema(Schema.fromJson(StreamUtil.openStreams(clazz, "/modern/schema")))
+                        .properties(properties.getProperties())
+                        .build(),
+                CONTEXT);
+
+        setupKnowsGraph(federatedGraph);
+        setupCreatedGraph(federatedGraph);
+
+        return federatedGraph;
+    }
+
+    private static void setupKnowsGraph(final Graph federatedGraph) throws OperationException {
+        List<Element> knowsGraphElements = new ArrayList<>();
+
+        knowsGraphElements.add(getEntity("1", "person", "marko"));
+        knowsGraphElements.add(getEntity("4", "person", "josh"));
+        knowsGraphElements.add(getEntity("2", "person", "vadas"));
+        knowsGraphElements.add(getEntity("6", "person", "peter"));
+        knowsGraphElements.add(getEdge("1", "4", "knows"));
+        knowsGraphElements.add(getEdge("1", "2", "knows"));
+
+        federatedGraph.execute(new AddElements.Builder()
+                .input(knowsGraphElements.toArray(new Element[0]))
+                .option(FederatedOperationHandler.OPT_GRAPH_IDS, KNOWS_GRAPH_ID)
+                .build(), CONTEXT);
+    }
+
+    private static void setupCreatedGraph(final Graph federatedGraph) throws OperationException {
+        List<Element> createdGraphElements = new ArrayList<>();
+
+        createdGraphElements.add(getEntity("3", "software", "lop"));
+        createdGraphElements.add(getEntity("5", "software", "ripple"));
+        createdGraphElements.add(getEntity("1", "person", "marko"));
+        createdGraphElements.add(getEntity("4", "person", "josh"));
+        createdGraphElements.add(getEntity("6", "person", "peter"));
+        createdGraphElements.add(getEdge("1", "3", "created"));
+        createdGraphElements.add(getEdge("4", "3", "created"));
+        createdGraphElements.add(getEdge("6", "3", "created"));
+        createdGraphElements.add(getEdge("4", "5", "created"));
+
+        federatedGraph.execute(new AddElements.Builder()
+                .input(createdGraphElements.toArray(new Element[0]))
+                .option(FederatedOperationHandler.OPT_GRAPH_IDS, CREATED_GRAPH_ID)
+                .build(), CONTEXT);
+    }
+
+    private static Entity getEntity(final String vertex, final String group, final String name) {
+        return new Entity.Builder()
+                .group(group)
+                .vertex(vertex)
+                .property("name", name)
+                .build();
+    }
+
+    private static Edge getEdge(final String source, final String dest, final String group) {
+        return new Edge.Builder()
+                .group(group)
+                .source(source)
+                .dest(dest)
+                .directed(true)
+                .build();
+    }
+}


### PR DESCRIPTION
Fixes a few issues for `GetWalks` when running on new federated POC along with some general bug fixes for it too.
Main changes:
* `GetWalks.flatten()` no longer gives all the operations get walks will run as this removes all the information about the operation can can be very misleading in an operation chain.
* `OperationChainHandler` can now apply all operation options on the top level chain to all child operations.
* Bug fix to `GetWalks` as it did not treat an `allEdges: true` as a valid hop.

# Related issue

- Resolve #3351