### PR TITLE
Gh-3353: Ensure user info passed in GafferPop

### DIFF
--- a/core/common-util/src/main/java/uk/gov/gchq/gaffer/commonutil/otel/OtelUtil.java
+++ b/core/common-util/src/main/java/uk/gov/gchq/gaffer/commonutil/otel/OtelUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Crown Copyright
+ * Copyright 2024-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/common-util/src/main/java/uk/gov/gchq/gaffer/commonutil/otel/OtelUtil.java
+++ b/core/common-util/src/main/java/uk/gov/gchq/gaffer/commonutil/otel/OtelUtil.java
@@ -25,6 +25,7 @@ public final class OtelUtil {
     public static final String JOB_ID_ATTRIBUTE = "gaffer.jobId";
     public static final String GRAPH_ID_ATTRIBUTE = "gaffer.graphId";
     public static final String VIEW_ATTRIBUTE = "gaffer.view";
+    public static final String OP_OPTIONS_ATTRIBUTE = "gaffer.operation.options";
     public static final String GREMLIN_QUERY_ATTRIBUTE = "gaffer.gremlin.query";
 
     private static boolean openTelemetryActive = false;

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/Graph.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/Graph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 Crown Copyright
+ * Copyright 2017-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/Graph.java
+++ b/core/graph/src/main/java/uk/gov/gchq/gaffer/graph/Graph.java
@@ -320,10 +320,11 @@ public final class Graph {
         // OpenTelemetry hooks
         Span span = OtelUtil.startSpan(
             this.getClass().getName(),
-            "Graph Request: " + clonedOpChain.toOverviewString());
+            "Graph Request: " + clonedContext.getJobId());
         span.setAttribute(OtelUtil.GRAPH_ID_ATTRIBUTE, getGraphId());
         span.setAttribute(OtelUtil.JOB_ID_ATTRIBUTE, clonedContext.getJobId());
         span.setAttribute(OtelUtil.USER_ATTRIBUTE, clonedContext.getUser().getUserId());
+        span.setAttribute(OtelUtil.OP_OPTIONS_ATTRIBUTE, clonedOpChain.getOptions().toString());
 
         O result = null;
         // Sets the span to current so parent child spans are auto linked

--- a/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
+++ b/core/store/src/main/java/uk/gov/gchq/gaffer/store/operation/handler/OperationChainHandler.java
@@ -58,8 +58,16 @@ public class OperationChainHandler<OUT> implements OutputOperationHandler<Operat
             // OpenTelemetry hooks
             Span span = OtelUtil.startSpan(this.getClass().getName(), op.getClass().getName());
             span.setAttribute(OtelUtil.JOB_ID_ATTRIBUTE, context.getJobId());
+            span.setAttribute(OtelUtil.OP_OPTIONS_ATTRIBUTE, (op.getOptions() != null) ? op.getOptions().toString() : "[]");
+            // Extract the view
             if (op instanceof OperationView && ((OperationView) op).getView() != null) {
-                span.setAttribute(OtelUtil.VIEW_ATTRIBUTE, ((OperationView) op).getView().toString());
+                String strView = ((OperationView) op).getView().toString();
+                // Truncate the view if its too long
+                if (strView.length() > 2048) {
+                    span.setAttribute(OtelUtil.VIEW_ATTRIBUTE, strView.substring(0, 2048));
+                } else {
+                    span.setAttribute(OtelUtil.VIEW_ATTRIBUTE, strView);
+                }
             }
 
             // Sets the span to current so parent child spans are auto linked

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -286,7 +286,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
         // Set the graph variables to current config
         variables = new GafferPopGraphVariables();
-        setDefaultVariables(variables);
+        setDefaultVariables(false);
 
         serviceRegistry = new ServiceRegistry();
         serviceRegistry.registerService(new GafferPopNamedOperationServiceFactory(this));
@@ -756,12 +756,16 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * Sets the {@link GafferPopGraphVariables} to default values for this
      * graph
      *
-     * @param variables The variables
+     * @param preserveUser optionally preserve the graph User as it may have been set
+     * externally
      */
-    public void setDefaultVariables(final GafferPopGraphVariables variables) {
+    public void setDefaultVariables(final boolean preserveUser) {
         LOGGER.debug("Resetting graph variables to defaults");
+        if (!preserveUser) {
+            LOGGER.debug("Resetting graph user variable");
+            variables.set(GafferPopGraphVariables.USER, defaultUser);
+        }
         variables.set(GafferPopGraphVariables.OP_OPTIONS, Collections.unmodifiableMap(opOptions));
-        variables.set(GafferPopGraphVariables.USER, defaultUser);
         variables.set(GafferPopGraphVariables.GET_ELEMENTS_LIMIT,
                 configuration().getInteger(GET_ELEMENTS_LIMIT, DEFAULT_GET_ELEMENTS_LIMIT));
         variables.set(GafferPopGraphVariables.HAS_STEP_FILTER_STAGE,

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -429,7 +429,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 .first(getOperation)
                 .then(new Limit<>(variables.getElementsLimit(), true))
                 .build();
-        final Set<Element> result = new HashSet<>(IterableUtils.toList(execute(chain)));
+        final List<? extends Element> result = IterableUtils.toList(execute(chain));
 
         // Warn of truncation
         if (result.size() >= variables.getElementsLimit()) {
@@ -440,11 +440,11 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
         // Translate results to GafferPop elements
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(this);
-        final Set<Vertex> translatedResults = StreamSupport.stream(result.spliterator(), false)
+        final List<Vertex> translatedResults = StreamSupport.stream(result.spliterator(), false)
                 .map(generator::_apply)
                 .filter(Vertex.class::isInstance)
                 .map(e -> (Vertex) e)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
 
         // Check for seeds that are not entities but are vertices on an edge (orphan vertices)
         if (variables.getIncludeOrphanedVertices()) {
@@ -597,16 +597,16 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         }
 
         // Run requested chain on the graph and buffer to set to avoid reusing iterator
-        final Set<Element> result = new HashSet<>(IterableUtils.toList(execute(getOperation)));
+        final List<? extends Element> result = IterableUtils.toList(execute(getOperation));
 
         // Translate results to Gafferpop elements
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(this);
-        final Set<Edge> translatedResults = StreamSupport.stream(result.spliterator(), false)
+        final List<Edge> translatedResults = StreamSupport.stream(result.spliterator(), false)
                 .map(generator::_apply)
                 .filter(Edge.class::isInstance)
                 .map(e -> (Edge) e)
                 .limit(variables.getElementsLimit())
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
 
         if (translatedResults.size() >= variables.getElementsLimit()) {
             LOGGER.warn(
@@ -819,15 +819,15 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 .first(getOperation)
                 .then(new Limit<>(variables.getElementsLimit(), true))
                 .build();
-        final Set<Element> result = new HashSet<>(IterableUtils.toList(execute(chain)));
+        final List<? extends Element> result = IterableUtils.toList(execute(chain));
 
         // Translate results to Gafferpop elements
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(this);
-        final Set<GafferPopVertex> translatedResults = StreamSupport.stream(result.spliterator(), false)
+        final List<GafferPopVertex> translatedResults = StreamSupport.stream(result.spliterator(), false)
                 .map(generator::_apply)
                 .filter(GafferPopVertex.class::isInstance)
                 .map(e -> (GafferPopVertex) e)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
 
         return translatedResults.iterator();
     }
@@ -855,16 +855,16 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         }
 
         // GetAdjacentIds provides list of entity seeds so run a GetElements to get the actual Entities
-        final Set<Element> result = new HashSet<>(IterableUtils.toList(
-            execute(new OperationChain.Builder().first(builder.build()).build())));
+        final List<? extends Element> result = IterableUtils.toList(
+            execute(new OperationChain.Builder().first(builder.build()).build()));
 
         // Translate results to Gafferpop elements
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(this);
-        final Set<Vertex> translatedResults = StreamSupport.stream(result.spliterator(), false)
+        final List<Vertex> translatedResults = StreamSupport.stream(result.spliterator(), false)
                 .map(generator::_apply)
                 .filter(Vertex.class::isInstance)
                 .map(e -> (Vertex) e)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
 
         // Check for seeds that are not entities but are vertices on an edge (orphan vertices)
         if (variables.getIncludeOrphanedVertices()) {
@@ -909,16 +909,16 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
         }
 
         // Run requested chain on the graph
-        final Set<Element> result = new HashSet<>(IterableUtils.toList(execute(getOperation)));
+        final List<? extends Element> result = IterableUtils.toList(execute(getOperation));
 
         // Translate results to Gafferpop elements
         final GafferPopElementGenerator generator = new GafferPopElementGenerator(this, true);
-        final Set<Edge> translatedResults = StreamSupport.stream(result.spliterator(), false)
+        final List<Edge> translatedResults = StreamSupport.stream(result.spliterator(), false)
                 .map(generator::_apply)
                 .filter(Edge.class::isInstance)
                 .map(e -> (Edge) e)
                 .limit(variables.getElementsLimit())
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
 
         return translatedResults.iterator();
     }

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraph.java
@@ -286,7 +286,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
         // Set the graph variables to current config
         variables = new GafferPopGraphVariables();
-        setDefaultVariables(false);
+        setDefaultVariables();
 
         serviceRegistry = new ServiceRegistry();
         serviceRegistry.registerService(new GafferPopNamedOperationServiceFactory(this));
@@ -297,6 +297,16 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
                 GafferPopHasStepStrategy.instance(),
                 GafferPopVertexStepStrategy.instance());
         GlobalCache.registerStrategies(this.getClass(), traversalStrategies);
+    }
+
+    /**
+     * Return a new instance of the graph  usually so a different set
+     * of graph variables can be used for a query.
+     *
+     * @return Identical instance this graph.
+     */
+    public GafferPopGraph newInstance() {
+        return new GafferPopGraph(configuration, graph);
     }
 
     private static Graph createGraph(final Configuration configuration) {
@@ -745,6 +755,7 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
 
         try {
             LOGGER.info("GafferPop operation chain called: {}", opChain.toOverviewString());
+            LOGGER.info("USER IS: " + variables.getUser().getUserId());
             return graph.execute(opChain, variables.getUser());
         } catch (final Exception e) {
             LOGGER.error("Operation chain failed: {}", e.getMessage());
@@ -756,15 +767,10 @@ public class GafferPopGraph implements org.apache.tinkerpop.gremlin.structure.Gr
      * Sets the {@link GafferPopGraphVariables} to default values for this
      * graph
      *
-     * @param preserveUser optionally preserve the graph User as it may have been set
-     * externally
      */
-    public void setDefaultVariables(final boolean preserveUser) {
+    public void setDefaultVariables() {
         LOGGER.debug("Resetting graph variables to defaults");
-        if (!preserveUser) {
-            LOGGER.debug("Resetting graph user variable");
-            variables.set(GafferPopGraphVariables.USER, defaultUser);
-        }
+        variables.set(GafferPopGraphVariables.USER, defaultUser);
         variables.set(GafferPopGraphVariables.OP_OPTIONS, Collections.unmodifiableMap(opOptions));
         variables.set(GafferPopGraphVariables.GET_ELEMENTS_LIMIT,
                 configuration().getInteger(GET_ELEMENTS_LIMIT, DEFAULT_GET_ELEMENTS_LIMIT));

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopGraphStep.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopGraphStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Crown Copyright
+ * Copyright 2024-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopGraphStep.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopGraphStep.java
@@ -73,6 +73,8 @@ public class GafferPopGraphStep<S, E extends Element> extends GraphStep<S, E> im
 
         // Save reference to the graph
         GafferPopGraph graph = (GafferPopGraph) originalGraphStep.getTraversal().getGraph().get();
+        // Reset vars on the graph but preserving the user in case it was set externally
+        graph.setDefaultVariables(true);
 
         // Find any options on the traversal
         Optional<OptionsStrategy> optionsStrategy = originalGraphStep.getTraversal().getStrategies().getStrategy(OptionsStrategy.class);

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopGraphStep.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopGraphStep.java
@@ -74,8 +74,8 @@ public class GafferPopGraphStep<S, E extends Element> extends GraphStep<S, E> im
         // Save reference to the graph
         GafferPopGraph graph = (GafferPopGraph) originalGraphStep.getTraversal().getGraph().get();
 
-        // Restore variables to defaults before parsing options
-        graph.setDefaultVariables((GafferPopGraphVariables) graph.variables());
+        // Restore variables to defaults before parsing options, preserve user as may have been set by REST API
+        graph.setDefaultVariables(true);
 
         // Find any options on the traversal
         Optional<OptionsStrategy> optionsStrategy = originalGraphStep.getTraversal().getStrategies().getStrategy(OptionsStrategy.class);

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopGraphStep.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/process/traversal/step/GafferPopGraphStep.java
@@ -74,9 +74,6 @@ public class GafferPopGraphStep<S, E extends Element> extends GraphStep<S, E> im
         // Save reference to the graph
         GafferPopGraph graph = (GafferPopGraph) originalGraphStep.getTraversal().getGraph().get();
 
-        // Restore variables to defaults before parsing options, preserve user as may have been set by REST API
-        graph.setDefaultVariables(true);
-
         // Find any options on the traversal
         Optional<OptionsStrategy> optionsStrategy = originalGraphStep.getTraversal().getStrategies().getStrategy(OptionsStrategy.class);
         if (optionsStrategy.isPresent()) {

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 Crown Copyright
+ * Copyright 2017-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
@@ -27,16 +27,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import io.opentelemetry.context.Context;
 import uk.gov.gchq.gaffer.cache.CacheServiceLoader;
 import uk.gov.gchq.gaffer.tinkerpop.util.GafferPopTestUtil.StoreType;
 import uk.gov.gchq.gaffer.tinkerpop.util.modern.GafferPopModernTestUtils;
-import uk.gov.gchq.gaffer.user.User;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -352,43 +348,6 @@ class GafferPopGraphIT {
         assertThat(resultLabel)
             .extracting(Element::id)
             .containsOnly(VERTEX_ONLY_ID_STRING);
-        reset();
-    }
-
-    @ParameterizedTest(name = TEST_NAME_FORMAT)
-    @MethodSource("provideTraversals")
-    void shouldPreserveExternallySetUser(String graph, GraphTraversalSource g) {
-        ExecutorService executorService = Context.taskWrapping(Executors.newFixedThreadPool(2));
-
-        User testUser = new User("shouldPreserveExternallySetUser");
-        User testUser2 = new User("shouldPreserveExternallySetUser2");
-
-        executorService.submit(() -> {
-            GraphTraversalSource g2 = ((GafferPopGraph) g.getGraph()).newInstance().traversal();
-            g2.getGraph().variables().set(GafferPopGraphVariables.USER, testUser);
-            g2.V().toList();
-            assertThat(((GafferPopGraphVariables) g.getGraph().variables()).getUser()).isEqualTo(testUser);
-        });
-
-        executorService.submit(() -> {
-            GraphTraversalSource g2 = ((GafferPopGraph) g.getGraph()).newInstance().traversal();
-            g2.getGraph().variables().set(GafferPopGraphVariables.USER, testUser2);
-            g2.V().toList();
-            assertThat(((GafferPopGraphVariables) g.getGraph().variables()).getUser()).isEqualTo(testUser2);
-        });
-
-        // Set the user
-        // g.getGraph().variables().set(GafferPopGraphVariables.USER, testUser);
-
-        // // Run a Query
-        // g.V().toList();
-
-        // Ensure user is still set
-        //assertThat(((GafferPopGraphVariables) g.getGraph().variables()).getUser()).isEqualTo(testUser);
-
-        // Reset vars
-        ((GafferPopGraph) g.getGraph()).setDefaultVariables();
-        assertThat(((GafferPopGraphVariables) g.getGraph().variables()).getUser()).isNotEqualTo(testUser);
         reset();
     }
 

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/config/GremlinConfig.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/config/GremlinConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Crown Copyright
+ * Copyright 2024-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/config/GremlinConfig.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/config/GremlinConfig.java
@@ -19,8 +19,6 @@ package uk.gov.gchq.gaffer.rest.config;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.builder.fluent.Configurations;
 import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
@@ -49,10 +47,9 @@ public class GremlinConfig {
     private static final String REQUEST_TIMEOUT_KEY = "gaffer.rest.timeout";
 
     @Bean
-    public GraphTraversalSource graphTraversalSource(final GraphFactory graphFactory) {
-        // Obtain the graph traversal
-        Graph graph = GafferPopGraph.open(findPropertiesFile(graphFactory), graphFactory.getGraph());
-        return graph.traversal();
+    public GafferPopGraph gafferPopGraph(final GraphFactory graphFactory) {
+        // Obtain the graph
+        return GafferPopGraph.open(findPropertiesFile(graphFactory), graphFactory.getGraph());
     }
 
     @Bean

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/config/GremlinWebSocketConfig.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/config/GremlinWebSocketConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Crown Copyright
+ * Copyright 2024-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/config/GremlinWebSocketConfig.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/config/GremlinWebSocketConfig.java
@@ -25,25 +25,26 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 
 import uk.gov.gchq.gaffer.rest.factory.spring.AbstractUserFactory;
 import uk.gov.gchq.gaffer.rest.handler.GremlinWebSocketHandler;
+import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph;
 
 @Configuration
 @EnableWebSocket
 public class GremlinWebSocketConfig implements WebSocketConfigurer {
 
-    private final GraphTraversalSource g;
+    private final GafferPopGraph graph;
     private final AbstractUserFactory userFactory;
     private final Long requestTimeout;
 
     @Autowired
-    public GremlinWebSocketConfig(final GraphTraversalSource g, final AbstractUserFactory userFactory, final Long requestTimeout) {
-        this.g = g;
+    public GremlinWebSocketConfig(final GafferPopGraph graph, final AbstractUserFactory userFactory, final Long requestTimeout) {
+        this.graph = graph;
         this.userFactory = userFactory;
         this.requestTimeout = requestTimeout;
     }
 
     @Override
     public void registerWebSocketHandlers(final WebSocketHandlerRegistry registry) {
-        registry.addHandler(new GremlinWebSocketHandler(g, userFactory, requestTimeout), "/gremlin");
+        registry.addHandler(new GremlinWebSocketHandler(graph, userFactory, requestTimeout), "/gremlin");
     }
 
 }

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/config/GremlinWebSocketConfig.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/config/GremlinWebSocketConfig.java
@@ -16,7 +16,6 @@
 
 package uk.gov.gchq.gaffer.rest.config;
 
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/handler/GremlinWebSocketHandler.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/handler/GremlinWebSocketHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Crown Copyright
+ * Copyright 2024-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ public class GremlinWebSocketHandler extends BinaryWebSocketHandler {
             new SimpleEntry<>(SerTokens.MIME_GRAPHSON_V3, new GraphSONMessageSerializerV3()),
             new SimpleEntry<>(SerTokens.MIME_JSON, new GraphSONMessageSerializerV3()))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
+    // Shared thread pool for executing gremlin queries in
     private final ExecutorService executorService = Context.taskWrapping(Executors.newFixedThreadPool(8));
     private final AbstractUserFactory userFactory;
     private final Long requestTimeout;
@@ -137,10 +137,9 @@ public class GremlinWebSocketHandler extends BinaryWebSocketHandler {
      */
     private GremlinExecutor setUpExecutor(final GafferPopGraph graphInstance) {
         final ConcurrentBindings bindings = new ConcurrentBindings();
-        final GraphTraversalSource g = graphInstance.traversal();
 
         // Set up the executor
-        bindings.putIfAbsent("g", g);
+        bindings.putIfAbsent("g", graphInstance.traversal());
         return GremlinExecutor.build()
                 .addPlugins("gremlin-groovy", plugins)
                 .evaluationTimeout(requestTimeout)

--- a/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/handler/GremlinWebSocketHandler.java
+++ b/rest-api/spring-rest/src/main/java/uk/gov/gchq/gaffer/rest/handler/GremlinWebSocketHandler.java
@@ -26,7 +26,6 @@ import io.opentelemetry.context.Scope;
 import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
 import org.apache.tinkerpop.gremlin.jsr223.ConcurrentBindings;
 import org.apache.tinkerpop.gremlin.process.remote.traversal.DefaultRemoteTraverser;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.util.MessageSerializer;
 import org.apache.tinkerpop.gremlin.util.Tokens;
 import org.apache.tinkerpop.gremlin.util.function.FunctionUtils;

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/GremlinControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/GremlinControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Crown Copyright
+ * Copyright 2024-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/GremlinControllerTest.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/controller/GremlinControllerTest.java
@@ -16,8 +16,6 @@
 
 package uk.gov.gchq.gaffer.rest.controller;
 
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -65,9 +63,8 @@ class GremlinControllerTest {
     @TestConfiguration
     static class TestConfig {
         @Bean
-        public GraphTraversalSource g() {
-            Graph graph = GafferPopModernTestUtils.createModernGraph(TestConfig.class, StoreType.MAP);
-            return graph.traversal();
+        public GafferPopGraph graph() {
+            return GafferPopModernTestUtils.createModernGraph(TestConfig.class, StoreType.MAP);
         }
 
         @Bean
@@ -85,7 +82,7 @@ class GremlinControllerTest {
     private MockMvc mockMvc;
 
     @Autowired
-    private GraphTraversalSource g;
+    private GafferPopGraph graph;
 
     @Test
     void shouldExecuteValidGremlinQuery() throws Exception {
@@ -93,7 +90,7 @@ class GremlinControllerTest {
 
         // Create the expected output
         OutputStream expectedOutput = new ByteArrayOutputStream();
-        GremlinController.GRAPHSON_V3_WRITER.writeObject(expectedOutput, Arrays.asList(MARKO.toVertex((GafferPopGraph) g.getGraph())));
+        GremlinController.GRAPHSON_V3_WRITER.writeObject(expectedOutput, Arrays.asList(MARKO.toVertex((GafferPopGraph) graph)));
 
         // When
         MvcResult result = mockMvc

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/integration/handler/GremlinWebSocketIT.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/integration/handler/GremlinWebSocketIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Crown Copyright
+ * Copyright 2024-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/integration/handler/GremlinWebSocketIT.java
+++ b/rest-api/spring-rest/src/test/java/uk/gov/gchq/gaffer/rest/integration/handler/GremlinWebSocketIT.java
@@ -19,8 +19,6 @@ package uk.gov.gchq.gaffer.rest.integration.handler;
 import org.apache.tinkerpop.gremlin.driver.Client;
 import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.Result;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV3;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,6 +35,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import uk.gov.gchq.gaffer.rest.factory.spring.AbstractUserFactory;
 import uk.gov.gchq.gaffer.rest.factory.spring.UnknownUserFactory;
+import uk.gov.gchq.gaffer.tinkerpop.GafferPopGraph;
 import uk.gov.gchq.gaffer.tinkerpop.util.GafferPopTestUtil.StoreType;
 import uk.gov.gchq.gaffer.tinkerpop.util.modern.GafferPopModernTestUtils;
 
@@ -70,9 +69,8 @@ class GremlinWebSocketIT {
 
         @Bean
         @Profile("test")
-        public GraphTraversalSource g() {
-            Graph graph = GafferPopModernTestUtils.createModernGraph(TestConfig.class, StoreType.MAP);
-            return graph.traversal();
+        public GafferPopGraph graph() {
+            return GafferPopModernTestUtils.createModernGraph(TestConfig.class, StoreType.MAP);
         }
 
         @Bean
@@ -92,7 +90,7 @@ class GremlinWebSocketIT {
     private Integer port;
 
     @Autowired
-    private GraphTraversalSource g;
+    private GafferPopGraph graph;
 
     private Client client;
 
@@ -161,7 +159,7 @@ class GremlinWebSocketIT {
 
         // Then
         assertThat(results)
-            .map(result -> result.getObject())
+            .map(Result::getObject)
             .containsExactlyInAnyOrder(
                 String.valueOf(MARKO.getAge()),
                 String.valueOf(VADAS.getAge()),


### PR DESCRIPTION
Addresses some of the issues with passing information from the REST API to gafferpop by ensuring each request now has its own instance of the tinkerpop graph layer so the variables are unique per request. Also stops the user from being reset immediately by the custom GraphStep.

Few other minor bits of tidying and improvements to otel logging.

# Related issue

- Resolve #3353