### PR TITLE
Gh-3350: Optimisations for federated POC

### DIFF
--- a/core/access/src/main/java/uk/gov/gchq/gaffer/access/predicate/user/NoAccessUserPredicate.java
+++ b/core/access/src/main/java/uk/gov/gchq/gaffer/access/predicate/user/NoAccessUserPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Crown Copyright
+ * Copyright 2020-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/access/src/main/java/uk/gov/gchq/gaffer/access/predicate/user/NoAccessUserPredicate.java
+++ b/core/access/src/main/java/uk/gov/gchq/gaffer/access/predicate/user/NoAccessUserPredicate.java
@@ -21,9 +21,11 @@ import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.predicate.KoryphePredicate;
 
+import java.io.Serializable;
+
 @Since("1.13.1")
 @Summary("Predicate which never allows user access")
-public class NoAccessUserPredicate extends KoryphePredicate<User> {
+public class NoAccessUserPredicate extends KoryphePredicate<User> implements Serializable {
     @Override
     public boolean test(final User user) {
         return false;

--- a/core/access/src/main/java/uk/gov/gchq/gaffer/access/predicate/user/UnrestrictedAccessUserPredicate.java
+++ b/core/access/src/main/java/uk/gov/gchq/gaffer/access/predicate/user/UnrestrictedAccessUserPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Crown Copyright
+ * Copyright 2020-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.gchq.gaffer.access.predicate.user;
 
 import uk.gov.gchq.gaffer.user.User;

--- a/core/access/src/main/java/uk/gov/gchq/gaffer/access/predicate/user/UnrestrictedAccessUserPredicate.java
+++ b/core/access/src/main/java/uk/gov/gchq/gaffer/access/predicate/user/UnrestrictedAccessUserPredicate.java
@@ -20,9 +20,11 @@ import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.predicate.KoryphePredicate;
 
+import java.io.Serializable;
+
 @Since("1.13.1")
 @Summary("A predicate which always allows a user access")
-public class UnrestrictedAccessUserPredicate extends KoryphePredicate<User> {
+public class UnrestrictedAccessUserPredicate extends KoryphePredicate<User> implements Serializable {
     @Override
     public boolean test(final User user) {
         return true;

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedStore.java
@@ -32,6 +32,7 @@ import uk.gov.gchq.gaffer.data.element.Element;
 import uk.gov.gchq.gaffer.data.element.id.EntityId;
 import uk.gov.gchq.gaffer.federated.simple.access.GraphAccess;
 import uk.gov.gchq.gaffer.federated.simple.operation.AddGraph;
+import uk.gov.gchq.gaffer.federated.simple.operation.ChangeDefaultGraphIds;
 import uk.gov.gchq.gaffer.federated.simple.operation.ChangeGraphAccess;
 import uk.gov.gchq.gaffer.federated.simple.operation.ChangeGraphId;
 import uk.gov.gchq.gaffer.federated.simple.operation.FederatedOperationChainValidator;
@@ -45,6 +46,7 @@ import uk.gov.gchq.gaffer.federated.simple.operation.handler.add.AddGraphHandler
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.get.GetAllGraphIdsHandler;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.get.GetAllGraphInfoHandler;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.get.GetSchemaHandler;
+import uk.gov.gchq.gaffer.federated.simple.operation.handler.misc.ChangeDefaultGraphIdsHandler;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.misc.ChangeGraphAccessHandler;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.misc.ChangeGraphIdHandler;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.misc.RemoveGraphHandler;
@@ -137,6 +139,7 @@ public class FederatedStore extends Store {
             new SimpleEntry<>(GetAllGraphInfo.class, new GetAllGraphInfoHandler()),
             new SimpleEntry<>(RemoveGraph.class, new RemoveGraphHandler()),
             new SimpleEntry<>(ChangeGraphAccess.class, new ChangeGraphAccessHandler()),
+            new SimpleEntry<>(ChangeDefaultGraphIds.class, new ChangeDefaultGraphIdsHandler()),
             new SimpleEntry<>(GetWalks.class, new GetWalksHandler()))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedUtils.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Crown Copyright
+ * Copyright 2024-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedUtils.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/FederatedUtils.java
@@ -19,13 +19,17 @@ package uk.gov.gchq.gaffer.federated.simple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import uk.gov.gchq.gaffer.core.exception.GafferRuntimeException;
 import uk.gov.gchq.gaffer.data.elementdefinition.view.View;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.FederatedOperationHandler;
 import uk.gov.gchq.gaffer.federated.simple.operation.handler.get.GetSchemaHandler;
 import uk.gov.gchq.gaffer.graph.GraphSerialisable;
 import uk.gov.gchq.gaffer.operation.Operation;
 import uk.gov.gchq.gaffer.operation.OperationChain;
+import uk.gov.gchq.gaffer.operation.OperationException;
 import uk.gov.gchq.gaffer.operation.graph.OperationView;
+import uk.gov.gchq.gaffer.store.Context;
+import uk.gov.gchq.gaffer.store.operation.GetSchema;
 import uk.gov.gchq.gaffer.store.schema.Schema;
 
 import java.util.ArrayList;
@@ -52,9 +56,12 @@ public final class FederatedUtils {
      * @return A merged {@link Schema}
      */
     public static Schema getSchema(final List<GraphSerialisable> graphs) {
-        List<Schema> schemasToMerge = new ArrayList<>();
-        graphs.forEach(g -> schemasToMerge.add(g.getSchema()));
-        return GetSchemaHandler.getMergedSchema(schemasToMerge);
+        try {
+            // The serialised version may not have the schemas attached so use the operation
+            return new GetSchemaHandler().doOperationOnGraphs(new GetSchema(), new Context(), graphs);
+        } catch (final OperationException e) {
+            throw new GafferRuntimeException(e.getMessage(), e);
+        }
     }
 
     /**

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/merge/DefaultResultAccumulator.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/merge/DefaultResultAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Crown Copyright
+ * Copyright 2024-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/merge/DefaultResultAccumulator.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/merge/DefaultResultAccumulator.java
@@ -16,9 +16,8 @@
 
 package uk.gov.gchq.gaffer.federated.simple.merge;
 
-import org.apache.commons.collections4.IterableUtils;
-
 import uk.gov.gchq.gaffer.data.element.Element;
+import uk.gov.gchq.koryphe.iterable.ChainedIterable;
 
 import java.util.Collection;
 import java.util.Map;
@@ -90,9 +89,7 @@ public class DefaultResultAccumulator<T> extends FederatedResultAccumulator<T> {
             }
 
             // By default just chain iterables together
-            // (need to use the iterator to make sure the FluentIterable under the hood serialises correctly)
-            Iterable<Object> chained = () -> IterableUtils.chainedIterable((Iterable<?>) state, updateIterable).iterator();
-            return (T) chained;
+            return (T) new ChainedIterable<>((Iterable<?>) state, updateIterable);
         }
 
         // Fallback just return the update

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/ChangeDefaultGraphIds.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/ChangeDefaultGraphIds.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.operation;
+
+import org.apache.commons.lang3.exception.CloneFailedException;
+
+import uk.gov.gchq.gaffer.operation.Operation;
+import uk.gov.gchq.koryphe.Since;
+import uk.gov.gchq.koryphe.Summary;
+
+import java.util.List;
+import java.util.Map;
+
+@Since("2.4.0")
+@Summary("Changes default Graph IDs of this store")
+public class ChangeDefaultGraphIds implements Operation {
+
+    private List<String> graphIds;
+    private Map<String, String> options;
+
+    // Getters
+    /**
+     * Get the new default graph IDs.
+     *
+     * @return the graph IDs
+     */
+    public List<String> geGraphIds() {
+        return graphIds;
+    }
+
+    // Setters
+    /**
+     * Set the new default graph IDs.
+     *
+     * @param graphIds the graph IDs
+     */
+    public void setGraphIds(final List<String> graphIds) {
+        this.graphIds = graphIds;
+    }
+
+    @Override
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    @Override
+    public void setOptions(final Map<String, String> options) {
+        this.options = options;
+    }
+
+    @Override
+    public Operation shallowClone() throws CloneFailedException {
+        return new ChangeDefaultGraphIds.Builder()
+                .graphIds(graphIds)
+                .options(options)
+                .build();
+    }
+
+    public static class Builder extends Operation.BaseBuilder<ChangeDefaultGraphIds, Builder> {
+        public Builder() {
+            super(new ChangeDefaultGraphIds());
+        }
+
+        /**
+         * Set the current graph ID
+         *
+         * @param graphIds the graph ID to be changed
+         * @return the builder
+         */
+        public Builder graphIds(final List<String> graphIds) {
+            _getOp().setGraphIds(graphIds);
+            return _self();
+        }
+    }
+
+}

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/EitherOperationHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/EitherOperationHandler.java
@@ -29,9 +29,9 @@ import uk.gov.gchq.gaffer.store.operation.handler.OperationChainHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
 import uk.gov.gchq.gaffer.store.operation.handler.named.AddToCacheHandler;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Custom handler for operations that could in theory target sub graphs or the
@@ -59,9 +59,9 @@ public class EitherOperationHandler<O extends Operation> implements AddToCacheHa
         // Check inside operation chain for if all the operations are handled by a federated store
         if (operation instanceof OperationChain) {
             Set<Class<? extends Operation>> storeSpecificOps = ((FederatedStore) store).getStoreSpecificOperations();
-            List<Class<? extends Operation>> chainOps = ((OperationChain<?>) operation).flatten().stream()
-                .map(Operation::getClass)
-                .collect(Collectors.toList());
+            List<Class<? extends Operation>> chainOps = new ArrayList<>();
+            ((OperationChain<?>) operation).flatten().forEach(op -> chainOps.add(op.getClass()));
+
             if (storeSpecificOps.containsAll(chainOps)) {
                 return new OperationChainHandler<>(store.getOperationChainValidator(), store.getOperationChainOptimisers())
                     .doOperation((OperationChain<Object>) operation, context, store);

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/EitherOperationHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/EitherOperationHandler.java
@@ -67,8 +67,7 @@ public class EitherOperationHandler<O extends Operation> implements AddToCacheHa
             if (!Collections.disjoint(storeSpecificOps, chainOps)) {
                 LOGGER.debug("Operation chain contains some operations that should not be forwarded");
                 context.setVariable(OperationChainHandler.APPLY_CHAIN_OPS_TO_ALL, true);
-                return new OperationChainHandler<>(store.getOperationChainValidator(), store.getOperationChainOptimisers())
-                    .doOperation((OperationChain<Object>) operation, context, store);
+                return standardHandler.doOperation(operation, context, store);
             }
         }
 

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/EitherOperationHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/EitherOperationHandler.java
@@ -67,7 +67,8 @@ public class EitherOperationHandler<O extends Operation> implements AddToCacheHa
             if (!Collections.disjoint(storeSpecificOps, chainOps)) {
                 LOGGER.debug("Operation chain contains some operations that should not be forwarded");
                 context.setVariable(OperationChainHandler.APPLY_CHAIN_OPS_TO_ALL, true);
-                return standardHandler.doOperation(operation, context, store);
+                return new OperationChainHandler<>(store.getOperationChainValidator(), store.getOperationChainOptimisers())
+                    .doOperation((OperationChain<Object>) operation, context, store);
             }
         }
 

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOperationHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOperationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Crown Copyright
+ * Copyright 2024-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOutputHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOutputHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Crown Copyright
+ * Copyright 2024-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOutputHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOutputHandler.java
@@ -75,6 +75,11 @@ public class FederatedOutputHandler<P extends Output<O>, O>
             return null;
         }
 
+        // If only one result we can exit early as no merging to do
+        if (graphResults.size() <= 1) {
+            return graphResults.get(0);
+        }
+
         // Merge the store props with the operation options for setting up the accumulator
         Properties combinedProps = store.getProperties().getProperties();
         if (operation.getOptions() != null) {
@@ -85,7 +90,7 @@ public class FederatedOutputHandler<P extends Output<O>, O>
         FederatedResultAccumulator<O> resultAccumulator = getResultAccumulator((FederatedStore) store, operation, graphsToExecute);
 
         // Should now have a list of <O> objects so need to reduce to just one
-        return graphResults.stream().reduce(resultAccumulator::apply).orElse(graphResults.get(0));
+        return graphResults.stream().reduce(graphResults.get(0), resultAccumulator::apply);
     }
 
 
@@ -108,7 +113,7 @@ public class FederatedOutputHandler<P extends Output<O>, O>
 
         // Set up the result accumulator
         FederatedResultAccumulator<O> resultAccumulator = new DefaultResultAccumulator<>(combinedProps);
-        resultAccumulator.setSchema(store.getSchema(graphsToExecute));
+        resultAccumulator.setSchema(FederatedUtils.getSchema(graphsToExecute));
 
         // Check if user has specified to aggregate
         if (operation.containsOption(OPT_AGGREGATE_ELEMENTS)) {

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOutputHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/FederatedOutputHandler.java
@@ -113,15 +113,18 @@ public class FederatedOutputHandler<P extends Output<O>, O>
 
         // Set up the result accumulator
         FederatedResultAccumulator<O> resultAccumulator = new DefaultResultAccumulator<>(combinedProps);
-        resultAccumulator.setSchema(FederatedUtils.getSchema(graphsToExecute));
 
         // Check if user has specified to aggregate
         if (operation.containsOption(OPT_AGGREGATE_ELEMENTS)) {
             resultAccumulator.setAggregateElements(Boolean.parseBoolean(operation.getOption(OPT_AGGREGATE_ELEMENTS)));
         }
         // Turn aggregation off if there are no shared groups
-        if (!FederatedUtils.doGraphsShareGroups(graphsToExecute)) {
+        if (resultAccumulator.aggregateElements() && !FederatedUtils.doGraphsShareGroups(graphsToExecute)) {
             resultAccumulator.setAggregateElements(false);
+        }
+        // Set the merged schema if we are aggregating
+        if (resultAccumulator.aggregateElements()) {
+            resultAccumulator.setSchema(FederatedUtils.getSchema(graphsToExecute));
         }
 
         return resultAccumulator;

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetSchemaHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetSchemaHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Crown Copyright
+ * Copyright 2024-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetSchemaHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetSchemaHandler.java
@@ -53,11 +53,22 @@ public class GetSchemaHandler extends FederatedOutputHandler<GetSchema, Schema> 
             graphResults.add(gs.getGraph().execute(operation, context.getUser()));
         }
 
+        return getMergedSchema(graphResults);
+    }
+
+    /**
+     * Merges all the supplied graph schemas together and returns the result.
+     *
+     * @param schemas The list of schemas
+     * @return The merged schema
+     */
+    public static Schema getMergedSchema(final List<Schema> schemas) {
         // Merge schemas using schema builder
         boolean wipeVisabilityProperty = false;
         boolean wipeVertexSerialiser = false;
         Schema.Builder mergeSchema = new Schema.Builder();
-        for (final Schema schema : graphResults) {
+
+        for (final Schema schema : schemas) {
             try {
                 mergeSchema.merge(schema);
             } catch (final VisibilityPropertySchemaException e) {

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetSchemaHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/get/GetSchemaHandler.java
@@ -57,6 +57,33 @@ public class GetSchemaHandler extends FederatedOutputHandler<GetSchema, Schema> 
     }
 
     /**
+     * Shortcut to running the operation if you already have the graphs you want
+     * to run on.
+     *
+     * @param operation The operation.
+     * @param context The context.
+     * @param graphsToExecute The list of graphs to execute on.
+     * @return The merged schema.
+     * @throws OperationException If issue.
+     */
+    public Schema doOperationOnGraphs(
+            final GetSchema operation,
+            final Context context,
+            final List<GraphSerialisable> graphsToExecute) throws OperationException {
+        if (graphsToExecute.isEmpty()) {
+            return new Schema();
+        }
+
+        // Execute the operation chain on each graph
+        List<Schema> graphResults = new ArrayList<>();
+        for (final GraphSerialisable gs : graphsToExecute) {
+            graphResults.add(gs.getGraph().execute(operation, context.getUser()));
+        }
+
+        return getMergedSchema(graphResults);
+    }
+
+    /**
      * Merges all the supplied graph schemas together and returns the result.
      *
      * @param schemas The list of schemas

--- a/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/ChangeDefaultGraphIdsHandler.java
+++ b/store-implementation/simple-federated-store/src/main/java/uk/gov/gchq/gaffer/federated/simple/operation/handler/misc/ChangeDefaultGraphIdsHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.gaffer.federated.simple.operation.handler.misc;
+
+import uk.gov.gchq.gaffer.federated.simple.FederatedStore;
+import uk.gov.gchq.gaffer.federated.simple.operation.ChangeDefaultGraphIds;
+import uk.gov.gchq.gaffer.operation.OperationException;
+import uk.gov.gchq.gaffer.store.Context;
+import uk.gov.gchq.gaffer.store.Store;
+import uk.gov.gchq.gaffer.store.operation.handler.OperationHandler;
+import uk.gov.gchq.gaffer.user.User;
+
+import static uk.gov.gchq.gaffer.federated.simple.FederatedStore.FEDERATED_STORE_SYSTEM_USER;
+
+public class ChangeDefaultGraphIdsHandler implements OperationHandler<ChangeDefaultGraphIds> {
+
+    @Override
+    public Object doOperation(final ChangeDefaultGraphIds operation, final Context context, final Store store) throws OperationException {
+        User user = context.getUser();
+        String adminAuth = store.getProperties().getAdminAuth();
+        // Check is user is admin as we're modifying the federated store, also allow if no admin auth is set
+        if ((user.getUserId().equals(FEDERATED_STORE_SYSTEM_USER))
+                || adminAuth.isEmpty()
+                || user.getOpAuths().contains(adminAuth)) {
+            ((FederatedStore) store).setDefaultGraphIds(operation.geGraphIds());
+        } else {
+            throw new OperationException("User: '" + user.getUserId() + "' does not have permission to change default Graph IDs");
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Some minor optimisations and helpful functions for new federated store, changes include:
- Minimising stream API on small collections to save initialisation overhead.
- Using array/list data types where iteration performance is more important.
- Helpful operation to allow changing default graph IDs.
- Some tweaks hit the cache fewer times.
- Better shortcut logic on checks.