### PR TITLE
Gh-3359: Reduce number of vertex lookups for edges

### DIFF
--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Crown Copyright
+ * Copyright 2016-2025 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
@@ -128,15 +128,17 @@ public final class GafferPopEdge extends GafferPopElement implements Edge {
         return newProperty;
     }
 
+    // This is the method TinkerPop uses when traversing edges
+    // lookup the 'full' vertices rather than returning the 'dummy' ID vertices
     @Override
     public Iterator<Vertex> vertices(final Direction direction) {
         switch (direction) {
             case OUT:
-                return IteratorUtils.of(getCompleteOutVertex());
+                return IteratorUtils.of(lookupVertex(outVertex));
             case IN:
-                return IteratorUtils.of(getCompleteInVertex());
+                return IteratorUtils.of(lookupVertex(inVertex));
             default:
-                return IteratorUtils.of(getCompleteOutVertex(), getCompleteInVertex());
+                return IteratorUtils.of(lookupVertex(outVertex), lookupVertex(inVertex));
         }
     }
 
@@ -157,32 +159,26 @@ public final class GafferPopEdge extends GafferPopElement implements Edge {
     }
 
 
+    /**
+     * Gets the outgoing vertex of the edge.
+     *
+     * Note: the returned vertex will not have any properties set - only the ID
+     * if you need the 'full' vertex use {@link #vertices(Direction.OUT)}
+     */
     @Override
     public Vertex outVertex() {
         return outVertex;
     }
 
     /**
-     * Performs a lookup for the outgoing vertex for this edge.
-     * The returned vertex will include all properties but incurs lookup cost
-     * @return The complete outgoing vertex
+     * Gets the incoming vertex of the edge.
+     *
+     * Note: the returned vertex will not have any properties set - only the ID
+     * if you need the 'full' vertex use {@link #vertices(Direction.IN)}
      */
-    public Vertex getCompleteOutVertex() {
-        return getVertex(outVertex);
-    }
-
     @Override
     public Vertex inVertex() {
         return inVertex;
-    }
-
-    /**
-     * Perform a full lookup for the incoming vertex for this edge.
-     * The returned vertex will include all properties but incurs lookup cost
-     * @return The complete incoming vertex
-     */
-    public Vertex getCompleteInVertex() {
-        return getVertex(inVertex);
     }
 
     /**
@@ -228,7 +224,7 @@ public final class GafferPopEdge extends GafferPopElement implements Edge {
      * @param vertex The vertex object or ID
      * @return A valid Vertex based on the supplied object or ID.
      */
-    private Vertex getVertex(final GafferPopVertex vertex) {
+    private Vertex lookupVertex(final GafferPopVertex vertex) {
         OperationChain<Iterable<? extends Element>> findBasedOnID = new OperationChain.Builder()
                 .first(new GetElements.Builder()
                         .input(new EntitySeed(vertex.id()))

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
@@ -163,7 +163,7 @@ public final class GafferPopEdge extends GafferPopElement implements Edge {
      * Gets the outgoing vertex of the edge.
      *
      * Note: the returned vertex will not have any properties set - only the ID
-     * if you need the 'full' vertex use {@link #vertices(Direction.OUT)}
+     * if you need the 'full' vertex use {@link #vertices(Direction)}
      */
     @Override
     public Vertex outVertex() {
@@ -174,7 +174,7 @@ public final class GafferPopEdge extends GafferPopElement implements Edge {
      * Gets the incoming vertex of the edge.
      *
      * Note: the returned vertex will not have any properties set - only the ID
-     * if you need the 'full' vertex use {@link #vertices(Direction.IN)}
+     * if you need the 'full' vertex use {@link #vertices(Direction)}
      */
     @Override
     public Vertex inVertex() {

--- a/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
+++ b/library/tinkerpop/src/main/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopEdge.java
@@ -132,11 +132,11 @@ public final class GafferPopEdge extends GafferPopElement implements Edge {
     public Iterator<Vertex> vertices(final Direction direction) {
         switch (direction) {
             case OUT:
-                return IteratorUtils.of(outVertex());
+                return IteratorUtils.of(getCompleteOutVertex());
             case IN:
-                return IteratorUtils.of(inVertex());
+                return IteratorUtils.of(getCompleteInVertex());
             default:
-                return IteratorUtils.of(outVertex(), inVertex());
+                return IteratorUtils.of(getCompleteOutVertex(), getCompleteInVertex());
         }
     }
 
@@ -156,13 +156,32 @@ public final class GafferPopEdge extends GafferPopElement implements Edge {
         return StringFactory.edgeString(this);
     }
 
+
     @Override
     public Vertex outVertex() {
+        return outVertex;
+    }
+
+    /**
+     * Performs a lookup for the outgoing vertex for this edge.
+     * The returned vertex will include all properties but incurs lookup cost
+     * @return The complete outgoing vertex
+     */
+    public Vertex getCompleteOutVertex() {
         return getVertex(outVertex);
     }
 
     @Override
     public Vertex inVertex() {
+        return inVertex;
+    }
+
+    /**
+     * Perform a full lookup for the incoming vertex for this edge.
+     * The returned vertex will include all properties but incurs lookup cost
+     * @return The complete incoming vertex
+     */
+    public Vertex getCompleteInVertex() {
         return getVertex(inVertex);
     }
 

--- a/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
+++ b/library/tinkerpop/src/test/java/uk/gov/gchq/gaffer/tinkerpop/GafferPopGraphIT.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.gchq.gaffer.tinkerpop.util.modern.GafferPopModernTestUtils.AGE;
 import static uk.gov.gchq.gaffer.tinkerpop.util.modern.GafferPopModernTestUtils.CREATED;
 import static uk.gov.gchq.gaffer.tinkerpop.util.modern.GafferPopModernTestUtils.JOSH;
 import static uk.gov.gchq.gaffer.tinkerpop.util.modern.GafferPopModernTestUtils.KNOWS;
@@ -275,6 +276,38 @@ class GafferPopGraphIT {
                 .extracting(Element::id)
                 .containsExactlyInAnyOrder(MARKO.knows(VADAS));
         });
+    }
+
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("provideTraversals")
+    void shouldLookupInVertex(String graph, GraphTraversalSource g) {
+        final List<Vertex> result = g.E("[1,knows,2]").inV().toList();
+
+        assertThat(result)
+                .hasSize(1);
+
+        // Check that properties are set on the returned vertex
+        // i.e. a vertex lookup has been performed
+        Vertex vadas = result.get(0);
+        assertThat(vadas.id()).isEqualTo(VADAS.getId());
+        assertThat(vadas.property(NAME).value()).isEqualTo(VADAS.getName());
+        assertThat(vadas.property(AGE).value()).isEqualTo(VADAS.getAge());
+    }
+
+    @ParameterizedTest(name = TEST_NAME_FORMAT)
+    @MethodSource("provideTraversals")
+    void shouldLookupOutVertex(String graph, GraphTraversalSource g) {
+        final List<Vertex> result = g.E("[1,knows,2]").outV().toList();
+
+        assertThat(result)
+                .hasSize(1);
+
+        // Check that properties are set on the returned vertex
+        // i.e. a vertex lookup has been performed
+        Vertex marko = result.get(0);
+        assertThat(marko.id()).isEqualTo(MARKO.getId());
+        assertThat(marko.property(NAME).value()).isEqualTo(MARKO.getName());
+        assertThat(marko.property(AGE).value()).isEqualTo(MARKO.getAge());
     }
 
     @ParameterizedTest(name = TEST_NAME_FORMAT)


### PR DESCRIPTION
Stop inV/outV performing a full vertex lookup
Add new methods for doing this when we want to traverse an Edge

# Related issue

- Resolve #3359